### PR TITLE
Add code of conduct

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -11,6 +11,7 @@
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                 <a class="dropdown-item" href="/about/overview">Overview</a>
                 <a class="dropdown-item" href="/about/team">Team</a>
+                <a class="dropdown-item" href="/about/code_of_conduct">Code of Conduct</a>
   </div>
               </li>
               <li class="nav-item dropdown active">

--- a/pages/about/code_of_conduct.md
+++ b/pages/about/code_of_conduct.md
@@ -1,0 +1,108 @@
+---
+permalink: /about/code_of_conduct
+layout: default
+title: Code of Conduct
+---
+# IRIS-HEP Code Of Conduct
+IRIS-HEP is a software institute funded by the National Science Foundation. It
+serves as a center for software R&D, functions as an intellectual hub for the
+larger community-wide software R&D efforts, and transforms the operational
+services required to ensure the success of the HL-LHC scientific program. Its
+success depends on its ability to engage a community from several institutions
+and disciplines with diverse skills, personalities and experiences.
+
+Naturally, this implies diversity of ideas and perspectives on often complex
+problems. Disagreement and healthy discussion of conflicting viewpoints is
+welcome: the best solutions to hard problems rarely come from a single angle.
+But disagreement is not an excuse for aggression: humans tend to take
+disagreement personally and easily drift into behavior that ultimately degrades
+a community. This is particularly acute with online communication across
+language and cultural gaps, where many cues of human behavior are unavailable.
+We are outlining here a set of principles and processes to support a healthy
+community in the face of these challenges. Fundamentally, we are committed to
+fostering an open, productive, harassment-free environment for everyone. Rather
+than considering this code an exhaustive list of things that you can’t do, take
+it in the spirit it is intended - a guide to make it easier to enrich all of us
+and the communities in which we participate. Importantly: as a member of our
+community, you are also a steward of these values. Not all problems need to be
+resolved via formal processes, and often a quick, friendly but clear word on an
+online forum or in person can help resolve a misunderstanding and de-escalate
+things. However, sometimes these informal processes may be inadequate: they fail
+to work, there is urgency or risk to someone, nobody is intervening publicly and
+you don't feel comfortable speaking in public, etc. For these or other reasons,
+structured follow-up may be necessary and here we provide the means for that: we
+welcome reports by emailing [conduct@iris-hep.org](mailto:conduct@iris-hep.org)
+or contacting any member of the
+Executive Board of IRIS-HEP. This code of conduct applies equally to all
+community members in all Institute situations online and offline, including
+conferences, mailing lists, forums, GitHub organizations, chat rooms, social
+media, social events associated with conferences, and one-to-one interactions.
+
+By embracing the following principles, guidelines and actions to follow or
+avoid, you will help us make IRIS-HEP a welcoming and productive community. Feel
+free to contact the Code of Conduct Committee
+at [conduct@iris-hep.org](mailto:conduct@iris-hep.org) with any questions.
+
+1. **Be friendly and patient**.
+
+2. **Be welcoming**. We strive to be a community that welcomes and supports people
+of all backgrounds and identities. This includes, but is not limited to,
+members of any race, ethnicity, culture, national origin, color, immigration
+status, social and economic class, educational level, sex, sexual orientation,
+gender identity and expression, age, physical appearance, family status,
+technological choices, academic discipline, political views, religion, mental
+ability, and physical ability.
+
+3. **Be considerate**. Your work will be used by other people, and you in turn will
+depend on the work of others. Any decision you take will affect users and
+colleagues, and you should take those consequences into account when making
+decisions. Remember that we're a world-wide community. You may be communicating
+with someone with a different primary language or cultural background.
+
+4. **Be respectful**. Not all of us will agree all the time, but disagreement is no
+excuse for poor behavior or poor manners. We might all experience some
+frustration now and then, but we cannot allow that frustration to turn into a
+personal attack. It’s important to remember that a community where people feel
+uncomfortable or threatened is not a productive one. Respect the work of others.
+We recognize the acknowledgment/citation requests of the original authors. As
+authors, we are explicit about how we want our own work to be cited or
+acknowledged.
+
+5. **Be careful in the words that you choose**. Be kind to others. Do not
+insult or put down other community members. Harassment and other exclusionary
+behavior are not acceptable. This includes, but is not limited to:
+* Violent threats or violent language directed against another person
+* Discriminatory jokes and language
+* Posting sexually explicit or violent material
+* Posting (or threatening to post) other people's personally identifying information ("doxing")
+* Personal insults, especially those using racist or sexist terms
+* Unwelcome sexual attention
+* Advocating for, or encouraging, any of the above behavior
+* Repeated harassment of others. In general, if someone asks you to stop, then stop
+
+
+6. **When we disagree, try to understand why**. Disagreements, both social
+and technical, happen all the time and the IRIS-HEP community is no exception.
+Try to understand where others are coming from, as seeing a question from their
+viewpoint may help find a new path forward. And don’t forget that it is human to
+err: blaming each other doesn’t get us anywhere, while we can learn from
+mistakes to find better solutions.
+
+7. **A simple apology can go a long way**. It can
+often de-escalate a situation, and telling someone that you are sorry is an act
+of empathy that doesn’t automatically imply an admission of guilt.
+
+## Reporting
+If you believe someone is violating the code of conduct, please report this in a
+timely manner. Code of conduct violations reduce the value of the community for
+everyone and we take them seriously.
+
+You can file a report by emailing
+[conduct@iris-hep.org](mailto:conduct@iris-hep.org) or by contacting a member of
+the Executive Board of IRIS-HEP
+
+This code was adapted from the Project JupyterHub code of conduct and
+is licenced
+
+All content on this page is licensed under a [*Creative Commons
+Attribution*](http://creativecommons.org/licenses/by/3.0/) license.


### PR DESCRIPTION
Add a code of conduct to the Institute website.

Added a new entry to the _About_ dropdown called _Code of Conduct_ which takes you to a Markdown page containing the proposed code.