### PR TITLE
Fix text rendering

### DIFF
--- a/pages/docs/newteammember.md
+++ b/pages/docs/newteammember.md
@@ -14,7 +14,7 @@ not mentioned here, or missing/unclear information, please [contribute an improv
 
 * Request membership in the [IRIS-HEP GitHub organization][].
 * Add a photo named `First-Last.jpg` or `.png` to the [assets/team folder][]. It should be 320x240 pixels.
-* Add a "<your github username>.md" file to the [people folder in the website repository][people]. Here is an example:
+* Add a "`<your github username>.md`" file to the [people folder in the website repository][people]. Here is an example:
 
 ```yml
 name: <Your name>


### PR DESCRIPTION
Markdown thinks that \< followed by \> is a tag unless you escape them or put them in code snippets, which is what I've done here to fix the missing text.