### PR TITLE
Add Feickert to Illinois institution file

### DIFF
--- a/_data/universities/uiuc.yml
+++ b/_data/universities/uiuc.yml
@@ -4,3 +4,4 @@ personnel:
   - danielskatz
   - BenGalewsky
   - matkinso
+  - matthewfeickert


### PR DESCRIPTION
# Description

Resolves #86 

Amends https://github.com/iris-hep/iris-hep.github.io/commit/abda6c8716be347ea735d37faff30c791b45d472 by adding @matthewfeickert to the University of Illinois at Urbana-Champaign institution personnel listing YAML