### PR TITLE
Use HTTPS for Feickert website

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -1,8 +1,8 @@
 name: Matthew Feickert
-shortname: matthewfeickert 
-title: 
+shortname: matthewfeickert
+title:
 active: green
 institution: University of Illinois at Urbana-Champaign
-website: http://www.matthewfeickert.com/ 
+website: https://www.matthewfeickert.com
 photo: /assets/images/team/matthewfeickert.jpeg
 presentations:


### PR DESCRIPTION
# Description

In a similar vein to @henryiii's nice PR #85, this PR uses the HTTPS link for @matthewfeickert's linked website (and additionally removes dangling whitespace).

This can be safely squashed and merged.