### PR TITLE
Sorting presentation pages

### DIFF
--- a/_includes/get_pres_list.html
+++ b/_includes/get_pres_list.html
@@ -1,5 +1,13 @@
 {% capture list %}
+  {% assign start = true %}
   {% for univ_hash in site.data.universities %}
+    {% if start %}
+      {% assign sep = "" %}
+    {% else %}
+      {% assign sep = "^" %}
+    {% endif %}
+    {% assign start = false %}
+
     {% assign univ = univ_hash[1] %}
     {% for member in univ.personnel  %}
       {% for person_hash in site.data.people %}
@@ -51,7 +59,7 @@
              {% assign pres_focus_area = presentation.focus-area %}
              {% endif %}
 
-             ^{{pres_date}}|{{pres_name}}|{{pres_title}}|{{pres_url}}|{{pres_meeting}}|{{pres_meetingurl}}|{{pres_project}}|{{pres_focus_area}}|{{pres_institution}} 
+             {{sep}}{{pres_date}}|{{pres_name}}|{{pres_title}}|{{pres_url}}|{{pres_meeting}}|{{pres_meetingurl}}|{{pres_project}}|{{pres_focus_area}}|{{pres_institution}} 
            {% endfor %}
         {% endif %}
       {% endfor %}

--- a/_includes/get_pres_list.html
+++ b/_includes/get_pres_list.html
@@ -60,3 +60,4 @@
 {% endcapture %}
 
 {% assign sorted_pres = list | split: "^"  | sort | reverse %}
+

--- a/_layouts/presentations.html
+++ b/_layouts/presentations.html
@@ -1,0 +1,28 @@
+<!doctype html>
+
+{% include layout_header_navbar.html %}
+
+      <div class="container">
+        <main role="main">
+          <div class="presentation toppagelinks">
+            <div class="inner">
+              Presentations:
+              <a href="/presentations/byarea.html">by area</a>
+              &#8226;
+              <a href="/presentations/byinstitution.html">by institution</a>
+              &#8226;
+              <a href="/presentations/bymonth.html">by date</a>
+              &#8226;
+              <a href="/presentations/byperson.html">by person</a>
+            </div>
+          </div>
+          
+          {{ content }}
+        </main>
+    {% include footer.html %}
+      </div>
+
+  {% include layout_analytics.html %}
+
+  </body>
+</html>

--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -117,3 +117,13 @@
     display: block;
   }
 }
+
+// Custom link list at top of page
+div.toppagelinks {
+    text-align: center;
+    margin-bottom: 1.5ex;
+}
+
+div.toppagelinks .inner {
+    display: inline-block;
+}

--- a/pages/presentations/byarea.md
+++ b/pages/presentations/byarea.md
@@ -1,12 +1,18 @@
 ---
 permalink: /presentations/byarea.html
-layout: default
+layout: presentations
 title: Presentations by Area
 ---
 
+{% include get_pres_list.html %}
+
+<!--
+  0     1       2      3       4          5           6          7            8
+date | name | title | url | meeting | meetingurl | project | focus_area | institution
+-->
+
 <h2>Presentations by the IRIS-HEP team</h2>
 
-{% assign orderedlist = "cornell, indiana, mit, morgridge, nyu, princeton, stanford, chicago, cincinnati, uiuc, michigan, nebraska, berkeley, ucsc, ucsd, uprm, washington, wisconsin" | split: ", " %}
 {% assign activities = site.pages | where: "layout", "focus-area" | where: "draft", "false" | sort: 'title' %}
 
 {% for focus-area-page in activities %}
@@ -14,17 +20,11 @@ title: Presentations by Area
   {% assign focus-area-name = focus-area-page.short_title %}
   <h4>{{ focus-area-title }}</h4>
   <ul>
-  {% for uniindex in orderedlist %}
-    {% assign uni = site.data.universities[uniindex] %}
-    {% for member in uni.personnel %}
-      {% assign presentationlist = site.data.people[member].presentations %}
-      {% for talk in presentationlist %}
-        {% assign talk-projects = talk.project %}
-        {% if talk.focus-area == focus-area-name %}
-          <li> {{talk.date}} - <a href="{{talk.url}}">"{{talk.title}}"</a>, {{site.data.people[member].name}}, <a href="{{talk.meetingurl}}">{{talk.meeting}}</a></li>
-        {% endif %}
-      {% endfor %}
-    {% endfor %}
+  {% for row in sorted_pres %}
+    {% assign pres = row | split: "|" %}
+    {% if focus-area-name contains pres[7] %}
+      <li> {{pres[0]}} - <a href="{{pres[3]}}">"{{pres[2]}}"</a>, {{pres[1]}}, <a href="{{pres[5]}}">{{pres[4]}}</a></li>
+    {% endif %}
   {% endfor %}
   </ul>
 {% endfor %}

--- a/pages/presentations/byinstitution.md
+++ b/pages/presentations/byinstitution.md
@@ -1,22 +1,30 @@
 ---
 permalink: /presentations/byinstitution.html
-layout: default
+layout: presentations
 title: Presentations by Institution
 ---
+
+{% include get_pres_list.html %}
+
+<!--
+  0     1       2      3       4          5           6          7            8
+date | name | title | url | meeting | meetingurl | project | focus_area | institution
+-->
 
 {% assign orderedlist = "cornell, indiana, mit, morgridge, nyu, princeton, stanford, chicago, cincinnati, uiuc, michigan, nebraska, berkeley, ucsc, ucsd, uprm, washington, wisconsin" | split: ", " %}
 
 <h2>Presentations by the IRIS-HEP team</h2>
+
 {% for uniindex in orderedlist %}
-{% assign uni = site.data.universities[uniindex] %}
-  <h4>{{uni.name}}</h4>
-  <ul>
-  {% for member in uni.personnel  %}
-     {% for talk in site.data.people[member].presentations %}
-         <li> {{talk.date}} - <a href="{{talk.url}}">"{{talk.title}}"</a>, {{site.data.people[member].name}}, <a href="{{talk.meetingurl}}">{{talk.meeting}}</a></li>
-     {% endfor %}
+  {% assign uni = site.data.universities[uniindex] %}
+<h4>{{uni.name}}</h4>
+<ul>
+  {% for row in sorted_pres %}
+    {% assign pres = row | split: "|" %}
+    {% if pres[8] contains uni.name %}
+<li> {{pres[0]}} - <a href="{{pres[3]}}">"{{pres[2]}}"</a>, {{pres[1]}}, <a href="{{pres[5]}}">{{pres[4]}}</a></li>
+    {% endif %}
   {% endfor %}
-  </ul>
+</ul>
+
 {% endfor %}
-
-

--- a/pages/presentations/bymonth.md
+++ b/pages/presentations/bymonth.md
@@ -1,41 +1,32 @@
 ---
 permalink: /presentations/bymonth.html
-layout: default
+layout: presentations
 title: Presentations by Month
 redirect_from: "/presentations/all"
 ---
 
-{% assign orderedlist = "cornell, indiana, mit, morgridge, nyu, princeton, stanford, chicago, cincinnati, uiuc, michigan, nebraska, berkeley, ucsc, ucsd, uprm, washington, wisconsin" | split: ", " %}
-{% assign yearlist = "2019, 2018, 2017, 2016" | split: ", " %}
-{% assign monthlist= "12, 11, 10, 09, 08, 07, 06, 05, 04, 03, 02, 01" | split: ", " %}
+{% include get_pres_list.html %}
+
+
+<!--
+  0     1       2      3       4          5           6          7            8
+date | name | title | url | meeting | meetingurl | project | focus_area | institution
+-->
 
 <h2>Presentations by the IRIS-HEP team</h2>
 
-{% for yearidx in yearlist %}
-{% for monthidx in monthlist %}
-{% assign hdrprint = true %}
-
-{% for uniindex in orderedlist %}
-{% assign uni = site.data.universities[uniindex] %}
-  {% for member in uni.personnel %}
-     {% assign presentationlist = site.data.people[member].presentations %}
 <ul>
-     {% for talk in presentationlist %}
-  {% assign talkyear = talk.date | date: "%Y" %}
-  {% assign talkmonth = talk.date | date: "%m" %}
-  {% if talkyear == yearidx and talkmonth == monthidx %}
-  {% if hdrprint == true %}
-    <br><h5>{{talk.date | date: "%B, %Y"}}</h5>
-    {% assign hdrprint = false %}
-  {% endif %}
-  {% assign prettydate = talk.date | date: "%-d %b %Y" %}
-   <li> {{prettydate}} - <a href="{{talk.url}}">"{{talk.title}}"</a>, {{site.data.people[member].name}} ({{site.data.people[member].institution}}), <a href="{{talk.meetingurl}}">{{talk.meeting}}</a></li>
-  {% endif %}
-     {% endfor %}
+{% assign prev_header = "" %}
+{% for row in sorted_pres %}
+  {% assign pres = row | split: "|" %}
+  {% assign talk_date = pres[0] | date: "%B, %Y" %}
+  {% if prev_header != talk_date %}
 </ul>
-  {% endfor %}
-{% endfor %}
+<h4> {{ talk_date }} </h4>
+<ul>
+    {% assign prev_header =  talk_date %}
+  {% endif %}
 
+  <li> {{pres[0]}} - <a href="{{pres[3]}}">"{{pres[2]}}"</a>, {{pres[1]}}, <a href="{{pres[5]}}">{{pres[4]}}</a></li>
 {% endfor %}
-{% endfor %}
-
+</ul>

--- a/pages/presentations/byperson.md
+++ b/pages/presentations/byperson.md
@@ -1,6 +1,6 @@
 ---
 permalink: /presentations/byperson.html
-layout: default
+layout: presentations
 title: Presentations by Person
 ---
 


### PR DESCRIPTION
This sorts the presentations by date on several pages, and adds presentation page layout with navigation bar on the top. Closes #95. Code is a bit simpler in some cases.