### PR TITLE
Topical meeting listings

### DIFF
--- a/_includes/get_indico_list.html
+++ b/_includes/get_indico_list.html
@@ -1,0 +1,10 @@
+
+
+{% assign selected_array = "" | split: ',' %}
+{% for event_hash in site.data.topical  %}
+  {% assign event = event_hash[1] %}
+  {% assign selected_array = selected_array | push: event %}
+{% endfor %}
+
+{% assign selected_array = selected_array | sort: 'startdate'%}
+

--- a/pages/index.md
+++ b/pages/index.md
@@ -62,6 +62,26 @@ IRIS-HEP team members are involved in organizing the following events:
 <a href="/events.html">View all past events</a>
 <br>
 
+
+<h4>Upcoming Topical Meetings:</h4>
+{% include get_indico_list.html %}
+<ul>
+{% for event in selected_array %}
+  {% assign startdatecmp = event.startdate | date: "%s" %}
+  {% if currentdatecmp <= startdatecmp %}
+    <li>{{event.startdate | date: "%-d %b" }}{{event.enddate | date: " - %-d %b" }}, {{event.startdate | date: "%Y" }} - <a href="{{event.meetingurl}}">{{event.name}}</a></li>
+  {% endif %}
+{% endfor %}
+</ul>
+
+<a href="/topical.html">View all past meetings</a>
+&bull;
+<a href="https://indico.cern.ch/category/10570/">Indico</a> <a href="https://www.youtube.com/channel/UC8Dmx4MYjp6RQ9ngc58Ujmg/videos">(recordings)</a>
+&bull;
+<a href="https://vidyoportal.cern.ch/join/oT21qIc1id">Vidyo room</a>
+
+<br>
+
 <h4>IRIS-HEP fellowship program:</h4>
 IRIS-HEP Fellows spend several months working closely with a mentor on 
 a HEP software R&D topic relevant to the Institute. 

--- a/pages/topical.md
+++ b/pages/topical.md
@@ -12,39 +12,30 @@ IRIS-HEP topical meetings cover one or more presentations involving IRIS-HEP res
 research areas. They are typically held Mondays 17:30 GVA and Wednesdays 18:00 GVA. Vidyo connections
 are always available and meetings are usually recorded. Find all topical meeting agendas [here](https://indico.cern.ch/category/10570/).
 <ul>
-{% assign yearlist = "2020, 2019, 2018, 2017, 2016" | split: ", " %}
-{% assign monthlist= "12, 11, 10, 09, 08, 07, 06, 05, 04, 03, 02, 01" | split: ", " %}
 
 {% comment %}
 Go through the list and produce a breakdown of the events in reverse 
 chronological order, grouped by months
 {% endcomment %}
 
-{% for yearidx in yearlist %}
-{% for monthidx in monthlist %}
-{% assign selected_array = "" | split: ',' %}
-{% for event_hash in site.data.topical  %}
-  {% assign event = event_hash[1] %}
+{% include get_indico_list.html %}
+{% assign selected_array = selected_array | reverse %}
+
+{% assign hdrprint = "" %}
+{% for event in selected_array %}
   {% assign eventyear = event.startdate | date: "%Y" %}
   {% assign eventmonth = event.startdate | date: "%m" %}
-  {% if eventyear == yearidx and eventmonth == monthidx %}
-     {% assign selected_array = selected_array | push: event %}
-  {% endif %}
-{% endfor %}
-
-{% assign selected_array = selected_array | sort: 'startdate' | reverse %}
-{% assign hdrprint = true %}
-<ul>
-{% for event in selected_array %}
-  {% if hdrprint == true %}
-    <br><h5>{{event.startdate | date: "%B, %Y"}}</h5>
-    {% assign hdrprint = false %}
+  {% assign newprint = event.startdate | date: "%B, %Y"%}
+  {% if hdrprint != newprint %}
+    {% if hdrprint != "" %}
+      </ul>
+    {% endif %}
+    <br><h5>{{newprint}}</h5>
+    <ul>
+    {% assign hdrprint = newprint %}
   {% endif %}
   <li>{{event.startdate | date: "%-d %b" }}{{event.enddate | date: " - %-d %b" }}, {{event.startdate | date: "%Y" }} - <a href="{{event.meetingurl}}">{{event.name}}</a></li>
 {% endfor %}
 </ul>
-
-{% endfor %}
-{% endfor %}
 <br>
 


### PR DESCRIPTION
This refactors the topical meeting listing, and adds the upcoming meetings to the homepage. First step toward new homepage (panes and news events still to go).

This also recovers the missing quicklinks (at least the content).