### PR TITLE
Team

### DIFF
--- a/_includes/institution_list.html
+++ b/_includes/institution_list.html
@@ -1,0 +1,2 @@
+
+{% assign institution_list = "cornell, indiana, mit, morgridge, nyu, princeton, stanford, chicago, cincinnati, uiuc, michigan, nebraska, berkeley, ucsc, ucsd, uprm, washington, wisconsin" | split: ", " %}

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -1,0 +1,24 @@
+<!doctype html>
+
+{% include layout_header_navbar.html %}
+
+      <div class="container">
+        <main role="main">
+          <div class="presentation toppagelinks">
+            <div class="inner">
+              Team:
+              <a href="/about/team.html">by institution</a>
+              &#8226;
+              <a href="/about/team_alphabetical.html">by name</a>.
+	    </div>
+          </div>
+          
+          {{ content }}
+        </main>
+      </div>
+      {% include footer.html %}
+
+  {% include layout_analytics.html %}
+
+  </body>
+</html>

--- a/pages/about/team.md
+++ b/pages/about/team.md
@@ -1,23 +1,37 @@
 ---
 permalink: /about/team.html
-layout: default
+layout: people
 title: Institute Team
 ---
 
 {% include institution_list.html %}
 
+
 <h1>Full Team</h1><br>
 
 <div class="container-fluid">
-<div class="row">
 {% for uniindex in institution_list %}
-{% assign univ = site.data.universities[uniindex] %}
-  {% for member in univ.personnel  %}
-       {% assign person = site.data.people[member] %}
+  <div class="row">
+  {%- assign univ = site.data.universities[uniindex] -%}
+
+  {%- assign sorted_mapping = "" | split:"," -%}
+  {%- for memberid in univ.personnel -%}
+    {%- assign member = site.data.people[memberid] -%}
+    {%- assign sortable_name = member.name | split:" " | reverse | join:" " -%}
+    {%- capture item -%}
+      {{sortable_name}};{{memberid}}
+    {%- endcapture -%}
+    {%- assign sorted_mapping = sorted_mapping | push: item -%}
+  {%- endfor -%}
+  {%- assign sorted_people = sorted_mapping | sort -%}
+
+  {% for member in sorted_people %}
+       {%- assign item = member | split:";" -%}
+       {%- assign item = item[1] -%}
+       {% assign person = site.data.people[item] %}
        {% include standard_person_card.md %}
   {% endfor %}
-  <br>
+  </div>
 {% endfor %}
-</div>
 </div>
 

--- a/pages/about/team.md
+++ b/pages/about/team.md
@@ -4,13 +4,13 @@ layout: default
 title: Institute Team
 ---
 
-{% assign orderedlist = "cornell, indiana, mit, morgridge, nyu, princeton, stanford, chicago, cincinnati, uiuc, michigan, nebraska, berkeley, ucsc, ucsd, uprm, washington, wisconsin" | split: ", " %}
+{% include institution_list.html %}
 
 <h1>Full Team</h1><br>
 
 <div class="container-fluid">
 <div class="row">
-{% for uniindex in orderedlist %}
+{% for uniindex in institution_list %}
 {% assign univ = site.data.universities[uniindex] %}
   {% for member in univ.personnel  %}
        {% assign person = site.data.people[member] %}

--- a/pages/about/team.md
+++ b/pages/about/team.md
@@ -10,28 +10,28 @@ title: Institute Team
 <h1>Full Team</h1><br>
 
 <div class="container-fluid">
-{% for uniindex in institution_list %}
   <div class="row">
-  {%- assign univ = site.data.universities[uniindex] -%}
+    {% for uniindex in institution_list %}
+      {%- assign univ = site.data.universities[uniindex] -%}
 
-  {%- assign sorted_mapping = "" | split:"," -%}
-  {%- for memberid in univ.personnel -%}
-    {%- assign member = site.data.people[memberid] -%}
-    {%- assign sortable_name = member.name | split:" " | reverse | join:" " -%}
-    {%- capture item -%}
-      {{sortable_name}};{{memberid}}
-    {%- endcapture -%}
-    {%- assign sorted_mapping = sorted_mapping | push: item -%}
-  {%- endfor -%}
-  {%- assign sorted_people = sorted_mapping | sort -%}
+      {%- assign sorted_mapping = "" | split:"," -%}
+      {%- for memberid in univ.personnel -%}
+        {%- assign member = site.data.people[memberid] -%}
+        {%- assign sortable_name = member.name | split:" " | reverse | join:" " -%}
+        {%- capture item -%}
+          {{sortable_name}};{{memberid}}
+        {%- endcapture -%}
+        {%- assign sorted_mapping = sorted_mapping | push: item -%}
+      {%- endfor -%}
+      {%- assign sorted_people = sorted_mapping | sort -%}
 
-  {% for member in sorted_people %}
-       {%- assign item = member | split:";" -%}
-       {%- assign item = item[1] -%}
-       {% assign person = site.data.people[item] %}
-       {% include standard_person_card.md %}
-  {% endfor %}
+      {% for member in sorted_people %}
+           {%- assign item = member | split:";" -%}
+           {%- assign item = item[1] -%}
+           {% assign person = site.data.people[item] %}
+           {% include standard_person_card.md %}
+      {% endfor %}
+    {% endfor %}
   </div>
-{% endfor %}
 </div>
 

--- a/pages/about/team_alphabetical.md
+++ b/pages/about/team_alphabetical.md
@@ -1,0 +1,30 @@
+---
+permalink: /about/team_alphabetical.html
+layout: people
+title: Institute Team
+---
+
+{%- assign sorted_mapping = "," | split:"," -%}
+{%- for member in site.data.people -%}
+  {%- assign sortable_name = member[1].name | split:" " | reverse | join:" " -%}
+  {%- capture item -%}
+    {{sortable_name}};{{member[0]}}
+  {%- endcapture -%}
+  {%- assign sorted_mapping = sorted_mapping | push: item -%}
+{%- endfor -%}
+{%- assign sorted_people = sorted_mapping | sort -%}
+
+<h1>Full Team</h1><br>
+
+<div class="container-fluid">
+<div class="row">
+{% for member in sorted_people %}
+  {%- assign item = member | split:";" -%}
+  {%- assign item = item[1] -%}
+  {% assign person = site.data.people[item] %}
+  {% include standard_person_card.md %}
+  <br>
+{% endfor %}
+</div>
+</div>
+

--- a/pages/presentations/byinstitution.md
+++ b/pages/presentations/byinstitution.md
@@ -11,11 +11,11 @@ title: Presentations by Institution
 date | name | title | url | meeting | meetingurl | project | focus_area | institution
 -->
 
-{% assign orderedlist = "cornell, indiana, mit, morgridge, nyu, princeton, stanford, chicago, cincinnati, uiuc, michigan, nebraska, berkeley, ucsc, ucsd, uprm, washington, wisconsin" | split: ", " %}
+{% include institution_list.html %}
 
 <h2>Presentations by the IRIS-HEP team</h2>
 
-{% for uniindex in orderedlist %}
+{% for uniindex in institution_list %}
   {% assign uni = site.data.universities[uniindex] %}
 <h4>{{uni.name}}</h4>
 <ul>

--- a/pages/presentations/byperson.md
+++ b/pages/presentations/byperson.md
@@ -4,11 +4,11 @@ layout: presentations
 title: Presentations by Person
 ---
 
-{% assign orderedlist = "cornell, indiana, mit, morgridge, nyu, princeton, stanford, chicago, cincinnati, uiuc, michigan, nebraska, berkeley, ucsc, ucsd, uprm, washington, wisconsin" | split: ", " %}
+{% include institution_list.html %}
 
 <h2>Presentations by the IRIS-HEP team</h2>
 
-{% for uniindex in orderedlist %}
+{% for uniindex in institution_list %}
 {% assign uni = site.data.universities[uniindex] %}
   {% for member in uni.personnel %}
      {% if site.data.people[member].presentations.size > 0 %}


### PR DESCRIPTION
Provide a by-name sorting, with header across the top to switch. Also make the institution based sorting a bit more obvious by fixing the missing line break after each institution. Moved the institution ordered list to a common location so it is not repeated (probably should be a yaml file eventually).

Requested on Slack by @gordonwatts and a few others.

Institution sorting is still the default.