### PR TITLE
Support for dark mode

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -35,6 +35,15 @@ body {
 
 // Dark mode
 @media (prefers-color-scheme: dark) {
+
+  a {
+    color: scale-color($iris-200, $lightness:50%)
+  }
+
+  a:hover {
+    color: scale-color($iris-200, $lightness:20%)
+  }
+
   header.masthead {
     .overlay {
       background-color: black;
@@ -98,8 +107,6 @@ body {
   margin-right: auto;
   display: block;
 }
-
-/* a:hover,a:focus{color:#2C3E50;text-decoration:underline;} */
 
 .boxed {
   background-color: rgb(242, 244, 244) ;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -12,6 +12,11 @@ body {
   padding-bottom: 0;
   color: #2C3E50;
 
+  @media (prefers-color-scheme: dark) {
+    color: white;
+    background-color: black;
+  }
+
   @media only print {
     padding-top: 0;
     color: black;
@@ -26,6 +31,21 @@ body {
   header.masthead .site-heading {
     padding: 0;
   }
+}
+
+// Dark mode
+.card {
+  @media (prefers-color-scheme: dark) {
+    background-color: inherit;
+    color: inherit;
+  }
+}
+
+%light-purple-header {
+    color: $iris-400;
+    @media (prefers-color-scheme: dark) {
+      color: scale-color($iris-400, $lightness:40%)
+    }
 }
 
 /* CUSTOMIZE THE CAROUSEL
@@ -94,7 +114,7 @@ body {
       font-weight: bolder;
       margin: 5px 0px 5px 0px;
       a {
-        color: $iris-400;
+        @extend %light-purple-header;
       }
     }
 
@@ -103,9 +123,18 @@ body {
 
 /* Custom footer */
 
+.navbar-dark {
+  @media (prefers-color-scheme: dark) {
+    @include gradient-x($black, $primary, 0%, 100%);
+  }
+}
+
 .footer-dark {
   @media not print {
     @include gradient-x($navbar-dark-active-color, $primary, 0%, 100%);
+  }
+  @media (prefers-color-scheme: dark) {
+    @include gradient-x($black, $primary, 0%, 100%);
   }
   border-top-color: $iris-100;
 
@@ -205,7 +234,7 @@ body {
   }
 
   .mainpage-core h4 {
-    color: $iris-400;
+    @extend %light-purple-header;
     font-size: 1.3rem;
     margin-bottom: .2rem;
   }
@@ -314,6 +343,9 @@ body {
     @media only screen and (min-width: 991px), only print {
       padding: 6px;
       background-color: scale-color($iris-100, $lightness:60%);
+      @media (prefers-color-scheme: dark) {
+        background-color: $iris-100
+      }
       border-radius: 6px;
     }
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -34,10 +34,36 @@ body {
 }
 
 // Dark mode
-.card {
-  @media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: dark) {
+  header.masthead {
+    .overlay {
+      background-color: black;
+      opacity: .4;
+    }
+    .site-heading {
+      color: white;
+    }
+  }
+
+  .card {
     background-color: inherit;
     color: inherit;
+  }
+  
+  .dropdown-menu {
+    background-color: $iris-200;
+    .dropdown-item {
+      color: white;
+    }
+    .dropdown-item:hover, .dropdown-item:focus {
+      color: black;
+    }
+  }
+  .projects .card-img-top {
+    background-color: white;
+  }
+  img.header-logo {
+    background-color: white;
   }
 }
 

--- a/pages/docs.md
+++ b/pages/docs.md
@@ -8,19 +8,19 @@ title: "Documentation pages for the IRIS-HEP team"
 
 #### Informational
 
-* [Acknowledgements](docs/acknowledgements)
-* [Logos](docs/logo)
-* [Preparing the annual IRIS-HEP SOWs](docs/sows)
-* [Related projects](docs/related-projects)
+* [Acknowledgements](/docs/acknowledgements)
+* [Logos](/docs/logo)
+* [Preparing the annual IRIS-HEP SOWs](/docs/sows)
+* [Related projects](/docs/related-projects)
 
 #### New team members
-* [Reimbursement](docs/reimbursement)
-* [New Team Member page](docs/newteammember)
-* [Vidyo web conferencing](docs/vidyo)
+* [Reimbursement](/docs/reimbursement)
+* [New Team Member page](/docs/newteammember)
+* [Vidyo web conferencing](/docs/vidyo)
 
 #### Website
 * [Website GitHub repo](https://github.com/iris-hep/iris-hep.github.io-source)
-* [Setting up for Web development](docs/webdev)
-* [Add new focus-area page](docs/add_focusarea_page)
-* [Add new project page](docs/add_project_page)
-* [Add new Publication](docs/add_publication)
+* [Setting up for Web development](/docs/webdev)
+* [Add new focus-area page](/docs/add_focusarea_page)
+* [Add new project page](/docs/add_project_page)
+* [Add new Publication](/docs/add_publication)

--- a/pages/docs/logo.md
+++ b/pages/docs/logo.md
@@ -6,7 +6,7 @@ pagetype: doc
 ---
 
 ### Full Version for light background
-![alt text](/assets/logos/Iris-hep-3-regular-complete.png "Logo Title Text 1")
+<img style="background-color:white" src="/assets/logos/Iris-hep-3-regular-complete.png" alt="Logo for light background" title="Logo Title Text 1">
 
 Formats: [png](/assets/logos/Iris-hep-3-regular-complete.png), [jpg](/assets/logos/Iris-hep-3-regular-complete.jpg), [pdf](/assets/logos/Iris-hep-3-regular-complete.pdf), [eps](/assets/logos/Iris-hep-3-regular-complete.eps), [svg](/assets/logos/Iris-hep-3-regular-complete.svg)
 
@@ -14,7 +14,7 @@ Formats: [png](/assets/logos/Iris-hep-3-regular-complete.png), [jpg](/assets/log
 
 ### Full Version for dark background
 
-<img style="background-color:black" src="/assets/logos/Iris-hep-6-WHITE-complete.png" alt="alt text" title="Logo Title Text 1">
+<img style="background-color:black" src="/assets/logos/Iris-hep-6-WHITE-complete.png" alt="Logo for dark background" title="Logo Title Text 1">
 
 Formats: [png](/assets/logos/Iris-hep-6-WHITE-complete.png), [jpg](/assets/logos/Iris-hep-4-no-long-name.jpg), [pdf](/assets/logos/Iris-hep-6-WHITE-complete.pdf), [eps](/assets/logos/Iris-hep-6-WHITE-complete.eps), [svg](/assets/logos/Iris-hep-6-WHITE-complete.svg)
 
@@ -32,3 +32,19 @@ Formats: [png](/assets/logos/Iris-hep-4-no-long-name.png), [jpg](/assets/logos/I
 
 Formats: [png](/assets/logos/Iris-hep-5-just-graphic.png), [jpg](/assets/logos/Iris-hep-5-just-graphic.jpg), [pdf](/assets/logos/Iris-hep-5-just-graphic.pdf), [eps](/assets/logos/Iris-hep-5-just-graphic.eps), [svg](/assets/logos/Iris-hep-5-just-graphic.svg)
 
+
+## Colors
+
+IRIS-HEP brand colors:
+
+* iris-100: #8A84D6 <span style="font-size:1.5rem;color:#8A84D6;">&#9632;</span>
+* iris-200: #0082CA <span style="font-size:1.5rem;color:#0082CA;">&#9632;</span>
+* iris-300: #270089 <span style="font-size:1.5rem;color:#270089;">&#9632;</span>
+* iris-400: #575195 <span style="font-size:1.5rem;color:#575195;">&#9632;</span>
+
+* iris-gray: #9a9b9d <span style="font-size:1.5rem;color:#9a9b9d;">&#9632;</span>
+
+* iris-accent-100: #dfdc7e <span style="font-size:1.5rem;color:#dfdc7e;">&#9632;</span>
+* iris-accent-200: #d2dc2f <span style="font-size:1.5rem;color:#d2dc2f;">&#9632;</span>
+* iris-accent-300: #c8d339 <span style="font-size:1.5rem;color:#c8d339;">&#9632;</span>
+* iris-accent-400: #66bcad <span style="font-size:1.5rem;color:#66bcad;">&#9632;</span>


### PR DESCRIPTION
This supports dark mode: if your device is set to dark mode (macOS, Windows or GTK+ on Linux), the theme of the webpage changes to match. Support for dark mode in desktop browsers has been implemented in the last few months (starting around March or so), and iOS will get dark mode on Friday, followed by iPadOS a week or two later.

Also adds theme colors to the logo page, and fixes doc links when building locally.

Comparison:
![lightIRIS](https://user-images.githubusercontent.com/4616906/65157926-80a9a480-d9ff-11e9-8312-0182a1b4a09c.png)
![darkIRIS](https://user-images.githubusercontent.com/4616906/65157927-80a9a480-d9ff-11e9-84a3-d7f7717a2812.png)
