### PR TITLE
Add ADL functionality benchmarks project page

### DIFF
--- a/pages/projects/adl-benchmarks-index.md
+++ b/pages/projects/adl-benchmarks-index.md
@@ -1,0 +1,16 @@
+---
+permalink: /projects/adl-benchmarks-index.html
+layout: project
+title: ADL Benchmarks
+shortname: adl-benchmarks-index
+pagetype: project
+image: logos/Iris-hep-5-just-graphic.png
+blurb: Functionality benchmarks for analysis description languages
+focus-area: as
+team:
+ - masonproffitt
+---
+
+A useful comparison of languages for HEP analysis requires code examples of each performing very similar tasks. The ADL benchmarks repository collects several analysis-inspired tasks which can be described concisely and span a range of complexity, along with links to open data sets on which these tasks can be run. As the community develops code examples that accomplish these tasks in particular languages, the repositories containing these examples are linked from this project to create a catalog of analysis languages.
+
+Everyone is encouraged to submit ideas for new functionality benchmark tasks or open data sets as GitHub issues and to submit pull requests with specific language implementations of the functionality benchmarks.


### PR DESCRIPTION
Add a project page for the [ADL benchmarks repository](https://github.com/iris-hep/adl-benchmarks-index).