### PR TITLE
Adding two recent presentations for Alexander Held

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -1,6 +1,6 @@
 name: Alexander Held
 shortname: alexander-held
-title: 
+title:
 active: green
 institution: New York University
 website:  https://github.com/alexander-held
@@ -13,3 +13,18 @@ presentations:
     meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
     location: NYU
     focus-area: as
+  - title: "Harmonizing statistics tools - ideas"
+    date: 2019-10-29
+    url: https://indico.cern.ch/event/859742/contributions/3620507/
+    meeting: ATLAS Statistics Committee Meeting
+    meetingurl: https://indico.cern.ch/event/859742/
+    location: CERN
+    focus-area: as
+  - title: "Constraining effective field theories with machine learning"
+    date: 2019-11-07
+    url: https://indico.cern.ch/event/773049/contributions/3476179/
+    meeting: 24th International Conference on Computing in High Energy & Nuclear Physics
+    meetingurl: https://indico.cern.ch/event/773049/
+    location: Adelaide, Australia
+    focus-area: as
+    project: madminer


### PR DESCRIPTION
adds two recent presentations:
- ATLAS statistics committee meeting, Oct 29
- CHEP2019 talk, Nov 7