### PR TITLE
Refactor pubs, add citations

### DIFF
--- a/_data/publications/atlas-pyhf.yml
+++ b/_data/publications/atlas-pyhf.yml
@@ -1,6 +1,6 @@
 title: "Reproducing searches for new physics with the ATLAS experiment through publication of full statistical likelihoods"
 link: https://cds.cern.ch/record/2684863
-date: Aug 05, 2019
+date: 2019-08-05
 citation: "ATL-PHYS-PUB-2019-029"
 focus-area: as
 project: 

--- a/_data/publications/atlas-recast.yml
+++ b/_data/publications/atlas-recast.yml
@@ -1,6 +1,6 @@
 title: "RECAST framework reinterpretation of an ATLAS Dark Matter Search constraining a model of a dark Higgs boson decaying to two b-quarks"
 link: https://cds.cern.ch/record/2686290
-date: Aug 12, 2019
+date: 2019-08-12
 citation: "ATL-PHYS-PUB-2019-032"
 focus-area: as
 project: recast

--- a/_data/publications/dahlgren-pdsw19.yml
+++ b/_data/publications/dahlgren-pdsw19.yml
@@ -1,6 +1,6 @@
 title: "Towards Physical Design Management in Storage Systems"
 link: https://conferences.computer.org/sc19w/2019/pdfs/PDSW2019-6YFSp9XMTx6Zb1FALMAAsH/4fvbcftXDF6ApQhwvi9qmt/6A71ELyT9VuTjMxO3Lp8bM.pdf
-date: Nov 18, 2019
+date: 2019-11-18
 citation: "Kathryn Dahlgren, Jeff LeFevre, Ashay Shirwadkar, Ken Iizawa, Aldrin Montana, Peter Alvaro, Carlos Maltzahn, 4th International Parallel Data Systems Workshop (PDSW 2019, co-located with SC’19), Denver, CO, November 18, 2019."
 focus-area: doma
 project: skyhookdm

--- a/_data/publications/david-precs19.yml
+++ b/_data/publications/david-precs19.yml
@@ -1,6 +1,6 @@
 title: "Reproducible Computer Network Experiments: A Case Study Using Popper"
 link: https://drive.google.com/file/d/1eqLFu-gb3l0JIO_OVupDe6cdXBYkdNvZ/view?usp=sharing
-date: Jun 24, 2018
+date: 2019-06-24
 citation: "Andrea David, Mariette Souppe, Ivo Jimenez, Katia Obraczka, Sam Mansfield, Kerry Veenstra, Carlos Maltzahn, 2nd International Workshop on Practical Reproducible Evaluation of Computer Systems (P-RECS, co-located with HPDC’19), Phoenix, AZ, June 24, 2019."
 focus-area: doma
 project: reproducibility

--- a/_data/publications/jimenez-rescue-hpc18.yml
+++ b/_data/publications/jimenez-rescue-hpc18.yml
@@ -1,6 +1,6 @@
 title: "Spotting Black Swans With Ease: The Case for a Practical Reproducibility Platform"
 link: http://doi.org/10.5281/zenodo.1488346
-date: Nov 11, 2018
+date: 2018-11-11
 citation: "Ivo Jimenez, Carlos Maltzahn, st Workshop on Reproducible, Customizable and Portable Workflows for HPC (ResCuE-HPC’18, co-located with SC’18), Dallas, TX, November 11, 2018."
 focus-area: doma
 project: reproducibility

--- a/_data/publications/liu-hpc-iodc19.yml
+++ b/_data/publications/liu-hpc-iodc19.yml
@@ -1,6 +1,6 @@
 title: "MBWU: Benefit Quantification for Data Access Function Offloading"
 link: https://drive.google.com/file/d/1ufV_TY1sff-rR8nVVlAYLZRGnBp0E1fB/view?usp=sharing
-date: Jun 20, 2019
+date: 2019-06-20
 citation: "Jianshen Liu, Philip Kufeldt, Carlos Maltzahn, HPC I/O in the Data Center Workshop (HPC-IODC 2019, co-located with ISC-HPC 2019), Frankfurt, Germany, June 20, 2019."
 focus-area: doma
 project: skyhookdm

--- a/_data/publications/maricq-osdi18.yml
+++ b/_data/publications/maricq-osdi18.yml
@@ -1,6 +1,6 @@
 title: "Taming performance variability"
 link: https://www.usenix.org/conference/osdi18/presentation/maricq
-date: Oct 8-10, 2018
+date: 2018-10-08
 citation: "Aleksander Maricq, Dmitry Duplyakin, Ivo Jimenez, Carlos Maltzahn, Ryan Stutsman, and Robert Ricci, 13th USENIX Symposium on Operating Systems Design and Implementation (OSDI’18), Carlsbad, CA, October 8-10, 2018."
 focus-area: doma
 project: reproducibility

--- a/_includes/get_pub_list.html
+++ b/_includes/get_pub_list.html
@@ -1,38 +1,7 @@
-{% capture list %}
-  {% for pub_hash in site.data.publications  %}
-    {% assign pub = pub_hash[1] %}
-    {% assign pub_date = "Unknown" %}
-    {% if pub.date contains '2' %}
-      {% assign pub_date = pub.date | date: "%Y-%m-%d" %}
-    {% endif %}
+{% assign sorted_publications = "" | split: "," %}
+{% for pub_hash in site.data.publications  %}
+  {% assign pub = pub_hash[1] %}
+  {% assign sorted_publications = sorted_publications | push: pub %}
+{% endfor %}
+{% assign sorted_publications = sorted_publications | sort: "date" | reverse %}
 
-    {% assign pub_title = "Unknown" %}
-    {% if pub.title %}
-      {% assign pub_title = pub.title %}
-    {% endif %}
-
-    {% assign pub_citation = "Unknown" %}
-    {% if pub.citation %}
-      {% assign pub_citation = pub.citation %}
-    {% endif %}
-
-    {% assign pub_link = "Unknown" %}
-    {% if pub.link %}
-      {% assign pub_link = pub.link %}
-    {% endif %}
-
-    {% assign project_name = "Unknown" %}
-    {% if pub.project %}
-      {% assign project_name = pub.project %}
-    {% endif %}
-
-    {% assign fa_name = "Unknown" %}
-    {% if pub.focus-area %}
-      {% assign fa_name = pub.focus-area %}
-    {% endif %}
-
-    ^{{pub_date }}|{{ pub_title }}|{{ pub_citation }}|{{ pub_link}}|{{project_name}}|{{fa_name}}
-  {% endfor %}
-{% endcapture %}
-
-{% assign sorted_pubs = list | split: "^" | sort | reverse %}

--- a/_includes/list_project_publications.html
+++ b/_includes/list_project_publications.html
@@ -1,32 +1,25 @@
 {% include get_pub_list.html %}
 
-{% assign has_pub = false %}
-{% for pub_item in sorted_pubs %}
-  {% if pub_item.size  > 20 %}
-    {% assign pub = pub_item | split: "|" %}
-    {% if pub[0] contains '2' %}
-      {% assign pub_project = pub[4] | strip %}
-      {% if pub_project contains include.shortname  %}
-        {% assign has_pub = true %}
-        {% break %}
-      {% endif %}
-    {% endif %}
+{% assign pubs = "" | split: "," %}
+{% for pub in sorted_publications %}
+  {% if pub.project contains include.shortname  %}
+    {% assign pubs = pubs | push: pub %}
   {% endif %}
 {% endfor %}
 
-{% if has_pub %}
+{% if pubs.size > 0 %}
 <h3>Publications</h3>
 <ul>
-{% for pub_item in sorted_pubs %}
-{% if pub_item.size  > 20 %}
-{% assign pub = pub_item | split: "|" %}
-{% if pub[0] contains '2' %}
-{% assign pub_project = pub[4] | strip %}
-{% if pub_project contains include.shortname  %}
-<li>{{ pub[1] }}, <a href="{{pub[3]}}">{{pub[2]}}</a> ({{ pub[0] | date_to_string }}).</li>
-{% endif %}
-{% endif %}
-{% endif %}
-{% endfor %}
+  {% for pub in sorted_publications %}
+    {% if pub.citation-count and pub.citation-count > 0 %}
+      {% assign cited = " [" | append: pub.citation-count | append: " citations]" %}
+      {% if pub.inspire-id %}
+        {% capture cited %} <a href='http://inspirehep.net/record/{{pub.inspire-id}}/citations'>{{cited}}</a>{% endcapture %}
+      {% endif %}
+    {% else %}
+      {% assign cited = "" %}
+    {% endif %}
+    <li> <a href="{{ pub.link }}">{{ pub.title }}</a>, {{ pub.citation }} ({{ pub.date | date_to_string }}){{ cited }}. </li>
+  {% endfor %}
 </ul>
 {% endif %}

--- a/_layouts/focus-area.html
+++ b/_layouts/focus-area.html
@@ -132,23 +132,17 @@
 </section>
 {% endif %}
 
-{% assign doPublications = 0 %}
 {% include get_pub_list.html %}
 
-{% for pub_item in sorted_pubs %}
-    {% if pub_item.size  > 20 %}
-        {% assign pub = pub_item | split: "|" %}
-        {% if pub[0] contains '2' %}
-            {% assign pub_fa = pub[5] | strip %}
-            {% if pub_fa contains page.short_title  %}
-                {% assign doPublications = 1 %}
-                {% break %}
-            {% endif %}
-        {% endif %}
-    {% endif %}
+{% assign pubs = "" | split: "," %}
+{% for pub in sorted_publications %}
+  {% assign page_st = page.short_title | strip %}
+  {% if pub.focus-area contains page_st %}
+    {% assign pubs = pubs | push: pub %}
+  {% endif %}
 {% endfor %}
 
-{% if doPublications == 1 %}
+{% if pubs.size > 0 %}
 
 
 <div class="container-lg p-responsive py-5 py-md-6 ">
@@ -158,21 +152,21 @@
 <ul>
 {% assign max_disp = 15 %}
 {% assign counter = 0 %}
-  {% for pub_item in sorted_pubs %}
-    {% if pub_item.size  > 20 %}
-      {% assign pub = pub_item | split: "|" %}
-      {% if pub[0] contains '2' %}
-        {% assign pub_fa = pub[5] | strip %}
-        {% if pub_fa contains page.short_title  %}
-          {% assign counter = counter | plus: 1 %}
-          <li> {{ pub[1] }}, <a href="{{pub[3]}}">{{pub[2]}}</a> ({{ pub[0] | date_to_string }}).</li>
-          {% if counter == max_disp %}
-          </ul>
-          <p>[expand]</p>
-          <ul>
-          {% endif %}
-        {% endif %}
+  {% for pub in pubs %}
+    {% assign counter = counter | plus: 1 %}
+    {% if pub.citation-count and pub.citation-count > 0 %}
+      {% assign cited = " [" | append: pub.citation-count | append: " citations]" %}
+      {% if pub.inspire-id %}
+        {% capture cited %} <a href='http://inspirehep.net/record/{{pub.inspire-id}}/citations'>{{cited}}</a>{% endcapture %}
       {% endif %}
+    {% else %}
+      {% assign cited = "" %}
+    {% endif %}
+    <li> <a href="{{ pub.link }}">{{ pub.title }}</a>, {{ pub.citation }} ({{ pub.date | date_to_string }}){{ cited }}. </li>
+    {% if counter == max_disp %}
+    </ul>
+    <p>[expand]</p>
+    <ul>
     {% endif %}
   {% endfor %}
 </ul>

--- a/_plugins/getpub.rb
+++ b/_plugins/getpub.rb
@@ -54,13 +54,13 @@ module Publications
 
     # Setup a publication - adds/fixes focus-area and project
     def prepare(pub, name)
-      begin
-        force_array(pub, 'project') if pub.key? 'project'
-      rescue NoMethodError
-        puts "Preparing #{name} publication: #{pub}"
-        raise
-      end
-      prepare_focus_area(pub, name) unless pub.key? 'focus-area'
+      pub['focus-area'] ||= []
+      pub['project'] ||= []
+
+      force_array(pub, 'project')
+
+      # Looks up focus areas from projects
+      prepare_focus_area(pub, name) if pub['focus-area'].empty?
 
       msg = 'You must have a project or focus-area in every publication'
       raise StandardError, msg unless pub.key? 'focus-area'
@@ -72,18 +72,20 @@ module Publications
     # Verify that an item is an Array
     def force_array(pub, name)
       # Make sure the projects are in a list
-      pub[name] = [pub[name]] unless pub[name].is_a? Array
+      pub[name] = [] if pub[name].nil?
+      pub[name] = [pub[name]] unless pub[name].respond_to? :each
     end
 
     # Add focus areas based on projects
     def prepare_focus_area(pub, name)
-      pub['focus-area'] = []
       pub['project'].each do |p|
         pg = @site.pages.detect { |page| page.data['shortname'] == p }
         msg = "Project #{pub['project']} missing! Cannot find focus-area for #{name}."
         raise StandardError, msg unless pg
 
-        pub['focus-area'] << pg.data['focus-area']
+        new_fas = pg.data['focus-area']
+        new_fas = [new_fas] if new_fas.is_a? String
+        pub['focus-area'] += new_fas unless new_fas.nil?
       end
 
       # Don't list the same focus area multiple times
@@ -125,6 +127,11 @@ module Publications
       # This *only* sets data if the previous line is nil
       pub['date'] ||= data.dig('imprints', 0, 'date')
 
+      # Normalize date (if Nil, this should fail (date required))
+      pub['date'] = Date.parse(pub['date'])
+
+      pub['citation-count'] ||= data['citation_count']
+
       # Make the author list, for eventual linking to author pages
       authors = data['authors'].map do |a|
         { 'name' => a['full_name'], 'id' => a.dig('ids', 0, 'value') }
@@ -133,6 +140,7 @@ module Publications
 
       # Build the author string
       mini_authors = join_names(pub['authors'].map { |a| a['name'] }, len: 5)
+
 
       # Build the citation string (non-author part)
       j = data.dig('publication_info', 0) # This may be nil

--- a/pages/publications/all.md
+++ b/pages/publications/all.md
@@ -10,33 +10,19 @@ draft: false
 {% assign doPublications = 0 %}
 {% include get_pub_list.html %}
 
-{% for pub_item in sorted_pubs %}
-    {% if pub_item.size  > 20 %}
-        {% assign pub = pub_item | split: "|" %}
-        {% if pub[0] contains '2' %}
-            {% assign doPublications = 1 %}
-            {% break %}
-        {% endif %}
-    {% endif %}
-{% endfor %}
-
-
-
-{% if doPublications == 1 %}
-
 
 <ul>
-  {% for pub_item in sorted_pubs %}
-    {% if pub_item.size  > 20 %}
-      {% assign pub = pub_item | split: "|" %}
-      {% if pub[0] contains '2' %}
-        {% assign pub_fa = pub[5] | strip %}
-        <li> {{ pub[1] }}, <a href="{{pub[3]}}">{{pub[2]}}</a> ({{ pub[0] | date_to_string }}).</li>
+  {% for pub in sorted_publications %}
+    {% if pub.citation-count and pub.citation-count > 0 %}
+      {% assign cited = " [" | append: pub.citation-count | append: " citations]" %}
+      {% if pub.inspire-id %}
+        {% capture cited %} <a href='http://inspirehep.net/record/{{pub.inspire-id}}/citations'>{{cited}}</a>{% endcapture %}
       {% endif %}
+    {% else %}
+      {% assign cited = "" %}
     {% endif %}
+    <li> <a href="{{ pub.link }}">{{ pub.title }}</a>, {{ pub.citation }} ({{ pub.date | date_to_string }}){{ cited }}. </li>
   {% endfor %}
 </ul>
-
-{% endif %}
 
 


### PR DESCRIPTION
Major refactor to publications, adds citation counts. Will be easier to modify in the future, drops about 50 LoC. Links are now on the title rather than the authors.

Dates for publications now *must* be written in ISO 8601 format. That's technically the only format natively Jekyll understands.

I've started at this a bit and I think all the publications are still there (and at least one publication was incorrectly entered, I believe).