### PR TITLE
Refactor presentation listings, recover 15 missing presentations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+Metrics/LineLength:
+  Max: 120
+Metrics/MethodLength:
+  Max: 30
+Style/NumericLiterals:
+  Enabled: false
+Metrics/AbcSize:
+  Max: 50
+Metrics/ClassLength:
+  Max: 200

--- a/_includes/get_pres_list.html
+++ b/_includes/get_pres_list.html
@@ -1,71 +1,10 @@
-{% capture list %}
-  {% assign start = true %}
-  {% for univ_hash in site.data.universities %}
-    {% if start %}
-      {% assign sep = "" %}
-    {% else %}
-      {% assign sep = "^" %}
-    {% endif %}
-    {% assign start = false %}
-
-    {% assign univ = univ_hash[1] %}
-    {% for member in univ.personnel  %}
-      {% for person_hash in site.data.people %}
-        {% assign person = person_hash[1] %}
-        {% if person.shortname == member %}
-           {% for presentation in person.presentations %}
-             {% assign pres_date = "Unknown" %}
-             {% if presentation.date  %}
-               {% assign pres_date = presentation.date | date: "%Y-%m-%d" %}
-             {% endif %}
-
-             {% assign pres_name = "Unknown" %}
-             {% if person.name %}
-               {% assign pres_name = person.name %}
-             {% endif %}
-
-             {% assign pres_institution = "Unknown" %}
-             {% if person.institution %}
-               {% assign pres_institution = person.institution %}
-             {% endif %}
-                
-             {% assign pres_title = "Unknown" %}
-             {% if presentation.title %}
-             {% assign pres_title = presentation.title %}
-             {% endif %}
-
-             {% assign pres_url = "Unknown" %}
-             {% if presentation.url %}
-             {% assign pres_url = presentation.url %}
-             {% endif %}
-
-             {% assign pres_meeting = "Unknown" %}
-             {% if presentation.meeting %}
-             {% assign pres_meeting = presentation.meeting %}
-             {% endif %}
-
-             {% assign pres_meetingurl = "Unknown" %}
-             {% if presentation.meetingurl %}
-             {% assign pres_meetingurl = presentation.meetingurl %} 
-             {% endif %}
-
-             {% assign pres_project = "Unknown" %}
-             {% if presentation.project %}
-             {% assign pres_project = presentation.project %}
-             {% endif %}
-
-             {% assign pres_focus_area = "Unknown" %}
-             {% if presentation.focus-area %}
-             {% assign pres_focus_area = presentation.focus-area %}
-             {% endif %}
-
-             {{sep}}{{pres_date}}|{{pres_name}}|{{pres_title}}|{{pres_url}}|{{pres_meeting}}|{{pres_meetingurl}}|{{pres_project}}|{{pres_focus_area}}|{{pres_institution}} 
-           {% endfor %}
-        {% endif %}
-      {% endfor %}
-    {% endfor %}
+{% assign sorted_presentations = "" | split: "," %}
+{% for person_hash in site.data.people %}
+  {% assign person = person_hash[1] %}
+  {% for presentation in person.presentations %}
+    {% assign sorted_presentations = sorted_presentations | push: presentation %}
   {% endfor %}
-{% endcapture %}
+{% endfor %}
 
-{% assign sorted_pres = list | split: "^"  | sort | reverse %}
+{% assign sorted_presentations = sorted_presentations | sort: "date" | reverse %}
 

--- a/_plugins/checkpres.rb
+++ b/_plugins/checkpres.rb
@@ -9,7 +9,6 @@ module Checks
     def generate(site)
       @site = site
 
-      puts "Running CheckPres:"
       @site.data['people'].each do |name, person_hash|
         presentations = person_hash['presentations']
 

--- a/_plugins/checkpres.rb
+++ b/_plugins/checkpres.rb
@@ -9,12 +9,13 @@ module Checks
     def generate(site)
       @site = site
 
+      puts "Running CheckPres:"
       @site.data['people'].each do |name, person_hash|
         presentations = person_hash['presentations']
 
-        presentations&.each_with_index do |pres_array, index|
+        presentations&.each_with_index do |pres_hash, index|
           msg = "presentation ##{index} in _data/people/#{name}.yml"
-          presentation = Record.new(msg, pres_array)
+          presentation = Record.new(msg, pres_hash)
 
           presentation.key 'title', :nonempty
           presentation.key 'date', :nonempty, :date
@@ -26,6 +27,9 @@ module Checks
           presentation.key 'project', :optional
 
           presentation.print_warnings
+
+          # Add the member shortname to every presentation
+          presentations[index]['member'] = name
         end
       end
     end

--- a/_plugins/checks.rb
+++ b/_plugins/checks.rb
@@ -11,6 +11,9 @@ module Checks
       @empty = []
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
+
     # Check to see if key is present. You can add :optional and/or :nonempty.
     def key(key, *args)
       optional = !args.delete(:optional).nil?
@@ -38,7 +41,11 @@ module Checks
       raise ArgumentError, dmsg unless d.is_a?(Date)
     end
 
+    # rubocop:enable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/CyclomaticComplexity
+
     def print_warnings
+      # rubocop:disable Style/GuardClause
       unless @missing.empty?
         keys = @missing.join ', '
         puts "#{@name} must contain #{keys}."
@@ -47,6 +54,7 @@ module Checks
         keys = @empty.join ', '
         puts "#{@name} must contain non-empty #{keys}."
       end
+      # rubocop:enable Style/GuardClause
     end
   end
 end

--- a/_plugins/checkusers.rb
+++ b/_plugins/checkusers.rb
@@ -11,7 +11,7 @@ module Checks
       @site = site
 
       people_in_inst = Set.new
-      @site.data['universities'].each do |inst_name, inst_hash|
+      @site.data['universities'].each do |_inst_name, inst_hash|
         people_in_inst.merge inst_hash['personnel']
       end
 

--- a/_plugins/getpub.rb
+++ b/_plugins/getpub.rb
@@ -141,7 +141,6 @@ module Publications
       # Build the author string
       mini_authors = join_names(pub['authors'].map { |a| a['name'] }, len: 5)
 
-
       # Build the citation string (non-author part)
       j = data.dig('publication_info', 0) # This may be nil
       journal =

--- a/pages/presentations/byarea.md
+++ b/pages/presentations/byarea.md
@@ -12,6 +12,7 @@ date | name | title | url | meeting | meetingurl | project | focus_area | instit
 -->
 
 <h2>Presentations by the IRIS-HEP team</h2>
+{% assign prescount = 0 %}
 
 {% assign activities = site.pages | where: "layout", "focus-area" | where_exp: "item", "item.draft != true" | sort: 'title' %}
 
@@ -20,13 +21,16 @@ date | name | title | url | meeting | meetingurl | project | focus_area | instit
   {% assign focus-area-name = focus-area-page.short_title | strip %}
   <h4>{{ focus-area-title }}</h4>
   <ul>
-  {% for row in sorted_pres %}
-    {% assign pres = row | split: "|" %}
-    {% if pres[7] contains focus-area-name %}
-      <li> {{pres[0]}} - <a href="{{pres[3]}}">"{{pres[2]}}"</a>, {{pres[1]}}, <a href="{{pres[5]}}">{{pres[4]}}</a></li>
+  {% for talk in sorted_presentations %}
+    {% if talk.focus-area contains focus-area-name %}
+      {% assign member = site.data.people[talk.member].name %}
+      {% assign prettydate = talk.date | date: "%-d %b %Y" %}
+      <li> {{prettydate}} - <a href="{{talk.url}}">"{{talk.title}}"</a>, {{member}}, <a href="{{talk.meetingurl}}">{{talk.meeting}}</a></li>
+      {% assign prescount = prescount | plus: "1" %}
     {% endif %}
   {% endfor %}
   </ul>
 {% endfor %}
 
 
+Total presentations: {{ prescount }}.

--- a/pages/presentations/byinstitution.md
+++ b/pages/presentations/byinstitution.md
@@ -14,17 +14,22 @@ date | name | title | url | meeting | meetingurl | project | focus_area | instit
 {% include institution_list.html %}
 
 <h2>Presentations by the IRIS-HEP team</h2>
+{% assign prescount = 0 %}
 
 {% for uniindex in institution_list %}
   {% assign uni = site.data.universities[uniindex] %}
 <h4>{{uni.name}}</h4>
 <ul>
-  {% for row in sorted_pres %}
-    {% assign pres = row | split: "|" %}
-    {% if pres[8] contains uni.name %}
-<li> {{pres[0]}} - <a href="{{pres[3]}}">"{{pres[2]}}"</a>, {{pres[1]}}, <a href="{{pres[5]}}">{{pres[4]}}</a></li>
+  {% for talk in sorted_presentations %}
+    {% if site.data.people[talk.member].institution contains uni.name %}
+      {% assign member = site.data.people[talk.member].name %}
+      {% assign prettydate = talk.date | date: "%-d %b %Y" %}
+      <li> {{prettydate}} - <a href="{{talk.url}}">"{{talk.title}}"</a>, {{member}}, <a href="{{talk.meetingurl}}">{{talk.meeting}}</a></li>
+      {% assign prescount = prescount | plus: "1" %}
     {% endif %}
   {% endfor %}
 </ul>
 
 {% endfor %}
+
+Total presentations: {{ prescount }}.

--- a/pages/presentations/bymonth.md
+++ b/pages/presentations/bymonth.md
@@ -14,12 +14,13 @@ date | name | title | url | meeting | meetingurl | project | focus_area | instit
 -->
 
 <h2>Presentations by the IRIS-HEP team</h2>
+{% assign prescount = 0 %}
 
 <ul>
 {% assign prev_header = "" %}
-{% for row in sorted_pres %}
-  {% assign pres = row | split: "|" %}
-  {% assign talk_date = pres[0] | date: "%B, %Y" %}
+{% for talk in sorted_presentations %}
+  {% assign member = site.data.people[talk.member].name %}
+  {% assign talk_date = talk.date | date: "%B, %Y" %}
   {% if prev_header != talk_date %}
 </ul>
 <h4> {{ talk_date }} </h4>
@@ -27,6 +28,10 @@ date | name | title | url | meeting | meetingurl | project | focus_area | instit
     {% assign prev_header =  talk_date %}
   {% endif %}
 
-  <li> {{pres[0]}} - <a href="{{pres[3]}}">"{{pres[2]}}"</a>, {{pres[1]}}, <a href="{{pres[5]}}">{{pres[4]}}</a></li>
+  {% assign prettydate = talk.date | date: "%-d %b %Y" %}
+  <li> {{prettydate}} - <a href="{{talk.url}}">"{{talk.title}}"</a>, {{member}}, <a href="{{talk.meetingurl}}">{{talk.meeting}}</a></li>
+  {% assign prescount = prescount | plus: "1" %}
 {% endfor %}
 </ul>
+
+Total presentations: {{ prescount }}.

--- a/pages/presentations/byperson.md
+++ b/pages/presentations/byperson.md
@@ -7,6 +7,7 @@ title: Presentations by Person
 {% include institution_list.html %}
 
 <h2>Presentations by the IRIS-HEP team</h2>
+{% assign prescount = 0 %}
 
 {% for uniindex in institution_list %}
 {% assign uni = site.data.universities[uniindex] %}
@@ -19,11 +20,14 @@ title: Presentations by Person
 <h4>{{site.data.people[member].name}} - {{site.data.people[member].institution}}</h4>
 <ul>
      {% for talk in presentationlist %}
-     {% assign prettydate = talk.date | date: "%-d %b %Y" %}
+         {% assign prettydate = talk.date | date: "%-d %b %Y" %}
+         {% assign prescount = prescount | plus: "1" %}
          <li> {{prettydate}} - <a href="{{talk.url}}">"{{talk.title}}"</a>, {{site.data.people[member].name}}, <a href="{{talk.meetingurl}}">{{talk.meeting}}</a></li>
      {% endfor %}
 </ul>
   {% endfor %}
 {% endfor %}
+
+Total presentations: {{ prescount }}.
 
 


### PR DESCRIPTION
Issue discovered by @ShawnMcKee. Refactoring the `"|"` based listing with a proper hash based one (using plugin to inject the original person key, since that doesn't seem to be possible with pure Liquid). This fixes the issue; and it also now displays the number of presentations at the bottom to help catch this in the future. Date formatting now consistent on all the presentation pages.