### PR TITLE
Fix override of inspire with a date

### DIFF
--- a/_data/publications/1675782.yml
+++ b/_data/publications/1675782.yml
@@ -3,5 +3,5 @@ project:
 - madminer
 - exploratory-ml
 link: https://doi.org/10.1073/pnas.1915980117
-date: '2020-02-20'
+date: 2020-02-20
 citation: Proceedings of the National Academy of Sciences; DOI:10.1073/pnas.1915980117

--- a/_data/publications/1752736.yml
+++ b/_data/publications/1752736.yml
@@ -3,6 +3,6 @@ project:
 - madminer
 - exploratory-ml
 link: https://doi.org/10.3847/1538-4357/ab4c41
-date: '2019-11-19'
+date: 2019-11-19
 citation: The Astrophysical Journal, Volume 886, Number 1; DOI:10.3847/1538-4357/ab4c41
 

--- a/_plugins/getpub.rb
+++ b/_plugins/getpub.rb
@@ -128,7 +128,7 @@ module Publications
       pub['date'] ||= data.dig('imprints', 0, 'date')
 
       # Normalize date (if Nil, this should fail (date required))
-      pub['date'] = Date.parse(pub['date'])
+      pub['date'] = Date.parse(pub['date']) unless pub['date'].is_a? Date
 
       pub['citation-count'] ||= data['citation_count']
 

--- a/pages/docs/add_publication.md
+++ b/pages/docs/add_publication.md
@@ -46,7 +46,7 @@ If you want to put a publication in that is not in Inspire, these are the requir
 ```yaml
 title: My fantastic publication
 link: https://www.cern.ch
-date: Dec 10, 2018
+date: 2018-12-10
 citation: D. Lange et. al., Nature *10* 100 (2018)
 focus-area: ia
 project: some-project


### PR DESCRIPTION
Follow up to #254.

If a date is given, the publication plugin should not attempt to convert it into a date again.

Also fixes example date for publications.