### PR TITLE
Add Feickert pyhf poster at IRIS-HEP Poster Session 2020

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -60,3 +60,10 @@ presentations:
     meetingurl: https://indico.cern.ch/event/863729/
     location: Vidyo
     focus-area: as
+  - title: "pyhf: Pure Python Implementation of HistFactory"
+    date: 2019-02-27
+    url: https://indico.cern.ch/event/894127/attachments/1996570/3334540/10_-_IRIS-HEP-2020-poster-session-pyhf.pdf
+    meeting: IRIS-HEP Poster Session 2020
+    meetingurl: https://indico.cern.ch/event/894127/
+    location: Princeton, U.S.A.
+    focus-area: as


### PR DESCRIPTION
Add pyhf poster shown by @matthewfeickert at the [IRIS-HEP Poster Session 2020 at Princeton](https://indico.cern.ch/event/894127/).