### PR TITLE
fix: Correct year to be 2020

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -61,7 +61,7 @@ presentations:
     location: Vidyo
     focus-area: as
   - title: "pyhf: Pure Python Implementation of HistFactory"
-    date: 2019-02-27
+    date: 2020-02-27
     url: https://indico.cern.ch/event/894127/attachments/1996570/3334540/10_-_IRIS-HEP-2020-poster-session-pyhf.pdf
     meeting: IRIS-HEP Poster Session 2020
     meetingurl: https://indico.cern.ch/event/894127/


### PR DESCRIPTION
Correct year of poster session to be 2020 (because apparently March isn't long enough for me to get this right).

- Amends PR #265