### PR TITLE
Better sort order for titles with capital letters 

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -34,7 +34,7 @@
                 <li class="nav-item dropdown active">
                     <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Activities</a>
                     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-                        {% assign activities = site.pages | where: "layout", "focus-area" | sort: 'title' %}
+                        {% assign activities = site.pages | where: "layout", "focus-area" | sort_natural: 'title' %}
                         {% for mypage in activities %}
                         <a class="dropdown-item" href="{{mypage.permalink}}">{{mypage.title}}</a>
                         {% endfor %}

--- a/_layouts/focus-area.html
+++ b/_layouts/focus-area.html
@@ -13,7 +13,7 @@
 </div>
 
 {% assign doProjects = 0 %}
-{% assign sorted = site.pages | sort: 'title' %}
+{% assign sorted = site.pages | sort_natural: 'title' %}
 {% for mypage in sorted %}
 {% if mypage.pagetype == 'project' %} 
 {% if mypage.focus-area contains page.short_title %}

--- a/pages/fellows.md
+++ b/pages/fellows.md
@@ -48,7 +48,7 @@ IRIS-HEP Fellow positions will be awarded in a rolling fashion based on submitte
 
 <div class="container-fluid">
   <div class="row">
-{% assign sorted = site.pages | sort: 'title' %}
+{% assign sorted = site.pages | sort_natural: 'title' %}
 {% for mypage in sorted %}
   {% if mypage.pagetype == 'fellow' %}
      {% assign person = mypage %}

--- a/pages/index.html
+++ b/pages/index.html
@@ -56,7 +56,7 @@ an HEP software R&D topic relevant to the Institute.
 
 <div class="container-fluid">
   <div class="row">
-    {% assign sorted = site.pages | sort: 'title' %}
+    {% assign sorted = site.pages | sort_natural: 'title' %}
     {% for mypage in sorted %}
       {% if mypage.pagetype == 'fellow' %} 
          {% assign person = mypage %}

--- a/pages/presentations/byarea.md
+++ b/pages/presentations/byarea.md
@@ -14,7 +14,7 @@ date | name | title | url | meeting | meetingurl | project | focus_area | instit
 <h2>Presentations by the IRIS-HEP team</h2>
 {% assign prescount = 0 %}
 
-{% assign activities = site.pages | where: "layout", "focus-area" | where_exp: "item", "item.draft != true" | sort: 'title' %}
+{% assign activities = site.pages | where: "layout", "focus-area" | where_exp: "item", "item.draft != true" | sort_natural: 'title' %}
 
 {% for focus-area-page in activities %}
   {% assign focus-area-title = focus-area-page.title %}

--- a/pages/sitemap.md
+++ b/pages/sitemap.md
@@ -13,7 +13,7 @@ different page categories (using our custom frontmatter tag "pagetype").
 <br>
 <b>Focus Area pages:</b>
 <ul>
-{% assign sorted = site.pages | sort: 'title' %}
+{% assign sorted = site.pages | sort_natural: 'title' %}
 {% for mypage in sorted %}
   {% if mypage.pagetype == 'focus-area' %} 
   <li><a href="{{mypage.permalink}}">{{ mypage.title }}</a></li>
@@ -24,7 +24,7 @@ different page categories (using our custom frontmatter tag "pagetype").
 <br>
 <b>Project pages:</b>
 <ul>
-{% assign sorted = site.pages | sort: 'title' %}
+{% assign sorted = site.pages | sort_natural: 'title' %}
 {% for mypage in sorted %}
   {% if mypage.pagetype == 'project' %} 
   <li><a href="{{mypage.permalink}}">{{ mypage.title }}</a></li>
@@ -35,7 +35,7 @@ different page categories (using our custom frontmatter tag "pagetype").
 <br>
 <b>Documentation pages:</b>
 <ul>
-{% assign sorted = site.pages | sort: 'title' %}
+{% assign sorted = site.pages | sort_natural: 'title' %}
 {% for mypage in sorted %}
   {% if mypage.pagetype == 'doc' %} 
   <li><a href="{{mypage.permalink}}">{{ mypage.title }}</a></li>
@@ -46,7 +46,7 @@ different page categories (using our custom frontmatter tag "pagetype").
 <br>
 <b>IRIS-HEP Fellow pages:</b>
 <ul>
-{% assign sorted = site.pages | sort: 'title' %}
+{% assign sorted = site.pages | sort_natural: 'title' %}
 {% for mypage in sorted %}
   {% if mypage.pagetype == 'fellow' %} 
   <li><a href="{{mypage.permalink}}">{{ mypage.title }}</a></li>
@@ -57,7 +57,7 @@ different page categories (using our custom frontmatter tag "pagetype").
 <br>
 <b>Other pages:</b>
 <ul>
-{% assign sorted = site.pages | sort: 'title' %}
+{% assign sorted = site.pages | sort_natural: 'title' %}
 {% for mypage in sorted %}
   {% if mypage.pagetype != 'doc' and mypage.pagetype != 'focus-area' and mypage.pagetype != 'project' and mypage.pagetype != 'fellow' and mypage.title %} 
   <li><a href="{{mypage.permalink}}">{{ mypage.title }}</a></li>


### PR DESCRIPTION
Fixes the sort order in a few more places (after #277 fixed it for the project page).