### PR TITLE
Bottom spacing

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,13 +1,14 @@
 <!doctype html>
 
 {% include layout_header_navbar.html %}
-
+    <div id="container">
       <div class="container">
         <main role="main">
           {{ content }}
         </main>
       </div>
       {% include footer.html %}
+    </div>
 
   {% include layout_analytics.html %}
 

--- a/_layouts/fellow.html
+++ b/_layouts/fellow.html
@@ -2,6 +2,7 @@
   
 {% include layout_header_navbar.html %}
 
+    <div id="container">
       <div class="container">
         <main role="main">
 
@@ -67,6 +68,7 @@ More information: <a href = {{page.proposal}}>My full proposal</a><br>
 
 </main>
 {% include footer.html %}
+</div>
 </div>
 
 {% include layout_analytics.html %}

--- a/_layouts/focus-area.html
+++ b/_layouts/focus-area.html
@@ -2,6 +2,7 @@
   
 {% include layout_header_navbar.html %}
 
+    <div id="container">
       <div class="container">
         <main role="main">
 
@@ -159,6 +160,7 @@
         </main>
       </div>
       {% include footer.html %}
+    </div>
 
   {% include layout_analytics.html %}
   </body>

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -5,13 +5,15 @@
 
     {% include navbar.html %}
     {% include masthead.html %}
-
+ 
+    <div id="container">
       <div class="container">
         <main role="main">
           {{ content }}
         </main>
       </div>
       {% include footer.html %}
+    </div>
 
   {% if site.google_analytics %}
     <script>

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -2,6 +2,7 @@
 
 {% include layout_header_navbar.html %}
 
+    <div id="container">
       <div class="container">
         <main role="main">
           <div class="presentation toppagelinks">
@@ -17,6 +18,7 @@
         </main>
       </div>
       {% include footer.html %}
+    </div>
 
   {% include layout_analytics.html %}
 

--- a/_layouts/presentations.html
+++ b/_layouts/presentations.html
@@ -2,6 +2,7 @@
 
 {% include layout_header_navbar.html %}
 
+  <div id="container">
       <div class="container">
         <main role="main">
           <div class="presentation toppagelinks">
@@ -25,6 +26,7 @@
         </main>
       </div>
       {% include footer.html %}
+    </div>
 
   {% include layout_analytics.html %}
 

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -2,6 +2,7 @@
 
 {% include layout_header_navbar.html %}
 
+  <div id="container">
       <div class="container">
         <main role="main">
 
@@ -24,6 +25,7 @@
         </main>
       </div>
       {% include footer.html %}
+    </div>
 
   {% include layout_analytics.html %}
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -5,11 +5,16 @@
 @import "variables";
 @import "mixins";
 
+html {
+  height: 100%;
+}
+
 /* DIANA dark blue: 2C3E50; DIANA light blue: 3B97D3 */
 /* Original padding-top was 6rem */
 body {
   padding-top: 5rem;
   padding-bottom: 0;
+  height: 100%;
   color: #2C3E50;
 
   @media (prefers-color-scheme: dark) {
@@ -154,6 +159,14 @@ body {
   }
 }
 
+div#container {
+  padding-bottom: 7em;
+  position:relative;
+  height: auto !important;
+  height: 100%; // IE 6
+  min-height:100%;
+}
+
 /* Custom footer */
 
 .navbar-dark {
@@ -177,6 +190,11 @@ body {
   padding-left: 1.0rem;
   padding-right: 0.5rem;
   padding-bottom: 1.5rem;
+
+  // Stick the footer to the bottom
+  position: absolute;
+  width: 100%;
+  bottom: 0;
 
   a {
     @media not print {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -28,11 +28,11 @@ body {
   }
 }
 
-@media only print {
-  header.masthead {
-    margin-bottom: 5mm;
-  }
+header.masthead {
+  margin-bottom: 0;
+}
 
+@media only print {
   header.masthead .site-heading {
     padding: 0;
   }
@@ -160,7 +160,7 @@ body {
 }
 
 div#container {
-  padding-bottom: 7em;
+  padding-bottom: 8em;
   position:relative;
   height: auto !important;
   height: 100%; // IE 6
@@ -268,6 +268,16 @@ div#container {
   }
 }
 
+main {
+  padding-top: 0px;
+}
+
+@media only screen and (min-width: 768px) {
+  main {
+    padding-top: 30px;
+  }
+}
+
 // Sidebar
 
 .mainpage-sidebar {
@@ -355,7 +365,7 @@ div#container {
   .iris-post-footer {
     clear: both;
     padding-top: 20px;
-    padding-bottom: 50px;
+    padding-bottom: 20px;
     @media only screen and (min-width: 768px), only print {
       margin-top: 40px;
     }


### PR DESCRIPTION
Fixes the long standing issue with the space at the bottom of pages on short pages. Before:

<img width="1100" alt="Screen Shot 2020-03-23 at 3 28 45 PM" src="https://user-images.githubusercontent.com/4616906/77355552-0265ec00-6d1b-11ea-91ca-f3f842d1bb9d.png">

After:

<img width="1101" alt="Screen Shot 2020-03-23 at 3 28 33 PM" src="https://user-images.githubusercontent.com/4616906/77355560-04c84600-6d1b-11ea-9a57-44b23199d33d.png">
