### PR TITLE
Nicer header (mobile and odd sizes)

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -3,10 +3,8 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-8 col-md-10 mx-auto">
-        <div class="site-heading">
-<div class="blurb">
-    <h2><b>Institute for Research and Innovation in Software for High Energy Physics (IRIS-HEP)</b></h2>
-</div><!-- /.blurb -->
+        <div class="site-heading blurb">
+          <h2>Institute for Research and Innovation in Software for High Energy Physics <span style="white-space: nowrap;">(IRIS-HEP)</span></h2>
         </div>
       </div>
     </div>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -31,13 +31,22 @@ body {
 header.masthead {
   margin-bottom: 0;
   margin-top: 15px;
-    .site-heading {
-      padding: 25px 0px 25px;
-      @media only screen and (min-width: 768px) {
-        padding: 60px 0px 60px;
-      }
+  .site-heading {
+    padding: 25px 0px 25px;
+    @media only screen and (min-width: 768px) {
+      padding: 60px 0px 60px;
     }
+  }
+  .site-heading > h2 {
+    font-size: 1.6rem;
+    font-weight: 600;
+    margin: 0;
+    @media only screen and (min-width: 768px), only print {
+      font-size: 2rem;
+    }
+  }
 }
+
 
 @media only print {
   header.masthead .site-heading {


### PR DESCRIPTION
Slightly smaller on mobile, no longer wraps on IRIS-HEP.