### PR TITLE
fixed Allen, updated getpub.rb, added publication

### DIFF
--- a/_data/publications/1789128.yml
+++ b/_data/publications/1789128.yml
@@ -1,0 +1,8 @@
+inspire-id: 1789128
+focus-area:
+  - ia
+  - as
+project:
+- exploratory-ml
+- madminer
+

--- a/_plugins/getpub.rb
+++ b/_plugins/getpub.rb
@@ -20,7 +20,7 @@ module Publications
   class Generator < Jekyll::Generator
     # Main entry point for Jekyll
     def generate(site)
-      @net = Net::HTTP.new('labs.inspirehep.net', 443)
+      @net = Net::HTTP.new('inspirehep.net', 443)
       @net.use_ssl = true
 
       @site = site

--- a/pages/projects/allen.md
+++ b/pages/projects/allen.md
@@ -6,7 +6,7 @@ shortname: allen
 pagetype: project
 image: logos/allen.png
 logowidth: 50%
-blurb: Allen: a GPU trigger for LHCb
+blurb: "Allen: a GPU trigger for LHCb"
 focus-area: ia
 team:
  - mityinzer


### PR DESCRIPTION
@henryiii I updated the URL from labs.inspirehep.net to inspirehep.net because I was getting 
jekyll 3.8.6 | Error:  Getting 1789128 failed with code 301: Moved Permanently
rake aborted!

The labs version moved to the main INSPIRE URL this week. 