### PR TITLE
Add Feickert IRIS-HEP postdoc presentation

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -67,3 +67,10 @@ presentations:
     meetingurl: https://indico.cern.ch/event/894127/
     location: Princeton, U.S.A.
     focus-area: as
+  - title: "pyhf: A Pure Python Statistical Fitting Library with Tensors and Autograd"
+    date: 2020-02-27
+    url: https://indico.cern.ch/event/897086/attachments/2001484/3341223/Feickert_pyhf-NSF-Review-IRIS-HEP_2020-02-27.pdf
+    meeting: IRIS-HEP Postdoc Presentations
+    meetingurl: https://indico.cern.ch/event/897086/
+    location: Princeton, U.S.A.
+    focus-area: as


### PR DESCRIPTION
Add [IRIS-HEP postodoc presentation](https://matthewfeickert.github.io/talk-NSF-Review-IRIS-HEP-2020/index.html) by @matthewfeickert given on [February 27th, 2020 at Princeton](https://indico.cern.ch/event/897086/).