### PR TITLE
fix: Run apt-get update before attempting install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
 
     - name: Install apt requirements
       run: |
+        sudo apt-get update
         sudo apt-get install libxslt-dev libxml2-dev
         gem install bundler
 


### PR DESCRIPTION
Fixes the regression @gordonwatts reported where `libxml` fails to install due to the `.deb` binary getting updated. To fix this simply run `apt-get update` to update the known listing of packages available.

We can see this as the error is

```
E: Failed to fetch http://ppa.launchpad.net/ondrej/php/ubuntu/pool/main/libx/libxml2/libxml2-dev_2.9.10+dfsg-2+ubuntu18.04.1+deb.sury.org+1_amd64.deb  404  Not Found [IP: 91.189.95.83 80]
```

and if you go to the URL http://ppa.launchpad.net/ondrej/php/ubuntu/pool/main/libx/libxml2/ you can see that's because it is `+dfsg-5` that was pushed up on 2020-05-06:

```
libxml2-dev_2.9.10+dfsg-5+ubuntu16.04.1+deb.sury.org+3_amd64.deb    2020-05-06 10:44	790K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu16.04.1+deb.sury.org+3_arm64.deb    2020-05-06 10:44	695K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu16.04.1+deb.sury.org+3_armhf.deb    2020-05-06 10:44	729K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu16.04.1+deb.sury.org+3_i386.deb     2020-05-06 10:44	848K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu16.04.1+deb.sury.org+3_ppc64el.deb  2020-05-06 10:44	739K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu18.04.1+deb.sury.org+3_amd64.deb    2020-05-06 10:44	802K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu18.04.1+deb.sury.org+3_arm64.deb    2020-05-06 10:44	722K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu18.04.1+deb.sury.org+3_armhf.deb    2020-05-06 10:44	738K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu18.04.1+deb.sury.org+3_i386.deb     2020-05-06 10:44	861K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu18.04.1+deb.sury.org+3_ppc64el.deb  2020-05-06 10:44	797K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu19.10.1+deb.sury.org+3_amd64.deb    2020-05-06 10:44	789K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu19.10.1+deb.sury.org+3_arm64.deb    2020-05-06 10:44	747K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu19.10.1+deb.sury.org+3_armhf.deb    2020-05-06 10:44	719K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu19.10.1+deb.sury.org+3_i386.deb     2020-05-06 10:44	850K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu19.10.1+deb.sury.org+3_ppc64el.deb  2020-05-06 10:44	854K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu20.04.1+deb.sury.org+3_amd64.deb    2020-05-06 10:44	790K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu20.04.1+deb.sury.org+3_arm64.deb    2020-05-06 10:44	747K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu20.04.1+deb.sury.org+3_armhf.deb    2020-05-06 10:44	720K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu20.04.1+deb.sury.org+3_i386.deb     2020-05-06 10:44	850K	 
libxml2-dev_2.9.10+dfsg-5+ubuntu20.04.1+deb.sury.org+3_ppc64el.deb  2020-05-06 10:44	855K	 
```
