### PR TITLE
fix: Update PyHEP 2020 date and location

### DIFF
--- a/_data/events/20200711-pyhep-2020.yml
+++ b/_data/events/20200711-pyhep-2020.yml
@@ -1,7 +1,0 @@
-name: PyHEP 2020 Workshop
-startdate: 2020-07-11
-enddate: 2020-07-13
-location:  Univ. of Texas at Austin (Austin, TX)
-meetingurl: https://indico.cern.ch/e/PyHEP2020
-image: 
-description: 

--- a/_data/events/20200713-pyhep-2020.yml
+++ b/_data/events/20200713-pyhep-2020.yml
@@ -1,0 +1,7 @@
+name: PyHEP 2020 Workshop
+startdate: 2020-07-13
+enddate: 2020-07-17
+location: Online
+meetingurl: https://indico.cern.ch/e/PyHEP2020
+image:
+description: Workshop to provide an environment to discuss and promote the usage of Python in the HEP community at large.


### PR DESCRIPTION
[PyHEP 2020](https://indico.cern.ch/event/882824/) has moved online and changed the dates to accomdate peoples schedule and timezones. cc @jpivarski 