### PR TITLE
feat: Add support for markdown in mentor list

### DIFF
--- a/_layouts/fellow.html
+++ b/_layouts/fellow.html
@@ -41,7 +41,7 @@ More information: <a href = {{page.proposal}}>My full proposal</a><br>
 {% endif %}
 {% endfor %}
 {% if ok == 0 %}
-{{mentor}}
+{{ mentor | markdownify }}
 {%endif%}
 </li>
 {% endfor %}

--- a/pages/fellows/BoZheng.md
+++ b/pages/fellows/BoZheng.md
@@ -13,7 +13,7 @@ institution: Rice University
 website: https://github.com/coolalexzb
 e-mail: bz30@rice.edu
 mentors:
-  - matthewfeickert (IRIS-HEP, pyhf dev team)
+  - matthewfeickert
   - Lukas Heinrich (pyhf dev team)
   - Giordon Stark (pyhf dev team)
 project_goal: >


### PR DESCRIPTION
Amends ~~Partially reverts~~ PR #328

It seems that personnel data can only be accessed through the `teams` category as 

```markdown
---
permalink: /projects/pyhf.html
layout: project
title: pyhf
shortname: pyhf
pagetype: project
image: logos/pyhf-logo.png
logowidth: 50%
blurb: Differentiable likelihoods
focus-area: as
team:
 - cranmer
 - Lukas Heinrich
 - matthewfeickert
 - Giordon Stark
---
```

allows for rendering `matthewfeickert` as [Matthew Feickert](https://www.matthewfeickert.com/), but this does not get automatically picked up (as attempted in PR #328). So add username support for `mentors` allowing `matthewfeickert` to be rendered, but removing trailing charecters.