### PR TITLE
Adding multi-internship fellow support to website

### DIFF
--- a/_layouts/fellow.html
+++ b/_layouts/fellow.html
@@ -13,39 +13,57 @@
 <img src="{{page.photo}}" width="150px">
 <br>
 <br>
-<b> Fellowship dates:</b> {{ page.dates }}
+<b> Fellowship dates:</b>
+{%- if page.dates.first -%}
+{{   page.dates | join: ", " }}
+{%- else -%}
+{{   page.dates }}
+{%- endif -%}
 <br>
 <b> Home Institution:</b> {{ page.institution }}
 <br>
 <br>
 </center>
 
-{{page.project_goal}}
-<br>
-<br>
-{% if page.proposal.size  > 4 %}
-More information: <a href = {{page.proposal}}>My full proposal</a><br>
-{% endif %}
+{%- if page.projects -%}
+{%-   assign projects = page.projects -%}
+{%- else -%}
+{%-   assign projects = "" | split: "," -%}
+{%-   assign projects = projects | push: page -%}
+{%- endif -%}
+
+{% for project in projects %}
+
+  <br>
+  <h3>{{project.project_title}}</h3>
+
+  {{project.project_goal}}
+  <br>
+  <br>
+   More information: <a href = "{{project.proposal}}">My project proposal</a><br>
+
+  <br>
+  <b>Mentors: </b> <br>
+  <ul>
+  {% for mentor in project.mentors %}
+  <li>
+  {% assign ok = 0 %}
+  {% for person_hash in site.data.people %}
+  {% assign person = person_hash[1] %}
+  {% if person.shortname == mentor %}
+  {{ person.name }} ({{person.institution}})
+  {% assign ok = 1 %}
+  {% endif %}
+  {% endfor %}
+  {% if ok == 0 %}
+  {{ mentor | markdownify }}
+  {%endif%}
+  </li>
+  {% endfor %}
+  </ul>
+{% endfor %}
 
 <br>
-<b>Mentors: </b> <br>
-<ul>
-{% for mentor in page.mentors %}
-<li>
-{% assign ok = 0 %}
-{% for person_hash in site.data.people %}
-{% assign person = person_hash[1] %}
-{% if person.shortname == mentor %}
-{{ person.name }} ({{person.institution}})
-{% assign ok = 1 %}
-{% endif %}
-{% endfor %}
-{% if ok == 0 %}
-{{ mentor | markdownify }}
-{%endif%}
-</li>
-{% endfor %}
-</ul>
 <hr>
 
 <b>Contact me:</b><br>

--- a/pages/fellows/PratyushDas.md
+++ b/pages/fellows/PratyushDas.md
@@ -6,37 +6,39 @@ active: green
 title: Reik Das - IRIS-HEP Fellow
 fellow-name: Pratyush (Reik) Das
 shortname: reikdas
-project_title: Adding ability to write TTrees to uproot
-dates: Jun-Sep 2019
+dates:
+  - Jun-Sep 2019
+  - Jun-Aug 2020
 photo: /assets/images/team/Pratyush-Das.jpg
 institution: Institute of Engineering & Management (Kolkata)
 website: https://reikdas.github.io/
 e-mail: reikdas@gmail.com
-mentors:
+
+projects:
+- project_title: Awkward-Array GPU Kernels
+  project_goal: >
+    As an IRIS-HEP undergraduate fellow, my work would involve creating a library of Awkward-Array
+    GPU kernels preceded by an investigation into the most appropriate way to translate pre-existing
+    CPU kernels to GPU kernels, with an emphasis on generalizing the translation between the scalar
+    code in the currently existing CPU kernels into vectorized code to be executed on GPUs. At the
+    end of the summer, users of Awkward Array should be able to naively switch between the CPU and
+    GPU backends without having to write specialized code or even leaving the Python prompt.
+  mentors:
   - jpivarski
-project_goal: >
-  As an IRIS-HEP undergraduate fellow, my work would involve creating a library of Awkward-Array
-  GPU kernels preceded by an investigation into the most appropriate way to translate pre-existing 
-  CPU kernels to GPU kernels, with an emphasis on generalizing the translation between the scalar 
-  code in the currently existing CPU kernels into vectorized code to be executed on GPUs. At the 
-  end of the summer, users of Awkward Array should be able to naively switch between the CPU and 
-  GPU backends without having to write specialized code or even leaving the Python prompt.<br/>
-  <br/>
-  More information: <a href="../../assets/pdf/Fellow-Pratyush-Das-Proposal2.pdf">My full proposal</a><br/>
-  <br/>
+  proposal: /assets/pdf/Fellow-Pratyush-Das-Proposal2.pdf
 
-  As an IRIS-HEP undergraduate fellow, I will be working on ​uproot, a​
-  software for reading and writing ROOT files in Python with the help of   
-  the Numpy library. Unlike the standard C++ ROOT implementation, uproot 
-  is strictly an I/O library, intended to stream data into other third 
-  party libraries in Python. Other ROOT file readers in Python like PyROOT 
-  and root_numpy rely on the C++ ROOT implementation but uproot does not. 
-  Instead, it uses Numpy calls to rapidly cast data blocks in the ROOT file as Numpy arrays.
+- project_title: Adding ability to write TTrees to uproot
+  project_goal: >
+    As an IRIS-HEP undergraduate fellow, I will be working on uproot, a
+    software for reading and writing ROOT files in Python with the help of 
+    the Numpy library. Unlike the standard C++ ROOT implementation, uproot 
+    is strictly an I/O library, intended to stream data into other third 
+    party libraries in Python. Other ROOT file readers in Python like PyROOT 
+    and root_numpy rely on the C++ ROOT implementation but uproot does not. 
+    Instead, it uses Numpy calls to rapidly cast data blocks in the ROOT file as Numpy arrays.
+  mentors:
+  - jpivarski
+  proposal: /assets/pdf/Fellow-Pratyush-Das-Proposal.pdf
 
-proposal: /assets/pdf/Fellow-Pratyush-Das-Proposal.pdf
 presentations:
-
-
-
----
-  
+---  

--- a/pages/index.html
+++ b/pages/index.html
@@ -67,7 +67,11 @@ an HEP software R&D topic relevant to the Institute.
                  <b><a href="{{person.permalink}}">{{person.fellow-name}}</a></b><br>
                  <small>{{person.institution}}</small><br><br>
               </div>
-              <div class="card-text mt-auto"><i>{{person.dates}}</i><br></div>
+              {% if person.dates.first %}
+                <div class="card-text mt-auto"><i>{{person.dates | join: "</i><br><i>"}}</i><br></div>
+              {% else %}
+                <div class="card-text mt-auto"><i>{{person.dates}}</i><br></div>
+              {% endif %}
             </div>
          </div>
       {% endif %}


### PR DESCRIPTION
You can now list multiple dates for a fellow, as well as one or more `projects:` (as a list of Hashes).

For example, see pages/fellows/PratyushDas.md.

Followup to #351. Also displays the title (which was missing before).