### PR TITLE
chore: Stricter checking of yaml/liquid

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,12 @@ plugins:
 # seems to cause problems currently (March 2019)
 #  - jekyll-redirect-from
 
+strict_front_matter: true
+
+liquid:
+  error_mode: strict
+  strict_filters: true
+
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.

--- a/pages/index.html
+++ b/pages/index.html
@@ -91,9 +91,9 @@ ongoing events don't get prematurely flagged as recent.
 {% endcomment %}
 
 {% assign currentdatecmp = 'now' | date: "%s" %}
-{% assign onedayago = 'now' | date: "%s" | minus: 86400 | date: "%b %d, %Y %I:%M %p -0500" | uri_encode | replace: "+","%20" | date: "%s"%}
-{% assign sixdaysago = 'now' | date: "%s" | minus: 518400 | date: "%b %d, %Y %I:%M %p -0500" | uri_encode | replace: "+","%20" | date: "%s"%}
-{% assign ninetydaysago = 'now' | date: "%s" | minus: 7776000| date: "%b %d, %Y %I:%M %p -0500" | uri_encode | replace: "+","%20" | date: "%s"%}
+{% assign onedayago = 'now' | date: "%s" | minus: 86400 | date: "%b %d, %Y %I:%M %p -0500" | url_encode | replace: "+","%20" | date: "%s"%}
+{% assign sixdaysago = 'now' | date: "%s" | minus: 518400 | date: "%b %d, %Y %I:%M %p -0500" | url_encode | replace: "+","%20" | date: "%s"%}
+{% assign ninetydaysago = 'now' | date: "%s" | minus: 7776000| date: "%b %d, %Y %I:%M %p -0500" | url_encode | replace: "+","%20" | date: "%s"%}
 
 {% assign selected_events = "" | split: ',' %}
 


### PR DESCRIPTION
Closes #350 - should catch simple mistakes (missing a `---` will probably still not be caught, though).