### PR TITLE
Adding NSF PAR page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ Metrics/MethodLength:
 Style/NumericLiterals:
   Enabled: false
 Metrics/AbcSize:
-  Max: 50
+  Max: 55
 Metrics/ClassLength:
   Max: 200
 Metrics/PerceivedComplexity:

--- a/_plugins/getpub.rb
+++ b/_plugins/getpub.rb
@@ -56,6 +56,7 @@ module Publications
     def prepare(pub, name)
       pub['focus-area'] ||= []
       pub['project'] ||= []
+      pub['filename'] = name
 
       force_array(pub, 'project')
 
@@ -145,8 +146,10 @@ module Publications
       j = data.dig('publication_info', 0) # This may be nil
       journal =
         if j&.key?('journal_title') && j&.key?('year')
+          pub['needs-nsf-par'] = true unless pub.key?('needs-nsf-par')
           "#{j['journal_title']} #{j['journal_volume']} #{j['artid']} (#{j['year']})"
         elsif data.key? 'arxiv_eprints'
+          pub['needs-nsf-par'] = false unless pub.key?('needs-nsf-par')
           "arXiv #{data['arxiv_eprints'][0]['value']}"
         else
           'Unknown'

--- a/pages/docs/nsfpar.md
+++ b/pages/docs/nsfpar.md
@@ -1,0 +1,63 @@
+---
+permalink: /docs/nsfpar.html
+layout: default
+title: NSF PAR listing
+pagetype: doc
+---
+
+## Publication listings
+
+This is a list of the publications, along with the NSF PAR status.
+
+{% assign doPublications = 0 %}
+{% include get_pub_list.html %}
+
+### TODO: Needs a NSF PAR ID
+
+For each of these, `nsf-par-id: <number>` should be added to the datafile. If
+an `nsf-par-id` really is not needed, set `needs-nsf-par: false` explicitly.
+
+<ul>
+  {% for pub in sorted_publications %}
+    {% unless pub.nsf-par-id -%}{%- if pub.needs-nsf-par -%}
+      <li>
+        <code class="highlighter-rouge">_data/publications/{{ pub.filename }}.yml</code>:
+        {% include print_pub.html pub=pub -%}
+      </li>
+    {%- endif -%}{%- endunless -%}
+  {% endfor %}
+</ul>
+
+
+### Has an NSF PAR ID
+
+For each of these, `nsf-par-id` has been added.
+
+<ul>
+  {% for pub in sorted_publications %}
+    {% if pub.nsf-par-id -%}
+      <li>
+        <code class="highlighter-rouge">_data/publications/{{ pub.filename }}.yml</code>:
+        {% include print_pub.html pub=pub -%}
+      </li>
+    {%- endif -%}
+  {% endfor %}
+</ul>
+
+
+### No explicit request for ID
+
+These to not have NSF PAR IDs, and probably do not need one; either because
+they are arXiv only, have an explicit false for `needs-nsf-par`, or were
+manually entered.
+
+<ul>
+  {% for pub in sorted_publications %}
+    {% unless pub.nsf-par-id -%}{%- unless pub.needs-nsf-par -%}
+      <li>
+        <code class="highlighter-rouge">_data/publications/{{ pub.filename }}.yml</code>:
+        {% include print_pub.html pub=pub -%}
+      </li>
+    {%- endunless -%}{%- endunless -%}
+  {% endfor %}
+</ul>

--- a/pages/docs/webdev.md
+++ b/pages/docs/webdev.md
@@ -7,7 +7,7 @@ pagetype: doc
 
 ### Getting the source
 
-The webite source is available at <https://github.com/iris-hep/iris-hep.github.io-source>.
+The website source is available at <https://github.com/iris-hep/iris-hep.github.io-source>.
 
 You can always click the edit button to make small edits to the website source, but if you want to test locally or make larger edits, you'll want to clone the source for the website and build it with Ruby.
 

--- a/pages/publications/all.md
+++ b/pages/publications/all.md
@@ -7,9 +7,7 @@ draft: false
 
 ## Publications by the IRIS-HEP team
 
-{% assign doPublications = 0 %}
 {% include get_pub_list.html %}
-
 
 <ul>
   {% for pub in sorted_publications %}


### PR DESCRIPTION
This adds a page (find in sitemap) that gives a status for NSF PAR IDs.