### PR TITLE
docs: Add Feickert SciPy 2020 and PyHEP 2020 talks

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -89,3 +89,11 @@ presentations:
     location: Virtual
     focus-area: as
     comment: Proceedings for slides not yet published
+  - title: "pyhf Tutorial: Accelerating analyses and preserving likelihoods"
+    date: 2020-07-16
+    url: https://indico.cern.ch/event/882824/contributions/3931292/
+    meeting: PyHEP 2020 Workshop
+    meetingurl: https://indico.cern.ch/event/882824/
+    location: Virtual
+    focus-area: as
+    comment: DOI not yet available

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -81,3 +81,11 @@ presentations:
     meetingurl: https://indico.cern.ch/event/896167/
     location: Virtual
     focus-area: as
+  - title: "pyhf: a pure Python statistical fitting library with tensors and autograd"
+    date: 2020-07-07
+    url: https://matthewfeickert.github.io/talk-SciPy-2020/index.html
+    meeting: 19th Python in Science Conference (SciPy 2020)
+    meetingurl: https://www.scipy2020.scipy.org/
+    location: Virtual
+    focus-area: as
+    comment: Proceedings for slides not yet published


### PR DESCRIPTION
Add: [`pyhf` talk given at SciPy 2020](https://matthewfeickert.github.io/talk-SciPy-2020/index.html) and [`pyhf` tutorial given at PyHEP 2020](https://indico.cern.ch/event/882824/contributions/3931292/)

Note that this PR will be amended by a follow up PR once the [SciPy 2020 proceedings for talks are released](https://github.com/scipy-conference/scipy_proceedings/pull/580) and the DOIs for PyHEP 2020 talks are made.