### PR TITLE
docs: Update linked pyhf talk to SciPy 2020

### DIFF
--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -18,7 +18,7 @@ team:
 
 `pyhf` is a pure-python implementation of the widely-used HistFactory p.d.f. template described in [[CERN-OPEN-2012-016](https://cds.cern.ch/record/1456844)]. It also includes interval estimation is based on the asymptotic formulas of "Asymptotic formulae for likelihood-based tests of new physics" [[arxiv:1007.1727](https://arxiv.org/abs/1007.1727)]. The aim is also to support modern computational graph libraries such as PyTorch and TensorFlow in order to make use of features such as autodifferentiation and GPU acceleration.
 
-[A talk on pyhf by Matthew Feickert](http://matthewfeickert.github.io/talk-DIANA-HEP-pyhf-2018/index.html?p=talk.md#1)
+[A talk on `pyhf` by Matthew Feickert](https://matthewfeickert.github.io/talk-SciPy-2020/index.html)
 
 
 [![GitHub Project](https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub)](https://github.com/scikit-hep/pyhf/)


### PR DESCRIPTION
The current linked talk is very old, so update the hyperlinked example talk to the one Matthew Feickert gave at SciPy 2020 (the [YouTube video](https://youtu.be/FrH9s3eB6fU) is hyperlinked from the title page and so allows for discovery)