### PR TITLE
feat: rct225 new fellows

### DIFF
--- a/_includes/fellow_dates.html
+++ b/_includes/fellow_dates.html
@@ -1,0 +1,17 @@
+
+{%- if include.dates.first.start -%}
+{%- assign dates = include.dates -%}
+{%- else -%}
+{%- assign dates = "" | split: "," -%}
+{% assign dates = dates | push: include.dates %}
+{%- endif -%}
+
+{% for date in dates %}
+  {%- assign date_start_year = date.start | date: "%Y" -%}
+  {%- assign date_end_year = date.end | date: "%Y" -%}
+  {% if date_start_year == date_end_year %}
+    {{ date.start | date: "%b" }} - {{ date.end | date: "%b %Y" }}<br/>
+  {%- else -%}
+    {{ date.start | date: "%b %Y" }} - {{ date.end | date: "%b %Y" }}<br/>
+  {%- endif -%}
+{% endfor %}

--- a/_layouts/fellow.html
+++ b/_layouts/fellow.html
@@ -14,13 +14,7 @@
 <br>
 <br>
 <b> Fellowship dates: </b>
-{%- if page.dates.first.start -%}
-  {% for date in page.dates %}
-    {{ date.start | date: "%b" }} - {{ date.end | date: "%b %Y" }}<br>
-  {% endfor %}
- {%- else -%}
-  {{ page.dates.start | date: "%b" }} - {{ page.dates.end | date: "%b %Y" }}<br>
- {%- endif -%}
+{% include fellow_dates.html dates=page.dates %}
 <br>
 <b> Home Institution:</b> {{ page.institution }}
 <br>

--- a/_layouts/fellow.html
+++ b/_layouts/fellow.html
@@ -14,12 +14,12 @@
 <br>
 <br>
 <b> Fellowship dates: </b>
-{%- if page.dates.first -%}
-  {% for dates in page.dates %}
-    {{ dates.start_date | date: "%b" }} - {{ dates.end_date | date: "%b %Y" }}<br>
+{%- if page.dates.first.start -%}
+  {% for date in page.dates %}
+    {{ date.start | date: "%b" }} - {{ date.end | date: "%b %Y" }}<br>
   {% endfor %}
  {%- else -%}
-  {{ page.start_date | date: "%b" }} - {{ page.end_date | date: "%b %Y" }}<br>
+  {{ page.dates.start | date: "%b" }} - {{ page.dates.end | date: "%b %Y" }}<br>
  {%- endif -%}
 <br>
 <b> Home Institution:</b> {{ page.institution }}

--- a/_layouts/fellow.html
+++ b/_layouts/fellow.html
@@ -1,5 +1,5 @@
 <!doctype html>
-  
+
 {% include layout_header_navbar.html %}
 
     <div id="container">
@@ -14,11 +14,9 @@
 <br>
 <br>
 <b> Fellowship dates: </b>
-{%- if page.dates.first -%}
-{{   page.dates | join: ", " }}
-{%- else -%}
-{{   page.dates }}
-{%- endif -%}
+{% for dates in page.dates %}
+  {{dates.start_date | date: "%b" }} - {{dates.end_date | date: "%b %Y"}}<br>
+{% endfor %}
 <br>
 <b> Home Institution:</b> {{ page.institution }}
 <br>
@@ -92,5 +90,3 @@
 {% include layout_analytics.html %}
 </body>
 </html>
-
-

--- a/_layouts/fellow.html
+++ b/_layouts/fellow.html
@@ -14,9 +14,13 @@
 <br>
 <br>
 <b> Fellowship dates: </b>
-{% for dates in page.dates %}
-  {{dates.start_date | date: "%b" }} - {{dates.end_date | date: "%b %Y"}}<br>
-{% endfor %}
+{%- if page.dates.first -%}
+  {% for dates in page.dates %}
+    {{ dates.start_date | date: "%b" }} - {{ dates.end_date | date: "%b %Y" }}<br>
+  {% endfor %}
+ {%- else -%}
+  {{ page.start_date | date: "%b" }} - {{ page.end_date | date: "%b %Y" }}<br>
+ {%- endif -%}
 <br>
 <b> Home Institution:</b> {{ page.institution }}
 <br>

--- a/pages/fellows.md
+++ b/pages/fellows.md
@@ -55,14 +55,15 @@ IRIS-HEP Fellow positions will be awarded in a rolling fashion based on submitte
 
 <div class="container-fluid">
   <div class="row">
-    {% assign current_fellows_start = '2020-05-01' | minus: 7257600 | date:'%F' %}
+    {% assign current_fellows_start = '2020-05-01' | minus: 7257600 | date: '%F' %}
     {% assign sorted = site.pages | sort_natural: 'title' %}
     {% for mypage in sorted %}
-      {%- if mypage.dates.first -%}
-        {% assign page_start_date = mypage.dates.first.start_date | date: '%F' %}
+      {%- if mypage.dates.first.start -%}
+        {% assign page_start_date = mypage.dates.first.start | date: '%F' %}
       {%- else -%}
-        {% assign page_start_date = mypage.start_date | date: '%F' %}
+        {% assign page_start_date = mypage.dates.start | date: '%F' %}
       {%- endif -%}
+
       {% if mypage.pagetype == 'fellow' and page_start_date >= current_fellows_start %}
          {% assign person = mypage %}
 
@@ -75,12 +76,12 @@ IRIS-HEP Fellow positions will be awarded in a rolling fashion based on submitte
               </div>
               <div class="card-text mt-auto"><i>
 
-              {%- if person.dates.first -%}
-                {% for dates in person.dates %}
-                  {{ dates.start_date | date: "%b" }} - {{ dates.end_date | date: "%b %Y" }}<br>
+              {%- if person.dates.first.start -%}
+                {% for date in person.dates %}
+                  {{ date.start | date: "%b" }} - {{ date.end | date: "%b %Y" }}<br>
                 {% endfor %}
                {%- else -%}
-                {{ person.start_date | date: "%b" }} - {{ person.end_date | date: "%b %Y" }}<br>
+                {{ person.dates.start | date: "%b" }} - {{ person.dates.end | date: "%b %Y" }}<br>
                {%- endif -%}
               </i><br></div>
             </div>

--- a/pages/fellows.md
+++ b/pages/fellows.md
@@ -49,33 +49,48 @@ Prospective fellows will eventually apply (to fellows@iris-hep.org) by providing
 
 IRIS-HEP Fellow positions will be awarded in a rolling fashion based on submitted project proposals.
 
-# IRIS-HEP Fellows
+# IRIS-HEP Current Fellows (Summer 2020)
+
+[Former IRIS-HEP Fellows](/former-fellows.html)
 
 <div class="container-fluid">
   <div class="row">
-{% assign sorted = site.pages | sort_natural: 'title' %}
-{% for mypage in sorted %}
-  {% if mypage.pagetype == 'fellow' %}
-     {% assign person = mypage %}
-     <div class="card" style="width: 12rem;">
-        <img class="card-img-top" src="{{person.photo}}" alt="Card image cap">
-        <div class="card-body d-flex flex-column">
-          <div class="card-text">
-             <b><a href="{{person.permalink}}">{{person.fellow-name}}</a></b><br>
-             <small>{{person.institution}}</small><br><br>
-          </div>
-          <div class="card-text mt-auto"><i>
-          {% for dates in person.dates %}
-            {{dates.start_date | date: "%b" }} - {{dates.end_date | date: "%b %Y"}}<br>
-          {% endfor %}
-          </i><br></div>
-        </div>
-     </div>
-  {% endif %}
-{% endfor %}
+    {% assign current_fellows_start = '2020-05-01' | minus: 7257600 | date:'%F' %}
+    {% assign sorted = site.pages | sort_natural: 'title' %}
+    {% for mypage in sorted %}
+      {%- if mypage.dates.first -%}
+        {% assign page_start_date = mypage.dates.first.start_date | date: '%F' %}
+      {%- else -%}
+        {% assign page_start_date = mypage.start_date | date: '%F' %}
+      {%- endif -%}
+      {% if mypage.pagetype == 'fellow' and page_start_date >= current_fellows_start %}
+         {% assign person = mypage %}
+
+         <div class="card" style="width: 12rem;">
+            <img class="card-img-top" src="{{person.photo}}" alt="Card image cap">
+            <div class="card-body d-flex flex-column">
+              <div class="card-text">
+                 <b><a href="{{person.permalink}}">{{person.fellow-name}}</a></b><br>
+                 <small>{{person.institution}}</small><br><br>
+              </div>
+              <div class="card-text mt-auto"><i>
+
+              {%- if person.dates.first -%}
+                {% for dates in person.dates %}
+                  {{ dates.start_date | date: "%b" }} - {{ dates.end_date | date: "%b %Y" }}<br>
+                {% endfor %}
+               {%- else -%}
+                {{ person.start_date | date: "%b" }} - {{ person.end_date | date: "%b %Y" }}<br>
+               {%- endif -%}
+              </i><br></div>
+            </div>
+         </div>
+      {% endif %}
+    {% endfor %}
   </div>
   <br>
 </div>
+
 
 # Example fellow projects
 

--- a/pages/fellows.md
+++ b/pages/fellows.md
@@ -4,16 +4,16 @@ layout: default
 title: IRIS/HEP Fellows Program
 ---
 
-# IRIS-HEP Fellows Program 
+# IRIS-HEP Fellows Program
 
 ### Proposals for Summer 2020 are no longer being accepted.  We are still accepting proposals for Fall 2020.
 
-  People are the key to successful software. IRIS-HEP aims to promote the 
-development of advanced research software skills by providing opportunities 
+  People are the key to successful software. IRIS-HEP aims to promote the
+development of advanced research software skills by providing opportunities
 for undergraduate and graduate students to connect with mentors within the
-larger HEP and Computational/Data Science community. At the same time, we aim 
-to promote software as a collaborative activity and encourage collaborations 
-which engage individuals in ways that maximize their potential and their 
+larger HEP and Computational/Data Science community. At the same time, we aim
+to promote software as a collaborative activity and encourage collaborations
+which engage individuals in ways that maximize their potential and their
 potential impact on the community.
 
   In order to accomplish these goals, IRIS-HEP has created a Fellow program.
@@ -28,14 +28,14 @@ R&D topic relevant to the Institute. Possible software R&D areas include:
   * [Service containerization, DevOps, security, service monitoring, and accounting](/osglhc.html)
   * [Network monitoring and analytics](/osglhc.html)
 
-It is *not* required that the mentors are IRIS-HEP team members, any 
+It is *not* required that the mentors are IRIS-HEP team members, any
 appropriate mentor from the larger community working in one of these areas
 can be part of the program.
 
   Two types of IRIS-HEP Fellows are possible:
 
   * **IRIS-HEP Graduate Fellows** - Graduate fellows spend 3 months working **remotely** with a mentor developing research software relevant for HEP in one of the R&D areas listed above. Fellows are expected to have a base research stipend from their university, but receive a monthly subsistence plus travel expenses from their IRIS-HEP fellowship.  **Travel support is not available in 2020 due to the COVID-19 pandemic.  All work and interactions with mentors will be entirely virtual.**
-  
+
   * **IRIS-HEP Undergraduate Fellows** - Undergraduate fellows work **remotely** with mentors in their local home institution for 10-12 weeks, either developing or using research software relevant for HEP in the categories listed above. Undergraduate fellows receive a monthly stipend during their fellowship.  In some cases, travel support may be available.  **Travel support is not available in 2020 due to the COVID-19 pandemic.  All work and interactions with mentors will be entirely virtual**.
 
   Examples fellows in a related program can be found on the [DIANA/HEP Fellow webpage](http://diana-hep.org/pages/fellows.html) and example projects of interest in the HEP community can be found on the [HEP Software Foundation Google Summer of Code (HSF GSoC) webpage](https://hepsoftwarefoundation.org/activities/gsoc.html). While GSoC is a separate program, funded by Google, many of the projects could also be appropriate for IRIS-HEP Fellows if they are within the R&D areas listed above.
@@ -45,7 +45,7 @@ Interested prospective fellows and/or mentors should write to fellows@iris-hep.o
 Prospective fellows will eventually apply (to fellows@iris-hep.org) by providing:
 
  * A CV
- * A short proposal.  In the proposal you should briefly describe the software development activity that you would like to pursue, and how that activity will enhance your own and other people's research activities. Note also the intended software project or person with whom you will collaborate and the location where you would need to travel for that collaboration. The proposal should be short, typically no more one page to describe the project and then a short timeline with deliverables (see also examples from previous fellows). 
+ * A short proposal.  In the proposal you should briefly describe the software development activity that you would like to pursue, and how that activity will enhance your own and other people's research activities. Note also the intended software project or person with whom you will collaborate and the location where you would need to travel for that collaboration. The proposal should be short, typically no more one page to describe the project and then a short timeline with deliverables (see also examples from previous fellows).
 
 IRIS-HEP Fellow positions will be awarded in a rolling fashion based on submitted project proposals.
 
@@ -64,7 +64,11 @@ IRIS-HEP Fellow positions will be awarded in a rolling fashion based on submitte
              <b><a href="{{person.permalink}}">{{person.fellow-name}}</a></b><br>
              <small>{{person.institution}}</small><br><br>
           </div>
-          <div class="card-text mt-auto"><i>{{person.dates}}</i><br></div>
+          <div class="card-text mt-auto"><i>
+          {% for dates in person.dates %}
+            {{dates.start_date | date: "%b" }} - {{dates.end_date | date: "%b %Y"}}<br>
+          {% endfor %}
+          </i><br></div>
         </div>
      </div>
   {% endif %}
@@ -87,9 +91,9 @@ for a Fellow to collaborate. (This is a non-exhaustive list, more to come!)
 - **Active learning for more efficient generation of Monte Carlo for exclusion plots:**
 An [active learning algorithm called has been developed](https://indico.cern.ch/event/708041/contributions/3269754/) to make smart choices for parameters of signal Monte Carlo (eg. for a SUSY scan) that requires many fewer signal samples for producing a quality exclusion contour. Project would be to interface [excursion](https://github.com/diana-hep/excursion)  with either the ATLAS or CMS production system and REANA/RECAST. Ideally, excursion algorithm would run on a machine with a GPU and be upgraded to include advances in scalable Gaussian Processes (eg. [GPyTorch](https://gpytorch.ai)).
 
-- **Contributions to Pythonic jet tools for Scikit-HEP:** [Scikit-HEP](http://scikit-hep.org) has a tool called [pyjet](https://github.com/scikit-hep/pyjet), which provides an interface between FastJet and NumPy. The tool was developed prior to [Uproot](https://github.com/scikit-hep/uproot#readme) and [Awkward Array](https://github.com/scikit-hep/awkward-1.0#readme), which extend columnar (NumPy-like) analysis to High Energy Physics. As of version 3.3, [FastJet](http://fastjet.fr/repo/fastjet-doc-3.3.3.pdf) itself ships with a Python interface, but it was not designed with columnar analysis in mind. Pyjet, on the other hand, is incomplete: it lacks some functionality related to jet substructure. This project would first investigate the design considerations of the existing Python bindings with Scikit-HEP’s Uproot and [Awkward Array](/projects/awkward.html) in mind and then contribute to improving the jet tools for the Scikit-HEP ecosystem. 
+- **Contributions to Pythonic jet tools for Scikit-HEP:** [Scikit-HEP](http://scikit-hep.org) has a tool called [pyjet](https://github.com/scikit-hep/pyjet), which provides an interface between FastJet and NumPy. The tool was developed prior to [Uproot](https://github.com/scikit-hep/uproot#readme) and [Awkward Array](https://github.com/scikit-hep/awkward-1.0#readme), which extend columnar (NumPy-like) analysis to High Energy Physics. As of version 3.3, [FastJet](http://fastjet.fr/repo/fastjet-doc-3.3.3.pdf) itself ships with a Python interface, but it was not designed with columnar analysis in mind. Pyjet, on the other hand, is incomplete: it lacks some functionality related to jet substructure. This project would first investigate the design considerations of the existing Python bindings with Scikit-HEP’s Uproot and [Awkward Array](/projects/awkward.html) in mind and then contribute to improving the jet tools for the Scikit-HEP ecosystem.
 
-- **CMS RECAST example & documentation:** [RECAST](/projects/recast.html) is a platform for systematic interpretation of LHC searches. It reuses preserved analysis workflows from the LHC experiments, which is now possible with containerization and tools such as [REANA](http://reanahub.io). Recently, IRIS-HEP and the HEP Software Foundation (HSF) supported an [analysis preservation bootcamp at CERN](/2020/02/17/analysis-preservation.html) teaching these tools. Furthermore, the ATLAS experiment is now actively using RECAST. We seek a member of CMS to incorporate a CMS analysis into the system with support from IRIS-HEP, REANA, and RECAST developers. 
+- **CMS RECAST example & documentation:** [RECAST](/projects/recast.html) is a platform for systematic interpretation of LHC searches. It reuses preserved analysis workflows from the LHC experiments, which is now possible with containerization and tools such as [REANA](http://reanahub.io). Recently, IRIS-HEP and the HEP Software Foundation (HSF) supported an [analysis preservation bootcamp at CERN](/2020/02/17/analysis-preservation.html) teaching these tools. Furthermore, the ATLAS experiment is now actively using RECAST. We seek a member of CMS to incorporate a CMS analysis into the system with support from IRIS-HEP, REANA, and RECAST developers.
 
 - **A pyhf converter for binned likelihood models in CMS Combine:** Binned likelihood models based on template histograms are ubiquitous in both ATLAS and CMS. Within ATLAS the HistFactory tool is used widely (sometimes from a higher-level tool like HistFitter or TRExFitter). Within CMS the Combine tool is widely used. Both produce RooFit workspaces. Recently, the HistFactory specification was implemented in a pure python environment called [pyhf](/projects/pyhf.html), which can take advantage of GPU acceleration, automatic differentiation, etc. via backends like TensorFlow, PyTorch, JAX, etc. In addition, the pyhf model uses a JSON schema which has benefits for digital publishing and reinterpretation. We seek a fellow to develop a to converter for binned template likelihoods from the CMS Combine syntax to the pyhf specification and develop some tools to perform comparisons between the two models.
 
@@ -108,14 +112,13 @@ The benchmarking suite would preferably be written as a [`pytest`](https://docs.
 - **Reproducible, large-scale SkyhookDM experiments**. SkyhookDM is a storage system that allows users to transparently grow and shrink their data storage and processing needs as demands change. SkyhookDM utilizes and extends the Ceph distributed object storage platform with customized C++ "object classes" that enable database operations such as `SELECT`, `PROJECT`, `AGGREGATE` to be offloaded directly into the object storage layer, allowing applications to efficiently query multi-dimensional arrays (HDF5, ROOT, among other formats are supported). The aim of this project is to implement and automate large-scale tests on CloudLab, GCP, AWS, and MS Azure, by benchmarking SkyhookDM at the 10's of terabyte scale over the various supported data formats.
 
 - **Graph Methods for Particle Tracking**:
-Particle track reconstruction is a critical software component for meeting the physics goals of the HL-LHC. 
-This project uses Graph based learning methods to address this problem; the overall goal is to do accelerated 
+Particle track reconstruction is a critical software component for meeting the physics goals of the HL-LHC.
+This project uses Graph based learning methods to address this problem; the overall goal is to do accelerated
 track-seeding at the trigger level by using Graph Neural Networks to construct tracklets in the ATLAS/CMS pixel
- detectors and implementing the algorithms on dedicated FPGAs. There are two areas within this work that a 
-fellow could contribute to (and this project could support two separate fellows depending on interest): 
+ detectors and implementing the algorithms on dedicated FPGAs. There are two areas within this work that a
+fellow could contribute to (and this project could support two separate fellows depending on interest):
 The first is on the Machine Learning side by implementing, training, and evaluating additional GNN architectures
- and graph construction methods. The second is on the hardware and acceleration side by working on translating 
+ and graph construction methods. The second is on the hardware and acceleration side by working on translating
 the graph components of these algorithms efficiently onto FPGAs.
 
-- **Augment SkyhookDM with in-storage support for a relevant subset of Awkward Array operations**. [SkyhookDM](https://www.skyhookdm.com) is a storage system that allows users to transparently grow and shrink their data storage and processing needs as demands change. SkyhookDM utilizes and extends the Ceph distributed object storage platform with customized C++ "object classes" that enable database operations such as `SELECT`, `PROJECT`, `AGGREGATE` to be offloaded directly into the object storage layer.  Awkward arrays are currently stored as [lists within Arrow tables](https://arrow.apache.org/docs/cpp/api/datatype.html#classarrow_1_1_list_type) inside Skyhook.  This project will investigate and implement a small subset of [awkard array](https://github.com/scikit-hep/awkward-array) operations that can be offloaded ("pushed down") into storage for query processing. Common list manipulations that perform data reduction such as filters or summary/agg methods will be most useful to apply withing storage, since these will reduce network IO transferred back to the client from the storage layer. 
-
+- **Augment SkyhookDM with in-storage support for a relevant subset of Awkward Array operations**. [SkyhookDM](https://www.skyhookdm.com) is a storage system that allows users to transparently grow and shrink their data storage and processing needs as demands change. SkyhookDM utilizes and extends the Ceph distributed object storage platform with customized C++ "object classes" that enable database operations such as `SELECT`, `PROJECT`, `AGGREGATE` to be offloaded directly into the object storage layer.  Awkward arrays are currently stored as [lists within Arrow tables](https://arrow.apache.org/docs/cpp/api/datatype.html#classarrow_1_1_list_type) inside Skyhook.  This project will investigate and implement a small subset of [awkard array](https://github.com/scikit-hep/awkward-array) operations that can be offloaded ("pushed down") into storage for query processing. Common list manipulations that perform data reduction such as filters or summary/agg methods will be most useful to apply withing storage, since these will reduce network IO transferred back to the client from the storage layer.

--- a/pages/fellows.md
+++ b/pages/fellows.md
@@ -75,14 +75,7 @@ IRIS-HEP Fellow positions will be awarded in a rolling fashion based on submitte
                  <small>{{person.institution}}</small><br><br>
               </div>
               <div class="card-text mt-auto"><i>
-
-              {%- if person.dates.first.start -%}
-                {% for date in person.dates %}
-                  {{ date.start | date: "%b" }} - {{ date.end | date: "%b %Y" }}<br>
-                {% endfor %}
-               {%- else -%}
-                {{ person.dates.start | date: "%b" }} - {{ person.dates.end | date: "%b %Y" }}<br>
-               {%- endif -%}
+              {% include fellow_dates.html dates=person.dates %}
               </i><br></div>
             </div>
          </div>

--- a/pages/fellows/AlanAneethJegaraj.md
+++ b/pages/fellows/AlanAneethJegaraj.md
@@ -7,9 +7,8 @@ title: Alan Aneeth Jegaraj - IRIS-HEP Fellow
 fellow-name: Alan Aneeth Jegaraj
 shortname: Alan
 project_title: Matrix Factorization for Primary Vertex Reconstruction in LHCb
-dates:
-  - start_date: 2020-06-01
-    end_date: 2020-08-31
+start_date: 2020-06-01
+end_date: 2020-08-31
 photo: /assets/images/team/Alan-AneethJegaraj.jpeg
 institution: University of Cincinnati
 website:

--- a/pages/fellows/AlanAneethJegaraj.md
+++ b/pages/fellows/AlanAneethJegaraj.md
@@ -7,8 +7,9 @@ title: Alan Aneeth Jegaraj - IRIS-HEP Fellow
 fellow-name: Alan Aneeth Jegaraj
 shortname: Alan
 project_title: Matrix Factorization for Primary Vertex Reconstruction in LHCb
-start_date: 2020-06-01
-end_date: 2020-08-31
+dates:
+  start: 2020-06-01
+  end: 2020-08-31
 photo: /assets/images/team/Alan-AneethJegaraj.jpeg
 institution: University of Cincinnati
 website:

--- a/pages/fellows/AlanAneethJegaraj.md
+++ b/pages/fellows/AlanAneethJegaraj.md
@@ -7,17 +7,19 @@ title: Alan Aneeth Jegaraj - IRIS-HEP Fellow
 fellow-name: Alan Aneeth Jegaraj
 shortname: Alan
 project_title: Matrix Factorization for Primary Vertex Reconstruction in LHCb
-dates: June - August 2020
+dates:
+  - start_date: 2020-06-01
+    end_date: 2020-08-31
 photo: /assets/images/team/Alan-AneethJegaraj.jpeg
 institution: University of Cincinnati
 website:
 e-mail: aneethaj@mail.uc.edu
 mentors:
   - Gowtham Atluri (Asst. Professor, Dept. EECS, UC)
-  - Mike Sokoloff (Professor, Dept. Physics, UC) 
+  - Mike Sokoloff (Professor, Dept. Physics, UC)
 project_goal: >
-  The Large Hadron Collider beauty detector (LHCb) aims to answer the question “Why is matter more prevalent than anti-matter in the         observable Universe” by studying beauty/bottom quarks (b-quarks) and their anti-matter counterpart (b anti-quarks) which were abundant at the time after Big-Bang. The LHCb detector is expected to produce 4Tb/sec of data when it starts running in 2021 after the LS2 maintenance is completed. This calls for efficient track and primary vertex (PV) reconstruction algorithms to analyze data effectively within a practical time frame using relatively low powered computers. This project aims to develop a python workflow to test the viability of matrix factorization for PV identification, specifically Matrix tri-factorization with orthogonality constraints. 
-  
+  The Large Hadron Collider beauty detector (LHCb) aims to answer the question “Why is matter more prevalent than anti-matter in the         observable Universe” by studying beauty/bottom quarks (b-quarks) and their anti-matter counterpart (b anti-quarks) which were abundant at the time after Big-Bang. The LHCb detector is expected to produce 4Tb/sec of data when it starts running in 2021 after the LS2 maintenance is completed. This calls for efficient track and primary vertex (PV) reconstruction algorithms to analyze data effectively within a practical time frame using relatively low powered computers. This project aims to develop a python workflow to test the viability of matrix factorization for PV identification, specifically Matrix tri-factorization with orthogonality constraints.
+
 proposal: /assets/pdf/Fellow-Alan-AneethJegaraj-Proposal.pdf
 presentations:
 ---

--- a/pages/fellows/AneeshHeintz.md
+++ b/pages/fellows/AneeshHeintz.md
@@ -31,8 +31,9 @@ active: green
 
 
 
-start_date: 2020-06-01
-end_date: 2020-09-30
+dates:
+  start: 2020-06-01
+  end: 2020-09-30
 
 
 

--- a/pages/fellows/AneeshHeintz.md
+++ b/pages/fellows/AneeshHeintz.md
@@ -30,9 +30,9 @@ active: green
 
 
 
-dates:
-    - start_date: 2020-06-01
-      end_date: 2020-09-30
+
+start_date: 2020-06-01
+end_date: 2020-09-30
 
 
 

--- a/pages/fellows/AneeshHeintz.md
+++ b/pages/fellows/AneeshHeintz.md
@@ -30,7 +30,9 @@ active: green
 
 
 
-dates: June - September 2020
+dates:
+    - start_date: 2020-06-01
+      end_date: 2020-09-30
 
 
 

--- a/pages/fellows/BoZheng.md
+++ b/pages/fellows/BoZheng.md
@@ -7,7 +7,9 @@ title: Bo Zheng - IRIS-HEP Fellow
 fellow-name: Bo Zheng
 shortname: Bo
 project_title: pyhf Hardware Acceleration Benchmarking with GPUs and TPUs
-dates: June - August 2020
+dates:
+    - start_date: 2020-06-01
+      end_date: 2020-08-31
 photo: /assets/images/team/Bo-Zheng.jpg
 institution: Rice University
 website: https://github.com/coolalexzb

--- a/pages/fellows/BoZheng.md
+++ b/pages/fellows/BoZheng.md
@@ -7,9 +7,8 @@ title: Bo Zheng - IRIS-HEP Fellow
 fellow-name: Bo Zheng
 shortname: Bo
 project_title: pyhf Hardware Acceleration Benchmarking with GPUs and TPUs
-dates:
-    - start_date: 2020-06-01
-      end_date: 2020-08-31
+start_date: 2020-06-01
+end_date: 2020-08-31
 photo: /assets/images/team/Bo-Zheng.jpg
 institution: Rice University
 website: https://github.com/coolalexzb

--- a/pages/fellows/BoZheng.md
+++ b/pages/fellows/BoZheng.md
@@ -7,8 +7,9 @@ title: Bo Zheng - IRIS-HEP Fellow
 fellow-name: Bo Zheng
 shortname: Bo
 project_title: pyhf Hardware Acceleration Benchmarking with GPUs and TPUs
-start_date: 2020-06-01
-end_date: 2020-08-31
+dates:
+  start: 2020-06-01
+  end: 2020-08-31
 photo: /assets/images/team/Bo-Zheng.jpg
 institution: Rice University
 website: https://github.com/coolalexzb

--- a/pages/fellows/ErikWallin.md
+++ b/pages/fellows/ErikWallin.md
@@ -7,9 +7,8 @@ title: Erik Wallin - IRIS-HEP Fellow
 fellow-name: Erik Wallin
 shortname: ewallin
 project_tile: zfp Compression for HEP Data
-dates:
-    - start_date: 2020-06-01
-      end_date: 2020-08-31
+start_date: 2020-06-01
+end_date: 2020-08-31
 photo: /assets/images/team/Erik-Wallin.jpg
 institution: Lund University
 website:

--- a/pages/fellows/ErikWallin.md
+++ b/pages/fellows/ErikWallin.md
@@ -7,7 +7,9 @@ title: Erik Wallin - IRIS-HEP Fellow
 fellow-name: Erik Wallin
 shortname: ewallin
 project_tile: zfp Compression for HEP Data
-dates: June - August 2020
+dates:
+    - start_date: 2020-06-01
+      end_date: 2020-08-31
 photo: /assets/images/team/Erik-Wallin.jpg
 institution: Lund University
 website:

--- a/pages/fellows/ErikWallin.md
+++ b/pages/fellows/ErikWallin.md
@@ -7,8 +7,9 @@ title: Erik Wallin - IRIS-HEP Fellow
 fellow-name: Erik Wallin
 shortname: ewallin
 project_tile: zfp Compression for HEP Data
-start_date: 2020-06-01
-end_date: 2020-08-31
+dates:
+  start: 2020-06-01
+  end: 2020-08-31
 photo: /assets/images/team/Erik-Wallin.jpg
 institution: Lund University
 website:

--- a/pages/fellows/JayjeetChakraborty.md
+++ b/pages/fellows/JayjeetChakraborty.md
@@ -5,9 +5,8 @@ pagetype: fellow
 fellow-name: Jayjeet Chakraborty
 shortname: jayjeet
 title: Jayjeet Chakraborty - IRIS-HEP Fellow
-dates:
-    - start_date: 2020-06-01
-      end_date: 2020-09-30
+start_date: 2020-06-01
+end_date: 2020-09-30
 photo: /assets/images/team/Jayjeet-Chakraborty.png
 institution: National Institute Of Technology, Durgapur
 website: https://github.com/JayjeetAtGithub/

--- a/pages/fellows/JayjeetChakraborty.md
+++ b/pages/fellows/JayjeetChakraborty.md
@@ -4,8 +4,10 @@ layout: fellow
 pagetype: fellow
 fellow-name: Jayjeet Chakraborty
 shortname: jayjeet
-title: Jayjeet Chakraborty - IRIS-HEP Fellow 
-dates: Jun-Sep 2020
+title: Jayjeet Chakraborty - IRIS-HEP Fellow
+dates:
+    - start_date: 2020-06-01
+      end_date: 2020-09-30
 photo: /assets/images/team/Jayjeet-Chakraborty.png
 institution: National Institute Of Technology, Durgapur
 website: https://github.com/JayjeetAtGithub/
@@ -14,13 +16,13 @@ project_title: Reproducible, large-scale SkyhookDM experiments
 project_goal: >
   SkyhookDM injects programmable data management and data storage capabilities directly
   in the storage layer of distributed object databases such as Ceph. SkyhookDM utilizes and extends
-  the Ceph distributed object storage platform with customized C++ object classes that enable 
-  database operations such as SELECT, PROJECT, AGGREGATE to be offloaded directly into the 
-  object storage layer, allowing applications to efficiently query multi-dimensional 
-  arrays. Compiling ceph along with Skyhook and running benchmark tests consists of a number of 
-  steps and can become irreproducible at times. The aim of this project is to implement a 
-  reproducible workflow with Popper to automate large-scale tests on different cloud 
-  infrastructure like GCP, Cloudlab and Kubernetes clusters and benchmark SkyhookDM at the 10's of terabyte 
+  the Ceph distributed object storage platform with customized C++ object classes that enable
+  database operations such as SELECT, PROJECT, AGGREGATE to be offloaded directly into the
+  object storage layer, allowing applications to efficiently query multi-dimensional
+  arrays. Compiling ceph along with Skyhook and running benchmark tests consists of a number of
+  steps and can become irreproducible at times. The aim of this project is to implement a
+  reproducible workflow with Popper to automate large-scale tests on different cloud
+  infrastructure like GCP, Cloudlab and Kubernetes clusters and benchmark SkyhookDM at the 10's of terabyte
   scale over the various supported data formats.
 
 proposal: /assets/pdf/Fellow-Jayjeet-Chakraborty-Proposal.pdf
@@ -31,4 +33,3 @@ mentors:
 presentations:
 
 ---
-

--- a/pages/fellows/JayjeetChakraborty.md
+++ b/pages/fellows/JayjeetChakraborty.md
@@ -5,8 +5,9 @@ pagetype: fellow
 fellow-name: Jayjeet Chakraborty
 shortname: jayjeet
 title: Jayjeet Chakraborty - IRIS-HEP Fellow
-start_date: 2020-06-01
-end_date: 2020-09-30
+dates:
+  start: 2020-06-01
+  end: 2020-09-30
 photo: /assets/images/team/Jayjeet-Chakraborty.png
 institution: National Institute Of Technology, Durgapur
 website: https://github.com/JayjeetAtGithub/

--- a/pages/fellows/PeterChatain.md
+++ b/pages/fellows/PeterChatain.md
@@ -4,8 +4,10 @@ layout: fellow
 pagetype: fellow
 fellow-name: Peter Chatain
 shortname: peter
-title: Peter Chatain - IRIS-HEP Fellow 
-dates: Jun-Sep 2020
+title: Peter Chatain - IRIS-HEP Fellow
+dates:
+    - start_date: 2020-06-01
+      end_date: 2020-09-30
 photo: /assets/images/team/Peter-Chatain.jpeg
 institution: Stanford University
 website: https://github.com/Pchatain

--- a/pages/fellows/PeterChatain.md
+++ b/pages/fellows/PeterChatain.md
@@ -5,8 +5,9 @@ pagetype: fellow
 fellow-name: Peter Chatain
 shortname: peter
 title: Peter Chatain - IRIS-HEP Fellow
-start_date: 2020-06-01
-end_date: 2020-09-30
+dates:
+  start: 2020-06-01
+  end: 2020-09-30
 photo: /assets/images/team/Peter-Chatain.jpeg
 institution: Stanford University
 website: https://github.com/Pchatain

--- a/pages/fellows/PeterChatain.md
+++ b/pages/fellows/PeterChatain.md
@@ -5,9 +5,8 @@ pagetype: fellow
 fellow-name: Peter Chatain
 shortname: peter
 title: Peter Chatain - IRIS-HEP Fellow
-dates:
-    - start_date: 2020-06-01
-      end_date: 2020-09-30
+start_date: 2020-06-01
+end_date: 2020-09-30
 photo: /assets/images/team/Peter-Chatain.jpeg
 institution: Stanford University
 website: https://github.com/Pchatain

--- a/pages/fellows/PratyushDas.md
+++ b/pages/fellows/PratyushDas.md
@@ -7,8 +7,10 @@ title: Reik Das - IRIS-HEP Fellow
 fellow-name: Pratyush (Reik) Das
 shortname: reikdas
 dates:
-  - Jun-Sep 2019
-  - Jun-Aug 2020
+  - start_date: 2020-06-01
+    end_date: 2020-09-01
+  - start_date: 2019-06-01
+    end_date: 2019-09-01
 photo: /assets/images/team/Pratyush-Das.jpg
 institution: Institute of Engineering & Management (Kolkata)
 website: https://reikdas.github.io/
@@ -30,11 +32,11 @@ projects:
 - project_title: Adding ability to write TTrees to uproot
   project_goal: >
     As an IRIS-HEP undergraduate fellow, I will be working on uproot, a
-    software for reading and writing ROOT files in Python with the help of 
-    the Numpy library. Unlike the standard C++ ROOT implementation, uproot 
-    is strictly an I/O library, intended to stream data into other third 
-    party libraries in Python. Other ROOT file readers in Python like PyROOT 
-    and root_numpy rely on the C++ ROOT implementation but uproot does not. 
+    software for reading and writing ROOT files in Python with the help of
+    the Numpy library. Unlike the standard C++ ROOT implementation, uproot
+    is strictly an I/O library, intended to stream data into other third
+    party libraries in Python. Other ROOT file readers in Python like PyROOT
+    and root_numpy rely on the C++ ROOT implementation but uproot does not.
     Instead, it uses Numpy calls to rapidly cast data blocks in the ROOT file as Numpy arrays.
   mentors:
   - jpivarski

--- a/pages/fellows/PratyushDas.md
+++ b/pages/fellows/PratyushDas.md
@@ -7,10 +7,10 @@ title: Reik Das - IRIS-HEP Fellow
 fellow-name: Pratyush (Reik) Das
 shortname: reikdas
 dates:
-  - start_date: 2020-06-01
-    end_date: 2020-09-01
-  - start_date: 2019-06-01
-    end_date: 2019-09-01
+- start_date: 2020-06-01
+  end_date: 2020-09-01
+- start_date: 2019-06-01
+  end_date: 2019-09-01
 photo: /assets/images/team/Pratyush-Das.jpg
 institution: Institute of Engineering & Management (Kolkata)
 website: https://reikdas.github.io/

--- a/pages/fellows/PratyushDas.md
+++ b/pages/fellows/PratyushDas.md
@@ -7,10 +7,10 @@ title: Reik Das - IRIS-HEP Fellow
 fellow-name: Pratyush (Reik) Das
 shortname: reikdas
 dates:
-- start_date: 2020-06-01
-  end_date: 2020-09-01
-- start_date: 2019-06-01
-  end_date: 2019-09-01
+- start: 2020-06-01
+  end: 2020-09-01
+- start: 2019-06-01
+  end: 2019-09-01
 photo: /assets/images/team/Pratyush-Das.jpg
 institution: Institute of Engineering & Management (Kolkata)
 website: https://reikdas.github.io/

--- a/pages/fellows/RaghavKansal.md
+++ b/pages/fellows/RaghavKansal.md
@@ -4,30 +4,31 @@ layout: fellow
 pagetype: fellow
 fellow-name: Raghav Kansal
 shortname: raghsthebest
-title: Raghav Kansal - IRIS-HEP Fellow 
-dates: Jun-Aug 2019
+title: Raghav Kansal - IRIS-HEP Fellow
+dates:
+    - start_date: 2019-06-01
+      end_date: 2019-08-31
 photo: /assets/images/team/Raghav-Kansal.jpg
 institution: University of California, San Diego
 website: https://github.com/raghsthebest/
 e-mail: NoEmailYet
 
 project_goal: >
-  High granular calorimeters will be the biggest novelty of the CMS Phase II upgrade and, in general, 
-  for the next generation of collider experiments. This kind of detectors offer more opportunities 
-  but much more complexity for ordinary tasks such as detector simulation. In order to stay within 
-  the technical budgets (e.g. computing time) and satisfy the demand for large simulation samples, 
-  experiments will have to work on faster and more accurate simulation techniques. Deep Learning, 
-  and in particular generative models, offer an interesting possibility to speed up the simulation 
-  technique. Moreover, Deep Learning solutions are particularly suitable for HGCAL, given the pixelated 
-  nature of the problem. This project aims to adapt existing work about GAN for fast simulation to the 
-  irregular geometry of this detector, using graph networks as a way to learn a sparse representation 
+  High granular calorimeters will be the biggest novelty of the CMS Phase II upgrade and, in general,
+  for the next generation of collider experiments. This kind of detectors offer more opportunities
+  but much more complexity for ordinary tasks such as detector simulation. In order to stay within
+  the technical budgets (e.g. computing time) and satisfy the demand for large simulation samples,
+  experiments will have to work on faster and more accurate simulation techniques. Deep Learning,
+  and in particular generative models, offer an interesting possibility to speed up the simulation
+  technique. Moreover, Deep Learning solutions are particularly suitable for HGCAL, given the pixelated
+  nature of the problem. This project aims to adapt existing work about GAN for fast simulation to the
+  irregular geometry of this detector, using graph networks as a way to learn a sparse representation
   of the hit distribution and embed it in a regular array, where traditional computing vision techniques can be used.
 
-proposal: 
+proposal:
 active: green
 mentors:
   - Maurizio Pierini (CERN)
 presentations:
 
 ---
-  

--- a/pages/fellows/RaghavKansal.md
+++ b/pages/fellows/RaghavKansal.md
@@ -5,9 +5,8 @@ pagetype: fellow
 fellow-name: Raghav Kansal
 shortname: raghsthebest
 title: Raghav Kansal - IRIS-HEP Fellow
-dates:
-    - start_date: 2019-06-01
-      end_date: 2019-08-31
+start_date: 2019-06-01
+end_date: 2019-08-31
 photo: /assets/images/team/Raghav-Kansal.jpg
 institution: University of California, San Diego
 website: https://github.com/raghsthebest/

--- a/pages/fellows/RaghavKansal.md
+++ b/pages/fellows/RaghavKansal.md
@@ -5,8 +5,9 @@ pagetype: fellow
 fellow-name: Raghav Kansal
 shortname: raghsthebest
 title: Raghav Kansal - IRIS-HEP Fellow
-start_date: 2019-06-01
-end_date: 2019-08-31
+dates:
+  start: 2019-06-01
+  end: 2019-08-31
 photo: /assets/images/team/Raghav-Kansal.jpg
 institution: University of California, San Diego
 website: https://github.com/raghsthebest/

--- a/pages/fellows/SeanCondon.md
+++ b/pages/fellows/SeanCondon.md
@@ -7,9 +7,8 @@ title: Sean Condon - IRIS-HEP Fellow
 fellow-name: Sean Condon
 shortname: Sean
 project_title: Developing selection algorithms to reduce output data rate from the Large Hadron Collider
-dates:
-    - start_date: 2020-06-01
-      end_date: 2020-08-31
+start_date: 2020-06-01
+end_date: 2020-08-31
 photo: /assets/images/team/Sean-Condon.jpg
 institution: Massachusetts Institute of Technology
 website: https://github.com/seancondon99

--- a/pages/fellows/SeanCondon.md
+++ b/pages/fellows/SeanCondon.md
@@ -7,7 +7,9 @@ title: Sean Condon - IRIS-HEP Fellow
 fellow-name: Sean Condon
 shortname: Sean
 project_title: Developing selection algorithms to reduce output data rate from the Large Hadron Collider
-dates: June - August 2020
+dates:
+    - start_date: 2020-06-01
+      end_date: 2020-08-31
 photo: /assets/images/team/Sean-Condon.jpg
 institution: Massachusetts Institute of Technology
 website: https://github.com/seancondon99

--- a/pages/fellows/SeanCondon.md
+++ b/pages/fellows/SeanCondon.md
@@ -7,8 +7,9 @@ title: Sean Condon - IRIS-HEP Fellow
 fellow-name: Sean Condon
 shortname: Sean
 project_title: Developing selection algorithms to reduce output data rate from the Large Hadron Collider
-start_date: 2020-06-01
-end_date: 2020-08-31
+dates:
+  start: 2020-06-01
+  end: 2020-08-31
 photo: /assets/images/team/Sean-Condon.jpg
 institution: Massachusetts Institute of Technology
 website: https://github.com/seancondon99

--- a/pages/fellows/SuhaibShaikh.md
+++ b/pages/fellows/SuhaibShaikh.md
@@ -6,8 +6,9 @@ permalink: /fellows/SuhaibShaikh.html
 fellow-name: Suhaib Shaikh
 title: Suhaib Shaikh - IRIS-HEP Fellow
 active: green
-start_date: 2020-07-01
-end_date: 2020-09-30
+dates:
+  start: 2020-07-01
+  end: 2020-09-30
 photo: /assets/images/team/SuhaibShaikhPicture.jpg
 institution: University of Nebraska - Lincoln
 website:

--- a/pages/fellows/SuhaibShaikh.md
+++ b/pages/fellows/SuhaibShaikh.md
@@ -6,11 +6,13 @@ permalink: /fellows/SuhaibShaikh.html
 fellow-name: Suhaib Shaikh
 title: Suhaib Shaikh - IRIS-HEP Fellow
 active: green
-dates: Jul-Sep 2020
+dates:
+    - start_date: 2020-07-01
+      end_date: 2020-09-30
 photo: /assets/images/team/SuhaibShaikhPicture.jpg
 institution: University of Nebraska - Lincoln
 website:
-e-mail: 
+e-mail:
 project_title: Proactive Site Monitoring
 project_goal: "Researchers using the OSG rely on the stability of resources in order to accomplish their science.  The OSG’s GRACC accounting service collects usage information for all sites contributing to and all jobs that run on the OSG.  The accounting service is a large source of information on the OSG.  The accounting data is stored within an ElasticSearch database at UNL.  Monitoring using this accounting service exists that will alert when a site completely fails, but there is no alerting on a decrease in functionality of a site. My project would be to develop proactive site monitoring to alert on site issues detected from the GRACC accounting system.  The alert would run periodically on OSG resources."
 mentors:

--- a/pages/fellows/SuhaibShaikh.md
+++ b/pages/fellows/SuhaibShaikh.md
@@ -6,9 +6,8 @@ permalink: /fellows/SuhaibShaikh.html
 fellow-name: Suhaib Shaikh
 title: Suhaib Shaikh - IRIS-HEP Fellow
 active: green
-dates:
-    - start_date: 2020-07-01
-      end_date: 2020-09-30
+start_date: 2020-07-01
+end_date: 2020-09-30
 photo: /assets/images/team/SuhaibShaikhPicture.jpg
 institution: University of Nebraska - Lincoln
 website:

--- a/pages/fellows/ThomasShearer.md
+++ b/pages/fellows/ThomasShearer.md
@@ -7,8 +7,9 @@ title: Thomas Shearer - IRIS-HEP Fellow
 fellow-name: Thomas Shearer
 shortname: Tommy
 project_title: Improving the User Interface to OSG-LHC Network Metrics
-start_date: 2020-05-01
-end_date: 2020-08-31
+dates:
+  start: 2020-05-01
+  end: 2020-08-31
 photo: /assets/images/team/Thomas-Shearer.jpg
 institution: University of Michigan - Ann Arbor
 website: https://github.com/shearert

--- a/pages/fellows/ThomasShearer.md
+++ b/pages/fellows/ThomasShearer.md
@@ -7,9 +7,8 @@ title: Thomas Shearer - IRIS-HEP Fellow
 fellow-name: Thomas Shearer
 shortname: Tommy
 project_title: Improving the User Interface to OSG-LHC Network Metrics
-dates:
-    - start_date: 2020-05-01
-      end_date: 2020-08-31
+start_date: 2020-05-01
+end_date: 2020-08-31
 photo: /assets/images/team/Thomas-Shearer.jpg
 institution: University of Michigan - Ann Arbor
 website: https://github.com/shearert

--- a/pages/fellows/ThomasShearer.md
+++ b/pages/fellows/ThomasShearer.md
@@ -7,7 +7,9 @@ title: Thomas Shearer - IRIS-HEP Fellow
 fellow-name: Thomas Shearer
 shortname: Tommy
 project_title: Improving the User Interface to OSG-LHC Network Metrics
-dates: May - August 2020
+dates:
+    - start_date: 2020-05-01
+      end_date: 2020-08-31
 photo: /assets/images/team/Thomas-Shearer.jpg
 institution: University of Michigan - Ann Arbor
 website: https://github.com/shearert

--- a/pages/fellows/VesalRazavimaleki.md
+++ b/pages/fellows/VesalRazavimaleki.md
@@ -30,8 +30,9 @@ active: green
 
 
 
-start_date: 2020-07-01
-end_date: 2020-09-30
+dates:
+  start: 2020-07-01
+  end: 2020-09-30
 
 
 

--- a/pages/fellows/VesalRazavimaleki.md
+++ b/pages/fellows/VesalRazavimaleki.md
@@ -30,7 +30,9 @@ active: green
 
 
 
-dates: July - September 2020
+dates:
+    - start_date: 2020-07-01
+      end_date: 2020-09-30
 
 
 

--- a/pages/fellows/VesalRazavimaleki.md
+++ b/pages/fellows/VesalRazavimaleki.md
@@ -1,77 +1,23 @@
 ---
-
-
-
 layout: fellow
-
-
-
 pagetype: fellow
-
-
-
 shortname: vesal-rm
-
-
-
 permalink: /fellows/VesalRazavimaleki.html
-
-
-
 fellow-name: Vesal Razavimaleki
-
-
-
 title: Vesal Razavimaleki - IRIS-HEP Fellow
-
-
-
 active: green
-
-
-
 dates:
   start: 2020-07-01
   end: 2020-09-30
-
-
-
 photo: /assets/images/team/Vesal-Razavimaleki.png
-
-
-
 institution: University of California, San Diego
-
-
-
 website:
-
-
-
 e-mail: vrazavim@ucsd.edu
-
 project_title: Adapting GNN Tracking for FPGAs with hls4ml
-
-
 project_goal: >
-
     Graph neural networks (GNNs) have demonstrated promise for pattern recognition problems like particle tracking. To meet the demands of the planned HL-LHC, there has been increased interest in accelerating large machine learning (ML) models with FPGA coprocessors for integration into the L1 trigger. Deployment of neural networks on FPGAs has been studied with the hls4ml compiler package which uses high-level synthesis to convert ML models to FPGA firmware. This project proposes to expand the hls4ml toolkit to support GNNs for particle tracking, allowing them to be implemented in FPGA coprocessor applications possibly including the L1 trigger.
-
-
 mentors:
-
-
-
   - Javier Duarte (University of California, San Diego)
-
-
-
 proposal: /assets/pdf/VesalRazavimaleki_Proposal.pdf
-
-
-
 presentations:
-
-
-
 ---

--- a/pages/fellows/VesalRazavimaleki.md
+++ b/pages/fellows/VesalRazavimaleki.md
@@ -30,9 +30,8 @@ active: green
 
 
 
-dates:
-    - start_date: 2020-07-01
-      end_date: 2020-09-30
+start_date: 2020-07-01
+end_date: 2020-09-30
 
 
 

--- a/pages/fellows/XiongfengSong.md
+++ b/pages/fellows/XiongfengSong.md
@@ -7,8 +7,9 @@ title: Xiongfeng Song - IRIS-HEP Fellow
 fellow-name: Xiongfeng Song
 shortname: Xiongfeng
 project_title: Implement Skyhook row index filter operation, Awkward list in-storage operations and Coffea processor/executor
-start_date: 2020-06-01
-end_date: 2020-08-31
+dates:
+  start: 2020-06-01
+  end: 2020-08-31
 photo: /assets/images/team/Xiongfeng_Song.JPG
 institution: Rice University
 website: https://github.com/kingwind123

--- a/pages/fellows/XiongfengSong.md
+++ b/pages/fellows/XiongfengSong.md
@@ -7,7 +7,9 @@ title: Xiongfeng Song - IRIS-HEP Fellow
 fellow-name: Xiongfeng Song
 shortname: Xiongfeng
 project_title: Implement Skyhook row index filter operation, Awkward list in-storage operations and Coffea processor/executor
-dates: June - August 2020
+dates:
+    - start_date: 2020-06-01
+      end_date: 2020-08-31
 photo: /assets/images/team/Xiongfeng_Song.JPG
 institution: Rice University
 website: https://github.com/kingwind123

--- a/pages/fellows/XiongfengSong.md
+++ b/pages/fellows/XiongfengSong.md
@@ -7,9 +7,8 @@ title: Xiongfeng Song - IRIS-HEP Fellow
 fellow-name: Xiongfeng Song
 shortname: Xiongfeng
 project_title: Implement Skyhook row index filter operation, Awkward list in-storage operations and Coffea processor/executor
-dates:
-    - start_date: 2020-06-01
-      end_date: 2020-08-31
+start_date: 2020-06-01
+end_date: 2020-08-31
 photo: /assets/images/team/Xiongfeng_Song.JPG
 institution: Rice University
 website: https://github.com/kingwind123

--- a/pages/fellows/dwliu.md
+++ b/pages/fellows/dwliu.md
@@ -7,8 +7,9 @@ title: David Liu - IRIS-HEP Fellow
 fellow-name: David Liu
 shortname: dwliu
 project_title: Verification of the Fidelity of ServiceX Data Set Extractions Using Python and C++
-start_date: 2020-05-01
-end_date: 2020-09-30
+dates:
+  start: 2020-05-01
+  end: 2020-09-30
 photo: /assets/images/team/David-Liu.jpg
 institution: University of Washington
 website:

--- a/pages/fellows/dwliu.md
+++ b/pages/fellows/dwliu.md
@@ -7,7 +7,9 @@ title: David Liu - IRIS-HEP Fellow
 fellow-name: David Liu
 shortname: dwliu
 project_title: Verification of the Fidelity of ServiceX Data Set Extractions Using Python and C++
-dates: May - September 2020
+dates:
+    - start_date: 2020-05-01
+      end_date: 2020-09-30
 photo: /assets/images/team/David-Liu.jpg
 institution: University of Washington
 website:
@@ -15,12 +17,12 @@ e-mail: dwliu@uw.edu
 mentors:
   - Gordon Watts (University of Washington)
 project_goal: >
-  ServiceX provides delivery of any requested portion of high energy physics data sets for analysis. 
-  The current version of the system has two transformers, which function for Python and C++. 
-  In this work, we will verify that both transformers produce the same outputs when queried. 
+  ServiceX provides delivery of any requested portion of high energy physics data sets for analysis.
+  The current version of the system has two transformers, which function for Python and C++.
+  In this work, we will verify that both transformers produce the same outputs when queried.
   We will also develop multiple tests that can be rapidly run against ServiceX to test the whole system's
-  functionality from beginning to end. This allows developers to rapidly find and fix bugs and test the 
-  software's stress limits. 
+  functionality from beginning to end. This allows developers to rapidly find and fix bugs and test the
+  software's stress limits.
 proposal: /assets/pdf/dwliu_proposal.pdf
 presentations:
 ---

--- a/pages/fellows/dwliu.md
+++ b/pages/fellows/dwliu.md
@@ -7,9 +7,8 @@ title: David Liu - IRIS-HEP Fellow
 fellow-name: David Liu
 shortname: dwliu
 project_title: Verification of the Fidelity of ServiceX Data Set Extractions Using Python and C++
-dates:
-    - start_date: 2020-05-01
-      end_date: 2020-09-30
+start_date: 2020-05-01
+end_date: 2020-09-30
 photo: /assets/images/team/David-Liu.jpg
 institution: University of Washington
 website:

--- a/pages/fellows/rfarkas.md
+++ b/pages/fellows/rfarkas.md
@@ -6,10 +6,12 @@ permalink: /fellows/rfarkas.html
 fellow-name: Ralf Farkas
 title: Ralf Farkas - IRIS-HEP Fellow
 active: green
-dates: Jan-Mar 2020
+dates:
+    - start_date: 2020-01-01
+      end_date: 2020-03-31
 photo: /assets/images/team/rfarkas.jpg
 institution: Universität Bonn (Germany)
-website: 
+website:
 e-mail: ralf.farkas@uni-bonn.de
 project_title: Combinatorial Kalman Filter for the ACTS tracking software
 project_goal: >

--- a/pages/fellows/rfarkas.md
+++ b/pages/fellows/rfarkas.md
@@ -6,8 +6,9 @@ permalink: /fellows/rfarkas.html
 fellow-name: Ralf Farkas
 title: Ralf Farkas - IRIS-HEP Fellow
 active: green
-start_date: 2020-01-01
-end_date: 2020-03-31
+dates:
+  start: 2020-01-01
+  end: 2020-03-31
 photo: /assets/images/team/rfarkas.jpg
 institution: Universität Bonn (Germany)
 website:

--- a/pages/fellows/rfarkas.md
+++ b/pages/fellows/rfarkas.md
@@ -6,9 +6,8 @@ permalink: /fellows/rfarkas.html
 fellow-name: Ralf Farkas
 title: Ralf Farkas - IRIS-HEP Fellow
 active: green
-dates:
-    - start_date: 2020-01-01
-      end_date: 2020-03-31
+start_date: 2020-01-01
+end_date: 2020-03-31
 photo: /assets/images/team/rfarkas.jpg
 institution: Universität Bonn (Germany)
 website:

--- a/pages/fellows/toyamaza.md
+++ b/pages/fellows/toyamaza.md
@@ -6,8 +6,9 @@ permalink: /fellows/TomohiroYamazaki.html
 fellow-name: Tomohiro Yamazaki
 title: Tomohiro Yamazaki - IRIS-HEP Fellow
 active: green
-start_date: 2020-07-01
-end_date: 2020-09-30
+dates:
+  start: 2020-07-01
+  end: 2020-09-30
 photo: /assets/images/team/Tomohiro-Yamazaki.jpeg
 institution: University of California, Berkeley
 website:

--- a/pages/fellows/toyamaza.md
+++ b/pages/fellows/toyamaza.md
@@ -6,9 +6,8 @@ permalink: /fellows/TomohiroYamazaki.html
 fellow-name: Tomohiro Yamazaki
 title: Tomohiro Yamazaki - IRIS-HEP Fellow
 active: green
-dates:
-    - start_date: 2020-07-01
-      end_date: 2020-09-30
+start_date: 2020-07-01
+end_date: 2020-09-30
 photo: /assets/images/team/Tomohiro-Yamazaki.jpeg
 institution: University of California, Berkeley
 website:

--- a/pages/fellows/toyamaza.md
+++ b/pages/fellows/toyamaza.md
@@ -6,7 +6,9 @@ permalink: /fellows/TomohiroYamazaki.html
 fellow-name: Tomohiro Yamazaki
 title: Tomohiro Yamazaki - IRIS-HEP Fellow
 active: green
-dates: Jul-Sep 2020
+dates:
+    - start_date: 2020-07-01
+      end_date: 2020-09-30
 photo: /assets/images/team/Tomohiro-Yamazaki.jpeg
 institution: University of California, Berkeley
 website:

--- a/pages/fellows/trivm963.md
+++ b/pages/fellows/trivm963.md
@@ -30,8 +30,9 @@ active: green
 
 
 
-dates: May-August 2020
-
+dates:
+    - start_date: 2020-05-01
+      end_date: 2020-08-31
 
 
 photo: /assets/images/team/trivm963.jpg
@@ -42,7 +43,7 @@ institution: University of Michigan, Ann Arbor
 
 
 
-website: 
+website:
 
 
 
@@ -58,7 +59,7 @@ project_goal: >
 
 
 
-    The LHC-OSG Network Monitoring Area gathers and makes accessible various network metrics related to network performance in order to debug complex network  problems more effectively. This is a unique dataset with continuous measurements of thousands of research and education network paths. It can be challenging to identify network problems and, more importantly, their location. The goal of my project is to create a network topology analysis web interface to aid with debugging and localizing network performance issues. This will be mostly focussed on path analysis: finding commonalities between paths, finding paths that contain a given address, correlating paths with other network metrics, and the degree of path symmetry. 
+    The LHC-OSG Network Monitoring Area gathers and makes accessible various network metrics related to network performance in order to debug complex network  problems more effectively. This is a unique dataset with continuous measurements of thousands of research and education network paths. It can be challenging to identify network problems and, more importantly, their location. The goal of my project is to create a network topology analysis web interface to aid with debugging and localizing network performance issues. This will be mostly focussed on path analysis: finding commonalities between paths, finding paths that contain a given address, correlating paths with other network metrics, and the degree of path symmetry.
 
 
 
@@ -79,4 +80,3 @@ presentations:
 
 
 ---
-

--- a/pages/fellows/trivm963.md
+++ b/pages/fellows/trivm963.md
@@ -1,82 +1,23 @@
 ---
-
-
-
 layout: fellow
-
-
-
 pagetype: fellow
-
-
-
 shortname: trivm963
-
-
-
 permalink: /fellows/trivm963.html
-
-
-
 fellow-name: Manjari Trivedi
-
-
-
 title: Manjari Trivedi - IRIS-HEP Fellow
-
-
-
 active: green
-
-
-
 dates:
   start: 2020-05-01
   end: 2020-08-31
-
-
 photo: /assets/images/team/trivm963.jpg
-
-
-
 institution: University of Michigan, Ann Arbor
-
-
-
 website:
-
-
-
 e-mail: trivm@umich.edu
-
-
-
 project_title: Creating a User Interface to Analyse Network Topology
-
-
-
 project_goal: >
-
-
-
     The LHC-OSG Network Monitoring Area gathers and makes accessible various network metrics related to network performance in order to debug complex network  problems more effectively. This is a unique dataset with continuous measurements of thousands of research and education network paths. It can be challenging to identify network problems and, more importantly, their location. The goal of my project is to create a network topology analysis web interface to aid with debugging and localizing network performance issues. This will be mostly focussed on path analysis: finding commonalities between paths, finding paths that contain a given address, correlating paths with other network metrics, and the degree of path symmetry.
-
-
-
 mentors:
-
-
-
   - Shawn McKee (University of Michigan, Ann Arbor)
-
-
-
 proposal: /assets/pdf/trivm963_proposal.pdf
-
-
-
 presentations:
-
-
-
 ---

--- a/pages/fellows/trivm963.md
+++ b/pages/fellows/trivm963.md
@@ -30,8 +30,9 @@ active: green
 
 
 
-start_date: 2020-05-01
-end_date: 2020-08-31
+dates:
+  start: 2020-05-01
+  end: 2020-08-31
 
 
 photo: /assets/images/team/trivm963.jpg

--- a/pages/fellows/trivm963.md
+++ b/pages/fellows/trivm963.md
@@ -30,9 +30,8 @@ active: green
 
 
 
-dates:
-    - start_date: 2020-05-01
-      end_date: 2020-08-31
+start_date: 2020-05-01
+end_date: 2020-08-31
 
 
 photo: /assets/images/team/trivm963.jpg

--- a/pages/fellows/vovechkin.md
+++ b/pages/fellows/vovechkin.md
@@ -6,8 +6,9 @@ permalink: /fellows/vovechkin.html
 fellow-name: Vladimir Ovechkin
 title: Vladimir Ovechkin - IRIS-HEP Fellow
 active: green
-start_date: 2020-06-01
-end_date: 2020-08-31
+dates:
+  start: 2020-06-01
+  end: 2020-08-31
 photo: /assets/images/team/Vladimir-Ovechkin.jpg
 institution: University of Washington, Seattle
 website: http://vladov3000.com/

--- a/pages/fellows/vovechkin.md
+++ b/pages/fellows/vovechkin.md
@@ -6,7 +6,9 @@ permalink: /fellows/vovechkin.html
 fellow-name: Vladimir Ovechkin
 title: Vladimir Ovechkin - IRIS-HEP Fellow
 active: green
-dates: June-August 2020
+dates:
+    - start_date: 2020-06-01
+      end_date: 2020-08-31
 photo: /assets/images/team/Vladimir-Ovechkin.jpg
 institution: University of Washington, Seattle
 website: http://vladov3000.com/

--- a/pages/fellows/vovechkin.md
+++ b/pages/fellows/vovechkin.md
@@ -6,9 +6,8 @@ permalink: /fellows/vovechkin.html
 fellow-name: Vladimir Ovechkin
 title: Vladimir Ovechkin - IRIS-HEP Fellow
 active: green
-dates:
-    - start_date: 2020-06-01
-      end_date: 2020-08-31
+start_date: 2020-06-01
+end_date: 2020-08-31
 photo: /assets/images/team/Vladimir-Ovechkin.jpg
 institution: University of Washington, Seattle
 website: http://vladov3000.com/

--- a/pages/former-fellows.md
+++ b/pages/former-fellows.md
@@ -11,11 +11,11 @@ title: IRIS/HEP Former Fellows
     {% assign current_fellows_start = '2020-05-01' | date:'%F' %}
     {% assign sorted = site.pages | sort_natural: 'title' %}
     {% for mypage in sorted %}
-      {%- if mypage.dates.first -%}
+      {%- if mypage.dates.first.start -%}
         {% assign sorted_dates = mypage.dates | reverse %}
-        {% assign page_start_date = sorted_dates.first.start_date | date: '%F' %}
+        {% assign page_start_date = sorted_dates.first.start | date: '%F' %}
       {%- else -%}
-        {% assign page_start_date = mypage.start_date | date: '%F' %}
+        {% assign page_start_date = mypage.dates.start | date: '%F' %}
       {%- endif -%}
       {% if mypage.pagetype == 'fellow' and page_start_date < current_fellows_start %}
          {% assign person = mypage %}
@@ -29,12 +29,12 @@ title: IRIS/HEP Former Fellows
               </div>
               <div class="card-text mt-auto"><i>
 
-              {%- if person.dates.first -%}
-                {% for dates in person.dates %}
-                  {{ dates.start_date | date: "%b" }} - {{ dates.end_date | date: "%b %Y" }}<br>
+              {%- if person.dates.first.start -%}
+                {% for date in person.dates %}
+                  {{ date.start | date: "%b" }} - {{ date.end | date: "%b %Y" }}<br>
                 {% endfor %}
                {%- else -%}
-                {{ person.start_date | date: "%b" }} - {{ person.end_date | date: "%b %Y" }}<br>
+                {{ person.dates.start | date: "%b" }} - {{ person.dates.start | date: "%b %Y" }}<br>
                {%- endif -%}
               </i><br></div>
             </div>

--- a/pages/former-fellows.md
+++ b/pages/former-fellows.md
@@ -1,0 +1,46 @@
+---
+permalink: /former-fellows.html
+layout: default
+title: IRIS/HEP Former Fellows
+---
+
+# IRIS-HEP Former Fellows
+
+<div class="container-fluid">
+  <div class="row">
+    {% assign current_fellows_start = '2020-05-01' | date:'%F' %}
+    {% assign sorted = site.pages | sort_natural: 'title' %}
+    {% for mypage in sorted %}
+      {%- if mypage.dates.first -%}
+        {% assign sorted_dates = mypage.dates | reverse %}
+        {% assign page_start_date = sorted_dates.first.start_date | date: '%F' %}
+      {%- else -%}
+        {% assign page_start_date = mypage.start_date | date: '%F' %}
+      {%- endif -%}
+      {% if mypage.pagetype == 'fellow' and page_start_date < current_fellows_start %}
+         {% assign person = mypage %}
+
+         <div class="card" style="width: 12rem;">
+            <img class="card-img-top" src="{{person.photo}}" alt="Card image cap">
+            <div class="card-body d-flex flex-column">
+              <div class="card-text">
+                 <b><a href="{{person.permalink}}">{{person.fellow-name}}</a></b><br>
+                 <small>{{person.institution}}</small><br><br>
+              </div>
+              <div class="card-text mt-auto"><i>
+
+              {%- if person.dates.first -%}
+                {% for dates in person.dates %}
+                  {{ dates.start_date | date: "%b" }} - {{ dates.end_date | date: "%b %Y" }}<br>
+                {% endfor %}
+               {%- else -%}
+                {{ person.start_date | date: "%b" }} - {{ person.end_date | date: "%b %Y" }}<br>
+               {%- endif -%}
+              </i><br></div>
+            </div>
+         </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+  <br>
+</div>

--- a/pages/former-fellows.md
+++ b/pages/former-fellows.md
@@ -28,14 +28,7 @@ title: IRIS/HEP Former Fellows
                  <small>{{person.institution}}</small><br><br>
               </div>
               <div class="card-text mt-auto"><i>
-
-              {%- if person.dates.first.start -%}
-                {% for date in person.dates %}
-                  {{ date.start | date: "%b" }} - {{ date.end | date: "%b %Y" }}<br>
-                {% endfor %}
-               {%- else -%}
-                {{ person.dates.start | date: "%b" }} - {{ person.dates.start | date: "%b %Y" }}<br>
-               {%- endif -%}
+              {% include fellow_dates.html dates=person.dates %}
               </i><br></div>
             </div>
          </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -75,14 +75,7 @@ an HEP software R&D topic relevant to the Institute.
                  <small>{{person.institution}}</small><br><br>
               </div>
               <div class="card-text mt-auto"><i>
-
-              {%- if person.dates.first.start -%}
-                {% for date in person.dates %}
-                  {{ date.start | date: "%b" }} - {{ date.end | date: "%b %Y" }}<br>
-                {% endfor %}
-              {%- else -%}
-                {{ person.dates.start | date: "%b" }} - {{ person.dates.end | date: "%b %Y" }}<br>
-              {%- endif -%}
+              {% include fellow_dates.html dates=person.dates %}
               </i><br></div>
             </div>
          </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -56,12 +56,17 @@ an HEP software R&D topic relevant to the Institute.
 
 <div class="container-fluid">
   <div class="row">
-    {% assign current_fellows_start = 'now' | date: '%s' | minus: 7257600 | date:'%F' %}
+    {% assign current_fellows_start = '2020-05-01' | date:'%F' %}
     {% assign sorted = site.pages | sort_natural: 'title' %}
     {% for mypage in sorted %}
-      {% assign page_start_date = mypage.dates[0].start_date | date: '%F' %}
+      {%- if mypage.dates.first -%}
+        {% assign page_start_date = mypage.dates.first.start_date | date: '%F' %}
+      {%- else -%}
+        {% assign page_start_date = mypage.start_date | date: '%F' %}
+      {%- endif -%}
       {% if mypage.pagetype == 'fellow' and page_start_date > current_fellows_start %}
          {% assign person = mypage %}
+
          <div class="card" style="width: 12rem;">
             <img class="card-img-top" src="{{person.photo}}" alt="Card image cap">
             <div class="card-body d-flex flex-column">
@@ -70,9 +75,17 @@ an HEP software R&D topic relevant to the Institute.
                  <small>{{person.institution}}</small><br><br>
               </div>
               <div class="card-text mt-auto"><i>
-              {% for dates in person.dates %}
+              <!-- {% for dates in person.dates %}
                 {{dates.start_date | date: "%b" }} - {{dates.end_date | date: "%b %Y"}}<br>
-              {% endfor %}
+              {% endfor %} -->
+
+              {%- if person.dates.first -%}
+                {% for dates in person.dates %}
+                  {{ dates.start_date | date: "%b" }} - {{ dates.end_date | date: "%b %Y" }}<br>
+                {% endfor %}
+               {%- else -%}
+                {{ person.start_date | date: "%b" }} - {{ person.end_date | date: "%b %Y" }}<br>
+               {%- endif -%}
               </i><br></div>
             </div>
          </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -52,13 +52,15 @@ IRIS-HEP is a software institute funded by the National Science Foundation. It a
 <h4>IRIS-HEP Fellows</h4>
 The IRIS-HEP Fellows program provides funding support for selected individuals to spend several months working closely with a mentor on
 an HEP software R&D topic relevant to the Institute.
-<a href="/fellows.html">Find out more about opportunities with the IRIS-HEP Fellows program.</a> Recent fellows include:
+<a href="/fellows.html">Find out more about opportunities with the IRIS-HEP Fellows program.</a> Current fellows include:
 
 <div class="container-fluid">
   <div class="row">
+    {% assign current_fellows_start = 'now' | date: '%s' | minus: 7257600 | date:'%F' %}
     {% assign sorted = site.pages | sort_natural: 'title' %}
     {% for mypage in sorted %}
-      {% if mypage.pagetype == 'fellow' %}
+      {% assign page_start_date = mypage.dates[0].start_date | date: '%F' %}
+      {% if mypage.pagetype == 'fellow' and page_start_date > current_fellows_start %}
          {% assign person = mypage %}
          <div class="card" style="width: 12rem;">
             <img class="card-img-top" src="{{person.photo}}" alt="Card image cap">

--- a/pages/index.html
+++ b/pages/index.html
@@ -59,10 +59,10 @@ an HEP software R&D topic relevant to the Institute.
     {% assign current_fellows_start = '2020-05-01' | date:'%F' %}
     {% assign sorted = site.pages | sort_natural: 'title' %}
     {% for mypage in sorted %}
-      {%- if mypage.dates.first -%}
-        {% assign page_start_date = mypage.dates.first.start_date | date: '%F' %}
+      {%- if mypage.dates.first.start -%}
+        {% assign page_start_date = mypage.dates.first.start | date: '%F' %}
       {%- else -%}
-        {% assign page_start_date = mypage.start_date | date: '%F' %}
+        {% assign page_start_date = mypage.dates.start | date: '%F' %}
       {%- endif -%}
       {% if mypage.pagetype == 'fellow' and page_start_date > current_fellows_start %}
          {% assign person = mypage %}
@@ -75,17 +75,14 @@ an HEP software R&D topic relevant to the Institute.
                  <small>{{person.institution}}</small><br><br>
               </div>
               <div class="card-text mt-auto"><i>
-              <!-- {% for dates in person.dates %}
-                {{dates.start_date | date: "%b" }} - {{dates.end_date | date: "%b %Y"}}<br>
-              {% endfor %} -->
 
-              {%- if person.dates.first -%}
-                {% for dates in person.dates %}
-                  {{ dates.start_date | date: "%b" }} - {{ dates.end_date | date: "%b %Y" }}<br>
+              {%- if person.dates.first.start -%}
+                {% for date in person.dates %}
+                  {{ date.start | date: "%b" }} - {{ date.end | date: "%b %Y" }}<br>
                 {% endfor %}
-               {%- else -%}
-                {{ person.start_date | date: "%b" }} - {{ person.end_date | date: "%b %Y" }}<br>
-               {%- endif -%}
+              {%- else -%}
+                {{ person.dates.start | date: "%b" }} - {{ person.dates.end | date: "%b %Y" }}<br>
+              {%- endif -%}
               </i><br></div>
             </div>
          </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -37,7 +37,7 @@ IRIS-HEP is a software institute funded by the National Science Foundation. It a
                   {{ post.summary | markdownify }}
               {% else %}
                   {{ post.excerpt | strip_html }}
-              {% endif %}  
+              {% endif %}
             <a href="{{post.url}}">Read more</a></div>
           </div>
        </div>
@@ -50,15 +50,15 @@ IRIS-HEP is a software institute funded by the National Science Foundation. It a
 
 <div class="mainpage-fellows mainpage-core">
 <h4>IRIS-HEP Fellows</h4>
-The IRIS-HEP Fellows program provides funding support for selected individuals to spend several months working closely with a mentor on 
-an HEP software R&D topic relevant to the Institute. 
+The IRIS-HEP Fellows program provides funding support for selected individuals to spend several months working closely with a mentor on
+an HEP software R&D topic relevant to the Institute.
 <a href="/fellows.html">Find out more about opportunities with the IRIS-HEP Fellows program.</a> Recent fellows include:
 
 <div class="container-fluid">
   <div class="row">
     {% assign sorted = site.pages | sort_natural: 'title' %}
     {% for mypage in sorted %}
-      {% if mypage.pagetype == 'fellow' %} 
+      {% if mypage.pagetype == 'fellow' %}
          {% assign person = mypage %}
          <div class="card" style="width: 12rem;">
             <img class="card-img-top" src="{{person.photo}}" alt="Card image cap">
@@ -67,11 +67,11 @@ an HEP software R&D topic relevant to the Institute.
                  <b><a href="{{person.permalink}}">{{person.fellow-name}}</a></b><br>
                  <small>{{person.institution}}</small><br><br>
               </div>
-              {% if person.dates.first %}
-                <div class="card-text mt-auto"><i>{{person.dates | join: "</i><br><i>"}}</i><br></div>
-              {% else %}
-                <div class="card-text mt-auto"><i>{{person.dates}}</i><br></div>
-              {% endif %}
+              <div class="card-text mt-auto"><i>
+              {% for dates in person.dates %}
+                {{dates.start_date | date: "%b" }} - {{dates.end_date | date: "%b %Y"}}<br>
+              {% endfor %}
+              </i><br></div>
             </div>
          </div>
       {% endif %}
@@ -85,7 +85,7 @@ an HEP software R&D topic relevant to the Institute.
 <div class="mainpage-events mainpage-core">
 
 {% comment %}
-Go through the list and produce a list of upcoming events as well as a 
+Go through the list and produce a list of upcoming events as well as a
 list of events in the past 90 days. Treat 6 days ago as "now" so that
 ongoing events don't get prematurely flagged as recent.
 {% endcomment %}
@@ -105,7 +105,7 @@ ongoing events don't get prematurely flagged as recent.
 
 {% for event in all_events %}
   {% assign startdatecmp = event.startdate | date: "%s" %}
-  {% if startdatecmp >= sixdaysago %} 
+  {% if startdatecmp >= sixdaysago %}
      {% assign selected_events = selected_events | push: event %}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
Hi @henryiii,

This is my attempt to add some date filtering to the fellows page.

I started by reworking the date field into an array in the YAML for the fellows markdown pages.  I used an array of "dictionaries" to overcome the issue when we have a fellow who returns (i.e. Reik).  I'm probably referring to the types wrong as far as YAML, but you can see what I did if you look at the files.

Then using this date field, I ensured the fellows page would display the date in a similar fashion to the current page.  On the main page, I created a way of limiting the list of fellows to the "current" round of fellows.  Basically I compare the end_date to the current_date minus 12 weeks - which gets us approximately into the current range of dates of the current fellows.  If end date is greater than 12 week from today, display the entry.  

I'm probably explaining this poorly, but I think this gets the page to a point where we can limit the displayed fellows by date. 

Could you take a look and let me know what you think?