### PR TITLE
feat: manual workflow trigger on master deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         echo "# WARNING: Do not edit this generated repository; edit [iris-hep.github.io-source](https://github.com/iris-hep/iris-hep.github.io-source) instead!" > _site/README.md
     
     - name: Deploy
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: success() && github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       uses: peaceiris/actions-gh-pages@v3
       with:
         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}


### PR DESCRIPTION
Simply clicking actions -> ci -> trigger workflow -> master will now rebuild the website without requiring a push.