### PR TITLE
Add SModelS paper citing pyhf

### DIFF
--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -54,6 +54,7 @@ team:
 
 Updating list of citations and use cases of `pyhf`:
 
+- Gaël Alguero, Sabine Kraml, and Wolfgang Waltenberger. A SModelS interface for pyhf likelihoods. 9 2020. [arXiv:2009.01809](https://arxiv.org/abs/2009.01809).
 - Waleed Abdallah and others. Reinterpretation of LHC Results for New Physics: Status and Recommendations after Run 2. 2020. [arXiv:2003.07868](https://arxiv.org/abs/2003.07868).
 - G. Brooijmans and others. Les Houches 2019 Physics at TeV Colliders: New Physics Working Group Report. In 2020. [arXiv:2002.12220](https://arxiv.org/abs/2002.12220).
 - J. Alison and others. Higgs boson potential at colliders: status and perspectives. In 2019. [arXiv:1910.00012](https://arxiv.org/abs/1910.00012).

--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -54,7 +54,7 @@ team:
 
 Updating list of citations and use cases of `pyhf`:
 
-- Gaël Alguero, Sabine Kraml, and Wolfgang Waltenberger. A SModelS interface for pyhf likelihoods. 9 2020. [arXiv:2009.01809](https://arxiv.org/abs/2009.01809).
+- Gaël Alguero, Sabine Kraml, and Wolfgang Waltenberger. A SModelS interface for pyhf likelihoods. Sep 2020. [arXiv:2009.01809](https://arxiv.org/abs/2009.01809).
 - Waleed Abdallah and others. Reinterpretation of LHC Results for New Physics: Status and Recommendations after Run 2. 2020. [arXiv:2003.07868](https://arxiv.org/abs/2003.07868).
 - G. Brooijmans and others. Les Houches 2019 Physics at TeV Colliders: New Physics Working Group Report. In 2020. [arXiv:2002.12220](https://arxiv.org/abs/2002.12220).
 - J. Alison and others. Higgs boson potential at colliders: status and perspectives. In 2019. [arXiv:1910.00012](https://arxiv.org/abs/1910.00012).


### PR DESCRIPTION
Add [_A SModelS interface for pyhf likelihoods_](https://inspirehep.net/literature/1814793) by Gaël Alguero, Sabine Kraml, and Wolfgang Waltenberger to list of papers that cite `pyhf`. :clap: to the SModelS team on both the [release of `v1.2.4`](https://github.com/SModelS/smodels/releases/tag/v1.2.4) as well as the nice paper. :rocket:

```
* Add SModelS paper on SModelS v1.2.4 pyhf interface and use of public likelihoods
   - c.f. https://inspirehep.net/literature/1814793
```