### PR TITLE
fix: Add missing titles to Illinois related LOIs

### DIFF
--- a/_data/publications/snowmass2021-FastML.yml
+++ b/_data/publications/snowmass2021-FastML.yml
@@ -1,5 +1,6 @@
+title: "Snowmass 2021 Letter of Interest: Fast Machine Learning"
 link: https://www.snowmass21.org/docs/files/summaries/CompF/SNOWMASS21-CompF3_CompF0-IF4_IF7-128.pdf
 date: 2020-08-31
 citation: "M.-A. Flechas, M. Atkinson, G.-Di Guglielmo, J. Duarte, F. Fahim, P. Harris, C. Herwig, B. Holzman, R. Kastner, M. Liu, C.-S. Moon, M. Neubauer, K. Pedro, A.-Q. Parra, D. Rankin, R. Rivera, N. Tran, M. Wang, T. Yang, J. Agar9, and E.-A. Huerta, Snowmass 2021 Letters of Interest"
 focus-area: ia
-project: 
+project:

--- a/_data/publications/snowmass2021-GNNs.yml
+++ b/_data/publications/snowmass2021-GNNs.yml
@@ -1,7 +1,6 @@
+title: "Snowmass 2021 Letter of Interest: Graph Data Structures and Graph Neural Networks for High Energy Physics"
 link: https://www.snowmass21.org/docs/files/summaries/CompF/SNOWMASS21-CompF3_CompF0-118.pdf
 date: 2020-08-31
-citation: "X. Ju, M. Neubauer, L. Gray, A. Aurisano, T. R. F. P. Tomei, J.-R. Vlimant, J. Hewes, K. Terao, S. Thais, D. Murnane
-, Snowmass 2021 Letters of Interest"
+citation: "X. Ju, M. Neubauer, L. Gray, A. Aurisano, T. R. F. P. Tomei, J.-R. Vlimant, J. Hewes, K. Terao, S. Thais, D. Murnane, Snowmass 2021 Letters of Interest"
 focus-area: ia
-project: 
-
+project:

--- a/_data/publications/snowmass2021-MLMELA.yml
+++ b/_data/publications/snowmass2021-MLMELA.yml
@@ -1,5 +1,6 @@
+title: "Snowmass 2021 Letter of Interest: Matrix Element Method in the Machine Learning Era"
 link: https://www.snowmass21.org/docs/files/summaries/CompF/SNOWMASS21-CompF3_CompF5-EF0_EF0_Mark_Neubauer-121.pdf
 date: 2020-08-31
 citation: "P. Chang, M. Feickert, and Mark S. Neubauer, Snowmass 2021 Letters of Interest"
 focus-area: as
-project: 
+project:

--- a/_data/publications/snowmass2021-MLedu.yml
+++ b/_data/publications/snowmass2021-MLedu.yml
@@ -1,5 +1,6 @@
+title: "Snowmass 2021 Letter of Interest: Particle Physics and Machine Learning in Education"
 link: https://www.snowmass21.org/docs/files/summaries/CompF/SNOWMASS21-CompF3_CompF0-CommF0_CommF0_Mark_Neubauer-130.pdf
 date: 2020-08-31
 citation: " Mark S. Neubauer, Snowmass 2021 Letters of Interest"
 focus-area: ssc
-project: 
+project:

--- a/_data/publications/snowmass2021-MLedu.yml
+++ b/_data/publications/snowmass2021-MLedu.yml
@@ -1,6 +1,6 @@
 title: "Snowmass 2021 Letter of Interest: Particle Physics and Machine Learning in Education"
 link: https://www.snowmass21.org/docs/files/summaries/CompF/SNOWMASS21-CompF3_CompF0-CommF0_CommF0_Mark_Neubauer-130.pdf
 date: 2020-08-31
-citation: " Mark S. Neubauer, Snowmass 2021 Letters of Interest"
+citation: "Mark S. Neubauer, Snowmass 2021 Letters of Interest"
 focus-area: ssc
 project:


### PR DESCRIPTION
Some of the LOIs added in PR #440 were missing titles. This PR fixes that. cc @msneubauer 