### PR TITLE
Update Madminer project info

### DIFF
--- a/pages/events.md
+++ b/pages/events.md
@@ -8,7 +8,7 @@ title: IRIS-HEP Events
 </center>
 
 <br>
-Events that IRIS-HEP team members are invovled in organizing, planning to participate in or otherwise interested in:
+Events that IRIS-HEP team members are involved in organizing, planning to participate in or otherwise interested in:
 
 <ul>
 {% assign yearlist = "2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016" | split: ", " %}

--- a/pages/projects/madminer.md
+++ b/pages/projects/madminer.md
@@ -36,7 +36,7 @@ playfully call this process "mining gold" from the simulator, since this informa
 to be very valuable for inference.
 
 
-[![GitHub](https://img.shields.io/badge/GitHub-555555.svg)](https://github.com/johannbrehmer/madminer)
+[![GitHub](https://img.shields.io/badge/GitHub-555555.svg)](https://github.com/diana-hep/madminer)
 [![PyPI version](https://badge.fury.io/py/madminer.svg)](https://badge.fury.io/py/madminer)
 [![Documentation Status](https://readthedocs.org/projects/madminer/badge/?version=latest)](https://madminer.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://travis-ci.com/johannbrehmer/madminer.svg?branch=master)](https://travis-ci.com/johannbrehmer/madminer)

--- a/pages/projects/madminer.md
+++ b/pages/projects/madminer.md
@@ -11,7 +11,8 @@ team:
  - cranmer
  - johannbrehmer
  - irinaespejo
- - Felix Kling 
+ - sinclert
+ - Felix Kling
 ---
 
 


### PR DESCRIPTION
This PR updates the [Madminer project information page](https://iris-hep.org/projects/madminer.html) by:

- Updating the GitHub link to the proper repo (under _DIANA-HEP_), instead of a fork.
- Adding me to the list of project authors. I was not one of the original authors (those publishing the paper), but I was later added to the project by Johann, given my contributions on both [madminer](https://github.com/diana-hep/madminer) and [madminer-workflow](https://github.com/scailfin/madminer-workflow) repositories.

In addition, fixes a typo on the _Events_ page.