### PR TITLE
Add ATLAS ss3L HEPData likelihood record

### DIFF
--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -74,8 +74,8 @@ Updating list of citations and use cases of `pyhf`:
 
 Updating list of HEPData entries for publications using `HistFactory` JSON likelihoods:
 
-- Search for squarks and gluinos in final states with same-sign leptons and jets using 139 fb−1 of data collected with the ATLAS detector. 2020. [doi:10.17182/hepdata.91214.v3](https://doi.org/10.17182/hepdata.91214.v3)
-- Search for direct production of electroweakinos in final states with one lepton, missing transverse momentum and a Higgs boson decaying into two b-jets in (pp) collisions at s√=13 TeV with the ATLAS detector. 2020. [doi:10.17182/hepdata.90607.v2](https://doi.org/10.17182/hepdata.90607.v2).
+- Search for squarks and gluinos in final states with same-sign leptons and jets using 139 fb−1 of data collected with the ATLAS detector. 2020. [doi:10.17182/hepdata.91214](https://doi.org/10.17182/hepdata.91214)
+- Search for direct production of electroweakinos in final states with one lepton, missing transverse momentum and a Higgs boson decaying into two b-jets in (pp) collisions at s√=13 TeV with the ATLAS detector. 2020. [doi:10.17182/hepdata.90607](https://doi.org/10.17182/hepdata.90607).
 - Search for chargino-neutralino production with mass splittings near the electroweak scale in three-lepton final states in s√ = 13 TeV pp collisions with the ATLAS detector. 2019. [doi:10.17182/hepdata.91127](https://doi.org/10.17182/hepdata.91127).
 - Search for direct stau production in events with two hadronic τ-leptons in s√=13 TeV pp collisions with the ATLAS detector. 2019. [doi:10.17182/hepdata.92006](https://doi.org/10.17182/hepdata.92006).
 - Search for bottom-squark pair production with the ATLAS detector in final states containing Higgs bosons, b-jets and missing transverse momentum. 2019. [doi:10.17182/hepdata.89408](https://doi.org/10.17182/hepdata.89408).

--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -74,6 +74,7 @@ Updating list of citations and use cases of `pyhf`:
 
 Updating list of HEPData entries for publications using `HistFactory` JSON likelihoods:
 
+- Search for squarks and gluinos in final states with same-sign leptons and jets using 139 fb−1 of data collected with the ATLAS detector. 2020. [doi:10.17182/hepdata.91214.v3](https://doi.org/10.17182/hepdata.91214.v3)
 - Search for direct production of electroweakinos in final states with one lepton, missing transverse momentum and a Higgs boson decaying into two b-jets in (pp) collisions at s√=13 TeV with the ATLAS detector. 2020. [doi:10.17182/hepdata.90607.v2](https://doi.org/10.17182/hepdata.90607.v2).
 - Search for chargino-neutralino production with mass splittings near the electroweak scale in three-lepton final states in s√ = 13 TeV pp collisions with the ATLAS detector. 2019. [doi:10.17182/hepdata.91127](https://doi.org/10.17182/hepdata.91127).
 - Search for direct stau production in events with two hadronic τ-leptons in s√=13 TeV pp collisions with the ATLAS detector. 2019. [doi:10.17182/hepdata.92006](https://doi.org/10.17182/hepdata.92006).


### PR DESCRIPTION
Add HEPData record for published statistical model and observations for [Search for squarks and gluinos in final states with same-sign leptons and jets using 139 fb−1 of data collected with the ATLAS detector](https://www.hepdata.net/record/91214?version=3).

```
* Add ATLAS ss3L HEPData record with patchset pallet (stat model and observations)
   - c.f. https://www.hepdata.net/record/ins1754675?version=3
* Remove version numbers from previous DOIs to default to latest
```