### PR TITLE
talk: Add Feickert Fitting as a Service with pyhf talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -103,3 +103,9 @@ presentations:
     meetingurl: https://indico.fnal.gov/event/43829/
     location: Virtual
     focus-area: as
+  - title: "Toward Fitting as a Service with pyhf"
+    date: 2020-10-26
+    url: https://indico.cern.ch/event/960587/contributions/4070323/
+    meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
+    meetingurl: https://indico.cern.ch/event/960587/
+    location: Virtual

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -109,3 +109,4 @@ presentations:
     meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
     meetingurl: https://indico.cern.ch/event/960587/
     location: Virtual
+    focus-area: as


### PR DESCRIPTION
Add "[Toward Fitting as a Service with pyhf](https://indico.cern.ch/event/960587/contributions/4070323/)" talk given by @matthewfeickert at the [October 2020 IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop](https://indico.cern.ch/event/960587/).