### PR TITLE
talk: Add Feickert TOOLS 2020 pyhf talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -111,3 +111,10 @@ presentations:
     meetingurl: https://indico.cern.ch/event/960587/
     location: Virtual
     focus-area: as
+  - title: "pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation"
+    date: 2020-11-03
+    url: https://indico.cern.ch/event/955391/contributions/4075505/
+    meeting: Tools for High Energy Physics and Cosmology 2020 Workshop
+    meetingurl: https://indico.cern.ch/event/955391/
+    location: Virtual
+    focus-area: as


### PR DESCRIPTION
Add pyhf talk given by @matthewfeickert at the [TOOLS 2020 Workshop](https://indico.cern.ch/event/955391/).