### PR TITLE
Nov 2020 update for Alexander Held

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -49,3 +49,17 @@ presentations:
     meetingurl: https://indico.cern.ch/event/896167/
     location: (Virtual)
     focus-area: as
+  - title: "Differentiable physics analyses"
+    date: 2020-08-11
+    url: https://indico.fnal.gov/event/43829/contributions/193761/
+    meeting: Snowmass Computational Frontier Workshop
+    meetingurl: https://indico.fnal.gov/event/43829/
+    location: (Virtual)
+    focus-area: as
+  - title: "Template-based Fitting: cabinetry"
+    date: 2020-10-26
+    url: https://indico.cern.ch/event/960587/contributions/4070322/
+    meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
+    meetingurl: https://indico.cern.ch/event/960587/
+    location: (Virtual)
+    focus-area: as

--- a/_data/publications/1832223.yml
+++ b/_data/publications/1832223.yml
@@ -1,0 +1,5 @@
+inspire-id: 1832223
+related-work: false
+focus-area: as
+project:
+- madminer

--- a/_data/publications/1832223.yml
+++ b/_data/publications/1832223.yml
@@ -1,5 +1,6 @@
 inspire-id: 1832223
 related-work: false
 focus-area: as
+date: 2020-11-16
 project:
 - madminer


### PR DESCRIPTION
This adds two talks (Snowmass workshop + IRIS-HEP blueprint workshop) and the now published CHEP proceedings on likelihood-free inference.