### PR TITLE
Fix missing e-mail from OSG LHC fellows projects

### DIFF
--- a/_data/people/brianhlin.yml
+++ b/_data/people/brianhlin.yml
@@ -5,6 +5,7 @@ active: true
 institution: University of Wisconsin–Madison
 website: 
 photo: /assets/images/team/Brian-Lin.jpg
+e-mail: blin@cs.wisc.edu
 presentations:
   - title: "Introduction to HTCondor-CE"
     date: 2020-06-17


### PR DESCRIPTION
Contacts for the recently merged OSG-LHC fellows projects (https://iris-hep.org/fellow_projects.html) are missing a listed contact because of my missing email address 