### PR TITLE
talk: Add Feickert talk on Fitting as a Service

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -125,10 +125,10 @@ presentations:
     meetingurl: https://lpsc-indico.in2p3.fr/event/2585/
     location: Virtual
     focus-area: as
-  - title: Workshop Overview and Goals
+  - title: "Fitting and Statistical Inference as a Service"
     date: 2020-12-04
-    url: https://indico.cern.ch/event/972791/contributions/4121084
+    url: https://indico.cern.ch/event/972791/contributions/4121109/
     meeting: Mini-Workshop on Portable Inference
     meetingurl: https://indico.cern.ch/event/972791
     location: Virtual
-    focus-area: as, ia
+    focus-area: as

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -125,3 +125,10 @@ presentations:
     meetingurl: https://lpsc-indico.in2p3.fr/event/2585/
     location: Virtual
     focus-area: as
+  - title: Workshop Overview and Goals
+    date: 2020-12-04
+    url: https://indico.cern.ch/event/972791/contributions/4121084
+    meeting: Mini-Workshop on Portable Inference
+    meetingurl: https://indico.cern.ch/event/972791
+    location: Virtual
+    focus-area: as, ia


### PR DESCRIPTION
Add @matthewfeickert's talk on [Fitting and Statistical Inference as a Service at the 2020 Mini-Workshop on Portable Inference](https://indico.cern.ch/event/972791/contributions/4121109/)

```
* c.f. https://indico.cern.ch/event/972791/contributions/4121109/
```