### PR TITLE
fix: empty events display

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -397,7 +397,7 @@ main {
     list-style: none;
   }
 
-  .event {
+  .event, .empty {
     display: flex;
     flex-flow: row wrap;
     margin: 5px 0 10px 0;
@@ -443,6 +443,9 @@ main {
         color: black;
       }
     }
+  }
+  .empty {
+    padding: 4px 8px 4px 8px;
   }
 }
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -125,8 +125,10 @@ ongoing events don't get prematurely flagged as recent.
 
 <ul>
   {% assign selected_events = selected_events | sort: 'startdate' %}
+  {%- assign has-event = false %}
   {% for event in selected_events %}
     {% assign startdatecmp = event.startdate | date: "%s" %}
+    {%- assign has-event = true %}
     <li>
       <a href="{{event.meetingurl}}">
         <div class="event">
@@ -144,6 +146,11 @@ ongoing events don't get prematurely flagged as recent.
     </li>
   {% endfor %}
 </ul>
+{%- unless has-event %}
+  <div class="empty">
+    No events currently scheduled. Check back again soon!
+  </div>
+{%- endunless %}
 
 <div class="mainpage-sidebar-links">
 <a href="/events.html">View all past events</a>
@@ -156,10 +163,12 @@ ongoing events don't get prematurely flagged as recent.
 <h4>Upcoming Topical Meetings:</h4>
 </div>
 {% include get_indico_list.html %}
+{%- assign has-event = false %}
 <ul>
 {% for event in selected_array %}
   {% assign startdatecmp = event.startdate | date: "%s" %}
   {% if onedayago <= startdatecmp %}
+    {%- assign has-event = true %}
     <li>
       <a href="{{event.meetingurl}}">
         <div class="event">
@@ -177,6 +186,11 @@ ongoing events don't get prematurely flagged as recent.
   {% endif %}
 {% endfor %}
 </ul>
+{%- unless has-event %}
+  <div class="empty">
+    No meetings currently scheduled. Check back again soon!
+  </div>
+{%- endunless %}
 <div class="mainpage-sidebar-links">
 <a href="/topical.html" aria-label="View all topical meetings">View all</a>
 &bull;


### PR DESCRIPTION
This displays a nicer box when there are no meeting or events upcoming.

<img width="392" alt="Screen Shot 2020-12-10 at 10 48 37 AM" src="https://user-images.githubusercontent.com/4616906/101794879-51d09000-3ad5-11eb-9f48-a045a7e0dea4.png">
