### PR TITLE
Add pyhf use citations from late 2020

### DIFF
--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -61,6 +61,7 @@ Updating list of citations and use cases of `pyhf`:
 
 - Matthew Feickert, Lukas Heinrich, and Giordon Stark. Likelihood preservation and statistical reproduction of searches for new physics. EPJ Web Conf., Nov 2020. [doi:10.1051/epjconf/202024506017](https://doi.org/10.1051/epjconf/202024506017).
 - Gaël Alguero, Sabine Kraml, and Wolfgang Waltenberger. A SModelS interface for pyhf likelihoods. Sep 2020. [arXiv:2009.01809](https://arxiv.org/abs/2009.01809).
+- ATLAS Collaboration. Search for new phenomena in events with two opposite-charge leptons, jets and missing transverse momentum in pp collisions at s√=13 TeV with the ATLAS detector. Geneva, Aug 2020. URL: [https://cds.cern.ch/record/2684863](https://cds.cern.ch/record/2728056).
 - Jeffrey Krupa and others. GPU coprocessors as a service for deep learning inference in high energy physics. July 2020. [arXiv:2007.10359](https://arxiv.org/abs/2007.10359).
 - Charanjit K. Khosa, Sabine Kraml, Andre Lessa, Philipp Neuhuber, and Wolfgang Waltenberger. SModelS database update v1.2.3. LHEP, 158:2020, May 2020. [arXiv:2005.00555](https://arxiv.org/abs/2005.00555), [doi:10.31526/lhep.2020.158](https://doi.org/10.31526/lhep.2020.158).
 - Waleed Abdallah and others. Reinterpretation of LHC Results for New Physics: Status and Recommendations after Run 2. 2020. [arXiv:2003.07868](https://arxiv.org/abs/2003.07868).

--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -59,6 +59,7 @@ The CERN homepage featured an article on pyhf: [New open release allows theorist
 
 Updating list of citations and use cases of `pyhf`:
 
+- Gaël Alguero, Jan Heisig, Charanjit K. Khosa, Sabine Kraml, Suchita Kulkarni, Andre Lessa, Philipp Neuhuber, Humberto Reyes-González, Wolfgang Waltenberger, and Alicia Wongel. New developments in SModelS. In _Tools for High Energy Physics and Cosmology_. Dec 2020. [arXiv:2012.08192](https://arxiv.org/abs/2012.08192).
 - Matthew Feickert, Lukas Heinrich, and Giordon Stark. Likelihood preservation and statistical reproduction of searches for new physics. EPJ Web Conf., Nov 2020. [doi:10.1051/epjconf/202024506017](https://doi.org/10.1051/epjconf/202024506017).
 - Gaël Alguero, Sabine Kraml, and Wolfgang Waltenberger. A SModelS interface for pyhf likelihoods. Sep 2020. [arXiv:2009.01809](https://arxiv.org/abs/2009.01809).
 - ATLAS Collaboration. Search for new phenomena in events with two opposite-charge leptons, jets and missing transverse momentum in pp collisions at s√=13 TeV with the ATLAS detector. Geneva, Aug 2020. URL: [https://cds.cern.ch/record/2684863](https://cds.cern.ch/record/2728056).


### PR DESCRIPTION
Add use citations for

- [Search for new phenomena in events with two opposite-charge leptons, jets and missing transverse momentum in p p collisions at √s = 13 TeV with the ATLAS detector](https://inspirehep.net/literature/1811757) (ATLAS-CONF-2020-046)
- [New developments in SModelS](https://inspirehep.net/literature/1836682)

```
* Add pyhf use citations from late 2020
   - ATLAS-CONF-2020-046 (https://inspirehep.net/literature/1811757)
   - New developments in SModelS (https://inspirehep.net/literature/1836682)
```