### PR TITLE
Add Symmetry Magazine article on likelihood publication and pyhf

### DIFF
--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -42,7 +42,7 @@ team:
 
 ### Featured on CERN homeapge and in Symmetry Magazine
 
-- The CERN homepage featured an article on pyhf: [New open release allows theorists to explore LHC data in a new way](https://home.cern/news/news/knowledge-sharing/new-open-release-allows-theorists-explore-lhc-data-new-way):  The ATLAS collaboration releases full analysis likelihoods, a first for an LHC experiment.
+- The CERN homepage featured an article on pyhf: [New open release allows theorists to explore LHC data in a new way](https://home.cern/news/news/knowledge-sharing/new-open-release-allows-theorists-explore-lhc-data-new-way):  The ATLAS collaboration releases full analysis likelihoods, a first for an LHC experiment. (January, 2020)
 - Symmetry Magazine: [ATLAS releases 'full orchestra' of analysis instruments](https://www.symmetrymagazine.org/article/atlas-releases-full-orchestra-of-analysis-instruments) (January, 2021)
 
 ### Recent Talks and Tutorials

--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -40,9 +40,9 @@ team:
 [![Docker Stars](https://img.shields.io/docker/stars/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/)
 
-### Featured on CERN homeapge
+### Featured on CERN homeapge and in Symmetry Magazine
 
-The CERN homepage featured an article on pyhf: [New open release allows theorists to explore LHC data in a new way](https://home.cern/news/news/knowledge-sharing/new-open-release-allows-theorists-explore-lhc-data-new-way):  The ATLAS collaboration releases full analysis likelihoods, a first for an LHC experiment.
+- The CERN homepage featured an article on pyhf: [New open release allows theorists to explore LHC data in a new way](https://home.cern/news/news/knowledge-sharing/new-open-release-allows-theorists-explore-lhc-data-new-way):  The ATLAS collaboration releases full analysis likelihoods, a first for an LHC experiment.
 
 ### Recent Talks and Tutorials
 

--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -43,6 +43,7 @@ team:
 ### Featured on CERN homeapge and in Symmetry Magazine
 
 - The CERN homepage featured an article on pyhf: [New open release allows theorists to explore LHC data in a new way](https://home.cern/news/news/knowledge-sharing/new-open-release-allows-theorists-explore-lhc-data-new-way):  The ATLAS collaboration releases full analysis likelihoods, a first for an LHC experiment.
+- Symmetry Magazine: [ATLAS releases 'full orchestra' of analysis instruments](https://www.symmetrymagazine.org/article/atlas-releases-full-orchestra-of-analysis-instruments) (January, 2021)
 
 ### Recent Talks and Tutorials
 


### PR DESCRIPTION
Adds ["ATLAS releases ‘full orchestra’ of analysis instruments" Symmetry Magazine article](https://www.symmetrymagazine.org/article/atlas-releases-full-orchestra-of-analysis-instruments) to `pyhf` project page


**Squash and merge commit message:**
```
* Add Symmetry Magazine article on likelihood publication using pyhf to pyhf page
   - c.f. https://www.symmetrymagazine.org/article/atlas-releases-full-orchestra-of-analysis-instruments
* Add dates to publications of storied in CERN News and Symmetry Magazine
```