### PR TITLE
feat: configure publication collector

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,7 +56,7 @@ exclude:
   - Rakefile
 
 sass:
-    sass_dir: _sass
+  sass_dir: _sass
 
 indico:
   url: https://indico.cern.ch
@@ -66,3 +66,10 @@ indico:
     blueprint: 11329
     sb: 10989
     ap: 11519
+
+inspire:
+  cache-dir: _cache
+  pub-dir: publications
+  authors:
+    min-len: 10
+    trunc-len: 1


### PR DESCRIPTION
Add configuration options, and update the "et. al." condenser; it will now leave up to 10 names alone, and compress to 1 name if longer (configurable in the _config.yml now). Moving a _little_ closer to pulling this plugin out too eventually.

Several papers currently have custom citations I believe; this might help make some of them unnecessary. At least _data/publications/1804768.yml possibly.