### PR TITLE
pyhf: Update information on pyhf tutorials

### DIFF
--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -54,10 +54,7 @@ team:
 [![SciPy 2020 talk YouTube](http://i3.ytimg.com/vi/FrH9s3eB6fU/hqdefault.jpg)](https://youtu.be/FrH9s3eB6fU)
 
 * [`pyhf` tutorial](https://pyhf.github.io/pyhf-tutorial/) (continually updated to use the lastest `pyhf` release)
-
-* [PyHEP 2020 tutorial](https://indico.cern.ch/event/882824/contributions/3931292/) (uses `pyhf` `v0.4.4`):
-
-[![PyHEP 2020 tutorial YouTube](http://i3.ytimg.com/vi/V0Li05ijv0U/hqdefault.jpg)](https://youtu.be/V0Li05ijv0U)
+   - Past tutorials (with recordings on YouTube) are listed on the [tutorial GitHub project](https://github.com/pyhf/pyhf-tutorial)
 
 ### Use in Publications
 

--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -53,6 +53,8 @@ team:
 <!-- http://www.get-youtube-thumbnail.com/ -->
 [![SciPy 2020 talk YouTube](http://i3.ytimg.com/vi/FrH9s3eB6fU/hqdefault.jpg)](https://youtu.be/FrH9s3eB6fU)
 
+* [`pyhf` tutorial](https://pyhf.github.io/pyhf-tutorial/) (continually updated to use the lastest `pyhf` release)
+
 * [PyHEP 2020 tutorial](https://indico.cern.ch/event/882824/contributions/3931292/) (uses `pyhf` `v0.4.4`):
 
 [![PyHEP 2020 tutorial YouTube](http://i3.ytimg.com/vi/V0Li05ijv0U/hqdefault.jpg)](https://youtu.be/V0Li05ijv0U)


### PR DESCRIPTION
Update the `pyhf` page to note that there is now a permanent tutorial location that will be updated incrementally with both release and anytime there are revisions. All versions of the tutorial will be archived on Zenodo. [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4670321.svg)](https://doi.org/10.5281/zenodo.4670321)

```
* Change tutorial links to point to new tutorial that will be updated continually
   - c.f. https://pyhf.github.io/pyhf-tutorial/
* Note that old tutorials will be listed on the GitHub project README
   - c.f. https://github.com/pyhf/pyhf-tutorial
```