### PR TITLE
Add instructions for trying out site using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ bundle install
 bundle exec rake serve
 ```
 
+Alternatively, you can test your changes out using the Jekyll docker image:
+```bash
+docker run --rm -it \
+      --volume="$PWD:/srv/jekyll"  \
+      -p 4000:4000 \
+      jekyll/builder:stable jekyll serve
+```
+This will mount your checked out copy of this repo, then build and start the
+jekyll server mapping it to port 4000 on your computer. You can make changes
+locally and view them at http://localhost:4000


### PR DESCRIPTION
I just got a new laptop and remember getting Jekyll running last time was not so easy. I tried to see if it could be done using
a standard docker image and it worked out very well. Adding instructions at the end of the README