### PR TITLE
Add --incremental to docker run for better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Alternatively, you can test your changes out using the Jekyll docker image:
 docker run --rm -it \
       --volume="$PWD:/srv/jekyll"  \
       -p 4000:4000 \
-      jekyll/builder:stable jekyll serve
+      jekyll/builder:stable jekyll serve --incremental
 ```
 This will mount your checked out copy of this repo, then build and start the
 jekyll server mapping it to port 4000 on your computer. You can make changes


### PR DESCRIPTION
# Problem
The docker container for the Jekyll server is _very_ slow to process changes

# Approach 
Add the `--incremental` command line argument to the serve command.