### PR TITLE
Add projects to presentations for Alexander Held

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -7,13 +7,14 @@ website:  https://github.com/alexander-held
 photo: /assets/images/team/alexander-held.jpeg
 e-mail: alexander.held@cern.ch
 presentations:
-  - title: "Template Fits: HistFitter / TRexFitter"
+  - title: "Template Fits: HistFitter / TRExFitter"
     date: 2019-06-19
     url: https://indico.cern.ch/event/822074/contributions/3471458/
     meeting: Analysis Systems Topical Meeting
     meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
     location: NYU
     focus-area: as
+    project: cabinetry
   - title: "Harmonizing statistics tools - ideas"
     date: 2019-10-29
     url: https://indico.cern.ch/event/859742/contributions/3620507/
@@ -21,6 +22,7 @@ presentations:
     meetingurl: https://indico.cern.ch/event/859742/
     location: CERN
     focus-area: as
+    project: cabinetry
   - title: "Constraining effective field theories with machine learning"
     date: 2019-11-07
     url: https://indico.cern.ch/event/773049/contributions/3476179/
@@ -36,6 +38,7 @@ presentations:
     meetingurl: https://indico.cern.ch/event/894127/
     location: Princeton, USA
     focus-area: as
+    project: cabinetry
   - title: "pyhf and thoughts about analysis workflow"
     date: 2020-03-12
     url: https://indico.cern.ch/event/897232/contributions/3784156/
@@ -43,6 +46,7 @@ presentations:
     meetingurl: https://indico.cern.ch/event/897232/
     location: CERN
     focus-area: as
+    project: cabinetry
   - title: "Cabinetry introduction"
     date: 2020-05-27
     url: https://indico.cern.ch/event/896167/contributions/3880230/
@@ -50,6 +54,7 @@ presentations:
     meetingurl: https://indico.cern.ch/event/896167/
     location: (Virtual)
     focus-area: as
+    project: cabinetry
   - title: "Differentiable physics analyses"
     date: 2020-08-11
     url: https://indico.fnal.gov/event/43829/contributions/193761/
@@ -64,6 +69,7 @@ presentations:
     meetingurl: https://indico.cern.ch/event/960587/
     location: (Virtual)
     focus-area: as
+    project: cabinetry
   - title: "The cabinetry library"
     date: 2021-02-25
     url: https://indico.cern.ch/event/1005890/contributions/4222699/
@@ -71,3 +77,4 @@ presentations:
     meetingurl: https://indico.cern.ch/event/1005890/
     location: (Virtual)
     focus-area: as
+    project: cabinetry


### PR DESCRIPTION
Adding a `project` tag for my presentations where a suitable project exists, to allow the talks to show up on the corresponding project page. Also fixing a small typo.

This is ready for review / merge.