### PR TITLE
initial stab at videos per person/fa/project

### DIFF
--- a/_data/videos/26YXz0fzMNQ_0.yml
+++ b/_data/videos/26YXz0fzMNQ_0.yml
@@ -1,0 +1,7 @@
+title: "Using GPUs and FPGAs as-a-service for LHC computing"
+speaker: Dylan Rankin
+focus_areas: 
+projects: 
+date: 2020-09-09
+startsec: 0
+url: https://www.youtube.com/embed/26YXz0fzMNQ

--- a/_data/videos/26YXz0fzMNQ_0.yml
+++ b/_data/videos/26YXz0fzMNQ_0.yml
@@ -1,7 +1,7 @@
 title: "Using GPUs and FPGAs as-a-service for LHC computing"
 speaker: Dylan Rankin
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-09
 startsec: 0
 url: https://www.youtube.com/embed/26YXz0fzMNQ

--- a/_data/videos/2QamxiCawXM_0.yml
+++ b/_data/videos/2QamxiCawXM_0.yml
@@ -1,7 +1,7 @@
 title: "Primary vertex finding at LHCb"
 speaker: Marian Stahl
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-01-29
 startsec: 0
 url: https://www.youtube.com/embed/2QamxiCawXM

--- a/_data/videos/2QamxiCawXM_0.yml
+++ b/_data/videos/2QamxiCawXM_0.yml
@@ -1,0 +1,7 @@
+title: "Primary vertex finding at LHCb"
+speaker: Marian Stahl
+focus_areas: 
+projects: 
+date: 2020-01-29
+startsec: 0
+url: https://www.youtube.com/embed/2QamxiCawXM

--- a/_data/videos/6gCp1BwQHdg_0.yml
+++ b/_data/videos/6gCp1BwQHdg_0.yml
@@ -1,7 +1,7 @@
 title: "Reproducible Large Scale SkyhookDM Experiments"
 speaker: Jayjeet Chakraborty
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-10-05
 startsec: 55
 url: https://www.youtube.com/embed/6gCp1BwQHdg

--- a/_data/videos/6gCp1BwQHdg_0.yml
+++ b/_data/videos/6gCp1BwQHdg_0.yml
@@ -1,0 +1,7 @@
+title: "Reproducible Large Scale SkyhookDM Experiments"
+speaker: Jayjeet Chakraborty
+focus_areas: 
+projects: 
+date: 2020-10-05
+startsec: 55
+url: https://www.youtube.com/embed/6gCp1BwQHdg

--- a/_data/videos/6gCp1BwQHdg_1.yml
+++ b/_data/videos/6gCp1BwQHdg_1.yml
@@ -1,0 +1,7 @@
+title: "Matrix Factorization for PV finding in LHCb"
+speaker: Alan Joshua Jegaraj
+focus_areas: 
+projects: 
+date: 2020-10-05
+startsec: 901
+url: https://www.youtube.com/embed/6gCp1BwQHdg

--- a/_data/videos/6gCp1BwQHdg_1.yml
+++ b/_data/videos/6gCp1BwQHdg_1.yml
@@ -1,7 +1,7 @@
 title: "Matrix Factorization for PV finding in LHCb"
 speaker: Alan Joshua Jegaraj
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-10-05
 startsec: 901
 url: https://www.youtube.com/embed/6gCp1BwQHdg

--- a/_data/videos/7teqrCNzrD8_0.yml
+++ b/_data/videos/7teqrCNzrD8_0.yml
@@ -1,0 +1,7 @@
+title: "Calling C++ libraries from a D-written DSL: A cling/cppyy-based approach"
+speaker: Alexandru Militaru
+focus_areas: 
+projects: 
+date: 2030-12-31
+startsec: 0
+url: https://www.youtube.com/embed/7teqrCNzrD8

--- a/_data/videos/7teqrCNzrD8_0.yml
+++ b/_data/videos/7teqrCNzrD8_0.yml
@@ -1,7 +1,7 @@
 title: "Calling C++ libraries from a D-written DSL: A cling/cppyy-based approach"
 speaker: Alexandru Militaru
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2030-12-31
 startsec: 0
 url: https://www.youtube.com/embed/7teqrCNzrD8

--- a/_data/videos/88E4W5xetZw_0.yml
+++ b/_data/videos/88E4W5xetZw_0.yml
@@ -1,7 +1,7 @@
 title: "fast-carpenter: turning trees into tables"
 speaker: Benjamin Krikler
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-03-04
 startsec: 0
 url: https://www.youtube.com/embed/88E4W5xetZw

--- a/_data/videos/88E4W5xetZw_0.yml
+++ b/_data/videos/88E4W5xetZw_0.yml
@@ -1,0 +1,7 @@
+title: "fast-carpenter: turning trees into tables"
+speaker: Benjamin Krikler
+focus_areas: 
+projects: 
+date: 2019-03-04
+startsec: 0
+url: https://www.youtube.com/embed/88E4W5xetZw

--- a/_data/videos/88E4W5xetZw_1.yml
+++ b/_data/videos/88E4W5xetZw_1.yml
@@ -1,0 +1,7 @@
+title: "scikit-validate: automating analysis validation"
+speaker: Lukasz Kreczko
+focus_areas: 
+projects: 
+date: 2019-03-04
+startsec: 2430
+url: https://www.youtube.com/embed/88E4W5xetZw

--- a/_data/videos/88E4W5xetZw_1.yml
+++ b/_data/videos/88E4W5xetZw_1.yml
@@ -1,7 +1,7 @@
 title: "scikit-validate: automating analysis validation"
 speaker: Lukasz Kreczko
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-03-04
 startsec: 2430
 url: https://www.youtube.com/embed/88E4W5xetZw

--- a/_data/videos/BlMl4SGkVnY_0.yml
+++ b/_data/videos/BlMl4SGkVnY_0.yml
@@ -1,7 +1,7 @@
 title: "mpl-hep"
 speaker: Nick Smith
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-04-15
 startsec: 0
 url: https://www.youtube.com/embed/BlMl4SGkVnY

--- a/_data/videos/BlMl4SGkVnY_0.yml
+++ b/_data/videos/BlMl4SGkVnY_0.yml
@@ -1,0 +1,7 @@
+title: "mpl-hep"
+speaker: Nick Smith
+focus_areas: 
+projects: 
+date: 2019-04-15
+startsec: 0
+url: https://www.youtube.com/embed/BlMl4SGkVnY

--- a/_data/videos/BlMl4SGkVnY_1.yml
+++ b/_data/videos/BlMl4SGkVnY_1.yml
@@ -1,0 +1,7 @@
+title: "boost-histogram and hist"
+speaker: Henry Schreiner
+focus_areas: 
+projects: 
+date: 2019-04-15
+startsec: 1280
+url: https://www.youtube.com/embed/BlMl4SGkVnY

--- a/_data/videos/BlMl4SGkVnY_1.yml
+++ b/_data/videos/BlMl4SGkVnY_1.yml
@@ -1,7 +1,7 @@
 title: "boost-histogram and hist"
 speaker: Henry Schreiner
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-04-15
 startsec: 1280
 url: https://www.youtube.com/embed/BlMl4SGkVnY

--- a/_data/videos/BlMl4SGkVnY_2.yml
+++ b/_data/videos/BlMl4SGkVnY_2.yml
@@ -1,0 +1,7 @@
+title: "Aghast"
+speaker: Jim Pivarski
+focus_areas: 
+projects: 
+date: 2019-04-15
+startsec: 2953
+url: https://www.youtube.com/embed/BlMl4SGkVnY

--- a/_data/videos/BlMl4SGkVnY_2.yml
+++ b/_data/videos/BlMl4SGkVnY_2.yml
@@ -1,7 +1,7 @@
 title: "Aghast"
 speaker: Jim Pivarski
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-04-15
 startsec: 2953
 url: https://www.youtube.com/embed/BlMl4SGkVnY

--- a/_data/videos/CAZtQIZ1-wE_0.yml
+++ b/_data/videos/CAZtQIZ1-wE_0.yml
@@ -1,0 +1,7 @@
+title: "Ambiguity Resolution in ACTS"
+speaker: Irina Ene
+focus_areas: 
+projects: 
+date: 2020-09-02
+startsec: 34
+url: https://www.youtube.com/embed/CAZtQIZ1-wE

--- a/_data/videos/CAZtQIZ1-wE_0.yml
+++ b/_data/videos/CAZtQIZ1-wE_0.yml
@@ -1,7 +1,7 @@
 title: "Ambiguity Resolution in ACTS"
 speaker: Irina Ene
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-02
 startsec: 34
 url: https://www.youtube.com/embed/CAZtQIZ1-wE

--- a/_data/videos/CAZtQIZ1-wE_1.yml
+++ b/_data/videos/CAZtQIZ1-wE_1.yml
@@ -1,0 +1,7 @@
+title: "Modernizing Boost in CMSSW"
+speaker: Lucas Camolez
+focus_areas: 
+projects: 
+date: 2020-09-02
+startsec: 1891
+url: https://www.youtube.com/embed/CAZtQIZ1-wE

--- a/_data/videos/CAZtQIZ1-wE_1.yml
+++ b/_data/videos/CAZtQIZ1-wE_1.yml
@@ -1,7 +1,7 @@
 title: "Modernizing Boost in CMSSW"
 speaker: Lucas Camolez
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-02
 startsec: 1891
 url: https://www.youtube.com/embed/CAZtQIZ1-wE

--- a/_data/videos/HEGDII5lAfo_0.yml
+++ b/_data/videos/HEGDII5lAfo_0.yml
@@ -1,7 +1,7 @@
 title: "Cling’s CUDA Backend: Interactive GPU development with CUDA C++"
 speaker: Simeon Ehrig
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2030-12-31
 startsec: 0
 url: https://www.youtube.com/embed/HEGDII5lAfo

--- a/_data/videos/HEGDII5lAfo_0.yml
+++ b/_data/videos/HEGDII5lAfo_0.yml
@@ -1,0 +1,7 @@
+title: "Cling’s CUDA Backend: Interactive GPU development with CUDA C++"
+speaker: Simeon Ehrig
+focus_areas: 
+projects: 
+date: 2030-12-31
+startsec: 0
+url: https://www.youtube.com/embed/HEGDII5lAfo

--- a/_data/videos/Hr0bq2Q31Zc_0.yml
+++ b/_data/videos/Hr0bq2Q31Zc_0.yml
@@ -1,0 +1,7 @@
+title: "Allen project @ LHCb"
+speaker: Daniel Craik
+focus_areas: 
+projects: 
+date: 2020-01-27
+startsec: 0
+url: https://www.youtube.com/embed/Hr0bq2Q31Zc

--- a/_data/videos/Hr0bq2Q31Zc_0.yml
+++ b/_data/videos/Hr0bq2Q31Zc_0.yml
@@ -1,7 +1,7 @@
 title: "Allen project @ LHCb"
 speaker: Daniel Craik
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-01-27
 startsec: 0
 url: https://www.youtube.com/embed/Hr0bq2Q31Zc

--- a/_data/videos/K17B-TZC6-Q_0.yml
+++ b/_data/videos/K17B-TZC6-Q_0.yml
@@ -1,0 +1,7 @@
+title: "Initial Studies of ACTS tracking on GPUs"
+speaker: Xiaocong Ai
+focus_areas: 
+projects: 
+date: 2020-08-26
+startsec: 0
+url: https://www.youtube.com/embed/K17B-TZC6-Q

--- a/_data/videos/K17B-TZC6-Q_0.yml
+++ b/_data/videos/K17B-TZC6-Q_0.yml
@@ -1,7 +1,7 @@
 title: "Initial Studies of ACTS tracking on GPUs"
 speaker: Xiaocong Ai
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-08-26
 startsec: 0
 url: https://www.youtube.com/embed/K17B-TZC6-Q

--- a/_data/videos/K17B-TZC6-Q_1.yml
+++ b/_data/videos/K17B-TZC6-Q_1.yml
@@ -1,7 +1,7 @@
 title: "Questions and Comments"
-speaker: 
-focus_areas: 
-projects: 
+speaker:
+focus_areas:
+projects:
 date: 2020-08-26
 startsec: 1772
 url: https://www.youtube.com/embed/K17B-TZC6-Q

--- a/_data/videos/K17B-TZC6-Q_1.yml
+++ b/_data/videos/K17B-TZC6-Q_1.yml
@@ -1,0 +1,7 @@
+title: "Questions and Comments"
+speaker: 
+focus_areas: 
+projects: 
+date: 2020-08-26
+startsec: 1772
+url: https://www.youtube.com/embed/K17B-TZC6-Q

--- a/_data/videos/NJHEPV4Etmg_0.yml
+++ b/_data/videos/NJHEPV4Etmg_0.yml
@@ -1,7 +1,7 @@
 title: "Extending JAX with CUDA"
 speaker: Daniel Foreman-Mackey
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-02-01
 startsec: 0
 url: https://www.youtube.com/embed/NJHEPV4Etmg

--- a/_data/videos/NJHEPV4Etmg_0.yml
+++ b/_data/videos/NJHEPV4Etmg_0.yml
@@ -1,0 +1,7 @@
+title: "Extending JAX with CUDA"
+speaker: Daniel Foreman-Mackey
+focus_areas: 
+projects: 
+date: 2021-02-01
+startsec: 0
+url: https://www.youtube.com/embed/NJHEPV4Etmg

--- a/_data/videos/QNqxuuz3pE8_0.yml
+++ b/_data/videos/QNqxuuz3pE8_0.yml
@@ -1,0 +1,7 @@
+title: "Analysis Description Languages"
+speaker: Harrison Prosper
+focus_areas: 
+projects: 
+date: 2019-02-25
+startsec: 0
+url: https://www.youtube.com/embed/QNqxuuz3pE8

--- a/_data/videos/QNqxuuz3pE8_0.yml
+++ b/_data/videos/QNqxuuz3pE8_0.yml
@@ -1,7 +1,7 @@
 title: "Analysis Description Languages"
 speaker: Harrison Prosper
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-02-25
 startsec: 0
 url: https://www.youtube.com/embed/QNqxuuz3pE8

--- a/_data/videos/QNqxuuz3pE8_1.yml
+++ b/_data/videos/QNqxuuz3pE8_1.yml
@@ -1,0 +1,7 @@
+title: "Declarative analysis with LINQ"
+speaker: Gordon Watts
+focus_areas: 
+projects: 
+date: 2019-02-25
+startsec: 2606
+url: https://www.youtube.com/embed/QNqxuuz3pE8

--- a/_data/videos/QNqxuuz3pE8_1.yml
+++ b/_data/videos/QNqxuuz3pE8_1.yml
@@ -1,7 +1,7 @@
 title: "Declarative analysis with LINQ"
 speaker: Gordon Watts
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-02-25
 startsec: 2606
 url: https://www.youtube.com/embed/QNqxuuz3pE8

--- a/_data/videos/SFYAIzDFta8_0.yml
+++ b/_data/videos/SFYAIzDFta8_0.yml
@@ -1,0 +1,7 @@
+title: "Integration of C++ Modules into CMSSW"
+speaker: Yuka Takahashi
+focus_areas: 
+projects: 
+date: 2019-02-18
+startsec: 0
+url: https://www.youtube.com/embed/SFYAIzDFta8

--- a/_data/videos/SFYAIzDFta8_0.yml
+++ b/_data/videos/SFYAIzDFta8_0.yml
@@ -1,7 +1,7 @@
 title: "Integration of C++ Modules into CMSSW"
 speaker: Yuka Takahashi
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-02-18
 startsec: 0
 url: https://www.youtube.com/embed/SFYAIzDFta8

--- a/_data/videos/Tpy6AR-lTlg_0.yml
+++ b/_data/videos/Tpy6AR-lTlg_0.yml
@@ -1,7 +1,7 @@
 title: "Graph Neural Networks Architectures"
 speaker: Markus Atkinson
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-10-21
 startsec: 0
 url: https://www.youtube.com/embed/Tpy6AR-lTlg

--- a/_data/videos/Tpy6AR-lTlg_0.yml
+++ b/_data/videos/Tpy6AR-lTlg_0.yml
@@ -1,0 +1,7 @@
+title: "Graph Neural Networks Architectures"
+speaker: Markus Atkinson
+focus_areas: 
+projects: 
+date: 2020-10-21
+startsec: 0
+url: https://www.youtube.com/embed/Tpy6AR-lTlg

--- a/_data/videos/Tpy6AR-lTlg_1.yml
+++ b/_data/videos/Tpy6AR-lTlg_1.yml
@@ -1,7 +1,7 @@
 title: "Tracking with GNNs on FPGAs"
 speaker: Javier Duarte
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-10-21
 startsec: 1589
 url: https://www.youtube.com/embed/Tpy6AR-lTlg

--- a/_data/videos/Tpy6AR-lTlg_1.yml
+++ b/_data/videos/Tpy6AR-lTlg_1.yml
@@ -1,0 +1,7 @@
+title: "Tracking with GNNs on FPGAs"
+speaker: Javier Duarte
+focus_areas: 
+projects: 
+date: 2020-10-21
+startsec: 1589
+url: https://www.youtube.com/embed/Tpy6AR-lTlg

--- a/_data/videos/XaCn2Gk2-eg_0.yml
+++ b/_data/videos/XaCn2Gk2-eg_0.yml
@@ -1,0 +1,7 @@
+title: "Hyperparameter Optimisation service at ATLAS"
+speaker: Rui Zhang
+focus_areas: 
+projects: 
+date: 2021-03-03
+startsec: 0
+url: https://www.youtube.com/embed/XaCn2Gk2-eg

--- a/_data/videos/XaCn2Gk2-eg_0.yml
+++ b/_data/videos/XaCn2Gk2-eg_0.yml
@@ -1,7 +1,7 @@
 title: "Hyperparameter Optimisation service at ATLAS"
 speaker: Rui Zhang
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-03-03
 startsec: 0
 url: https://www.youtube.com/embed/XaCn2Gk2-eg

--- a/_data/videos/XaCn2Gk2-eg_1.yml
+++ b/_data/videos/XaCn2Gk2-eg_1.yml
@@ -1,7 +1,7 @@
 title: "Towards cross-platform performance portability of random number generation in SYCL"
 speaker: Vincent Pascuzzi
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-03-03
 startsec: 2203
 url: https://www.youtube.com/embed/XaCn2Gk2-eg

--- a/_data/videos/XaCn2Gk2-eg_1.yml
+++ b/_data/videos/XaCn2Gk2-eg_1.yml
@@ -1,0 +1,7 @@
+title: "Towards cross-platform performance portability of random number generation in SYCL"
+speaker: Vincent Pascuzzi
+focus_areas: 
+projects: 
+date: 2021-03-03
+startsec: 2203
+url: https://www.youtube.com/embed/XaCn2Gk2-eg

--- a/_data/videos/_fB2aUbQwV8_0.yml
+++ b/_data/videos/_fB2aUbQwV8_0.yml
@@ -1,0 +1,7 @@
+title: "intelligent Data Delivery Service"
+speaker: Wen Guan
+focus_areas: 
+projects: 
+date: 2021-03-29
+startsec: 0
+url: https://www.youtube.com/embed/_fB2aUbQwV8

--- a/_data/videos/_fB2aUbQwV8_0.yml
+++ b/_data/videos/_fB2aUbQwV8_0.yml
@@ -1,7 +1,7 @@
 title: "intelligent Data Delivery Service"
 speaker: Wen Guan
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-03-29
 startsec: 0
 url: https://www.youtube.com/embed/_fB2aUbQwV8

--- a/_data/videos/a4N_iY5fhmw_0.yml
+++ b/_data/videos/a4N_iY5fhmw_0.yml
@@ -1,0 +1,7 @@
+title: "ATLAS Fast Calorimeter Simulation"
+speaker: Jana Schaarschmidt
+focus_areas: 
+projects: 
+date: 2021-03-31
+startsec: 0
+url: https://www.youtube.com/embed/a4N_iY5fhmw

--- a/_data/videos/a4N_iY5fhmw_0.yml
+++ b/_data/videos/a4N_iY5fhmw_0.yml
@@ -1,7 +1,7 @@
 title: "ATLAS Fast Calorimeter Simulation"
 speaker: Jana Schaarschmidt
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-03-31
 startsec: 0
 url: https://www.youtube.com/embed/a4N_iY5fhmw

--- a/_data/videos/a4N_iY5fhmw_1.yml
+++ b/_data/videos/a4N_iY5fhmw_1.yml
@@ -1,7 +1,7 @@
 title: "Accelerating End-To-End DL Reconstruction for CMS"
 speaker: Davide Di Croce
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-03-31
 startsec: 1477
 url: https://www.youtube.com/embed/a4N_iY5fhmw

--- a/_data/videos/a4N_iY5fhmw_1.yml
+++ b/_data/videos/a4N_iY5fhmw_1.yml
@@ -1,0 +1,7 @@
+title: "Accelerating End-To-End DL Reconstruction for CMS"
+speaker: Davide Di Croce
+focus_areas: 
+projects: 
+date: 2021-03-31
+startsec: 1477
+url: https://www.youtube.com/embed/a4N_iY5fhmw

--- a/_data/videos/ajcqHESGAQY_0.yml
+++ b/_data/videos/ajcqHESGAQY_0.yml
@@ -1,7 +1,7 @@
 title: "Accelerating Graph Neural Networks on CPU + FPGA co-processors for scalable track reconstruction tasks"
 speaker: Aneesh Heintz
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-10-14
 startsec: 0
 url: https://www.youtube.com/embed/ajcqHESGAQY

--- a/_data/videos/ajcqHESGAQY_0.yml
+++ b/_data/videos/ajcqHESGAQY_0.yml
@@ -1,0 +1,7 @@
+title: "Accelerating Graph Neural Networks on CPU + FPGA co-processors for scalable track reconstruction tasks"
+speaker: Aneesh Heintz
+focus_areas: 
+projects: 
+date: 2020-10-14
+startsec: 0
+url: https://www.youtube.com/embed/ajcqHESGAQY

--- a/_data/videos/ajcqHESGAQY_1.yml
+++ b/_data/videos/ajcqHESGAQY_1.yml
@@ -1,7 +1,7 @@
 title: "SkyhookDM projection-only pushdown and Arrow dataset integration into Skyhook objects"
 speaker: Xiongfeng Song
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-10-14
 startsec: 1180
 url: https://www.youtube.com/embed/ajcqHESGAQY

--- a/_data/videos/ajcqHESGAQY_1.yml
+++ b/_data/videos/ajcqHESGAQY_1.yml
@@ -1,0 +1,7 @@
+title: "SkyhookDM projection-only pushdown and Arrow dataset integration into Skyhook objects"
+speaker: Xiongfeng Song
+focus_areas: 
+projects: 
+date: 2020-10-14
+startsec: 1180
+url: https://www.youtube.com/embed/ajcqHESGAQY

--- a/_data/videos/b2z8d2tWqcE_0.yml
+++ b/_data/videos/b2z8d2tWqcE_0.yml
@@ -1,7 +1,7 @@
 title: "Particles and decays in the Scikit-HEP project"
 speaker: Eduardo Rodrigues
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-05-13
 startsec: 0
 url: https://www.youtube.com/embed/b2z8d2tWqcE

--- a/_data/videos/b2z8d2tWqcE_0.yml
+++ b/_data/videos/b2z8d2tWqcE_0.yml
@@ -1,0 +1,7 @@
+title: "Particles and decays in the Scikit-HEP project"
+speaker: Eduardo Rodrigues
+focus_areas: 
+projects: 
+date: 2019-05-13
+startsec: 0
+url: https://www.youtube.com/embed/b2z8d2tWqcE

--- a/_data/videos/b2z8d2tWqcE_1.yml
+++ b/_data/videos/b2z8d2tWqcE_1.yml
@@ -1,7 +1,7 @@
 title: "Live demos"
 speaker: Eduardo Rodrigues
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-05-13
 startsec: 1180
 url: https://www.youtube.com/embed/b2z8d2tWqcE

--- a/_data/videos/b2z8d2tWqcE_1.yml
+++ b/_data/videos/b2z8d2tWqcE_1.yml
@@ -1,0 +1,7 @@
+title: "Live demos"
+speaker: Eduardo Rodrigues
+focus_areas: 
+projects: 
+date: 2019-05-13
+startsec: 1180
+url: https://www.youtube.com/embed/b2z8d2tWqcE

--- a/_data/videos/b4iMNk2m-Dc_0.yml
+++ b/_data/videos/b4iMNk2m-Dc_0.yml
@@ -1,7 +1,7 @@
 title: "Particle decay classifiers for the LHCb Run 3 first"
 speaker: Sean Condon
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-28
 startsec: 0
 url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/b4iMNk2m-Dc_0.yml
+++ b/_data/videos/b4iMNk2m-Dc_0.yml
@@ -1,0 +1,7 @@
+title: "Particle decay classifiers for the LHCb Run 3 first"
+speaker: Sean Condon
+focus_areas: 
+projects: 
+date: 2020-09-28
+startsec: 0
+url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/b4iMNk2m-Dc_1.yml
+++ b/_data/videos/b4iMNk2m-Dc_1.yml
@@ -1,7 +1,7 @@
 title: "Graph Neural Networks for Particle Tracking in FPGAs with hls4m"
 speaker: Vesal Razavimaleki
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-28
 startsec: 845
 url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/b4iMNk2m-Dc_1.yml
+++ b/_data/videos/b4iMNk2m-Dc_1.yml
@@ -1,0 +1,7 @@
+title: "Graph Neural Networks for Particle Tracking in FPGAs with hls4m"
+speaker: Vesal Razavimaleki
+focus_areas: 
+projects: 
+date: 2020-09-28
+startsec: 845
+url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/b4iMNk2m-Dc_2.yml
+++ b/_data/videos/b4iMNk2m-Dc_2.yml
@@ -1,0 +1,7 @@
+title: "Proactive Site Monitoring"
+speaker: Suhaib Shaikh
+focus_areas: 
+projects: 
+date: 2020-09-28
+startsec: 2097
+url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/b4iMNk2m-Dc_2.yml
+++ b/_data/videos/b4iMNk2m-Dc_2.yml
@@ -1,7 +1,7 @@
 title: "Proactive Site Monitoring"
 speaker: Suhaib Shaikh
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-28
 startsec: 2097
 url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/b4iMNk2m-Dc_3.yml
+++ b/_data/videos/b4iMNk2m-Dc_3.yml
@@ -1,7 +1,7 @@
 title: "Anomaly Detection using VAEs, Normalizing Flows for New Physics Searches"
 speaker: Pratik Jawahar
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-28
 startsec: 2849
 url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/b4iMNk2m-Dc_3.yml
+++ b/_data/videos/b4iMNk2m-Dc_3.yml
@@ -1,0 +1,7 @@
+title: "Anomaly Detection using VAEs, Normalizing Flows for New Physics Searches"
+speaker: Pratik Jawahar
+focus_areas: 
+projects: 
+date: 2020-09-28
+startsec: 2849
+url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/c8FEyWP0dWc_0.yml
+++ b/_data/videos/c8FEyWP0dWc_0.yml
@@ -1,0 +1,7 @@
+title: "Introduction to modern CDN Architectures"
+speaker: John Dilley
+focus_areas: 
+projects: 
+date: 2019-03-25
+startsec: 0
+url: https://www.youtube.com/embed/c8FEyWP0dWc

--- a/_data/videos/c8FEyWP0dWc_0.yml
+++ b/_data/videos/c8FEyWP0dWc_0.yml
@@ -1,7 +1,7 @@
 title: "Introduction to modern CDN Architectures"
 speaker: John Dilley
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-03-25
 startsec: 0
 url: https://www.youtube.com/embed/c8FEyWP0dWc

--- a/_data/videos/dbUQZbtfNfk_0.yml
+++ b/_data/videos/dbUQZbtfNfk_0.yml
@@ -1,0 +1,7 @@
+title: "Rumble"
+speaker: Ghislain Fourny and Ingo Mueller
+focus_areas: 
+projects: 
+date: 2020-05-04
+startsec: 0
+url: https://www.youtube.com/embed/dbUQZbtfNfk

--- a/_data/videos/dbUQZbtfNfk_0.yml
+++ b/_data/videos/dbUQZbtfNfk_0.yml
@@ -1,7 +1,7 @@
 title: "Rumble"
 speaker: Ghislain Fourny and Ingo Mueller
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-05-04
 startsec: 0
 url: https://www.youtube.com/embed/dbUQZbtfNfk

--- a/_data/videos/gOVg4qvyw0w_0.yml
+++ b/_data/videos/gOVg4qvyw0w_0.yml
@@ -1,0 +1,7 @@
+title: "Graph Networks for Tracking"
+speaker: Savannah Thais
+focus_areas: 
+projects: 
+date: 2021-03-01
+startsec: 0
+url: https://www.youtube.com/embed/gOVg4qvyw0w

--- a/_data/videos/gOVg4qvyw0w_0.yml
+++ b/_data/videos/gOVg4qvyw0w_0.yml
@@ -1,7 +1,7 @@
 title: "Graph Networks for Tracking"
 speaker: Savannah Thais
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-03-01
 startsec: 0
 url: https://www.youtube.com/embed/gOVg4qvyw0w

--- a/_data/videos/gOVg4qvyw0w_1.yml
+++ b/_data/videos/gOVg4qvyw0w_1.yml
@@ -1,7 +1,7 @@
 title: "Sherpa performence study - Glibc"
 speaker: Rui Wang
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-03-01
 startsec: 1927
 url: https://www.youtube.com/embed/gOVg4qvyw0w

--- a/_data/videos/gOVg4qvyw0w_1.yml
+++ b/_data/videos/gOVg4qvyw0w_1.yml
@@ -1,0 +1,7 @@
+title: "Sherpa performence study - Glibc"
+speaker: Rui Wang
+focus_areas: 
+projects: 
+date: 2021-03-01
+startsec: 1927
+url: https://www.youtube.com/embed/gOVg4qvyw0w

--- a/_data/videos/hIiEu7XFu5Y_0.yml
+++ b/_data/videos/hIiEu7XFu5Y_0.yml
@@ -1,7 +1,7 @@
 title: "Testing Bitshuffle compression algorithm preconditioner in ROOT I/O"
 speaker: Keisuke Kamahori
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-08
 startsec: 0
 url: https://www.youtube.com/embed/hIiEu7XFu5Y

--- a/_data/videos/hIiEu7XFu5Y_0.yml
+++ b/_data/videos/hIiEu7XFu5Y_0.yml
@@ -1,0 +1,7 @@
+title: "Testing Bitshuffle compression algorithm preconditioner in ROOT I/O"
+speaker: Keisuke Kamahori
+focus_areas: 
+projects: 
+date: 2020-09-08
+startsec: 0
+url: https://www.youtube.com/embed/hIiEu7XFu5Y

--- a/_data/videos/hIiEu7XFu5Y_1.yml
+++ b/_data/videos/hIiEu7XFu5Y_1.yml
@@ -1,7 +1,7 @@
 title: "Enabling C++ Modules For ROOT on Windows"
 speaker: Vaibhav Garg
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-08
 startsec: 1054
 url: https://www.youtube.com/embed/hIiEu7XFu5Y

--- a/_data/videos/hIiEu7XFu5Y_1.yml
+++ b/_data/videos/hIiEu7XFu5Y_1.yml
@@ -1,0 +1,7 @@
+title: "Enabling C++ Modules For ROOT on Windows"
+speaker: Vaibhav Garg
+focus_areas: 
+projects: 
+date: 2020-09-08
+startsec: 1054
+url: https://www.youtube.com/embed/hIiEu7XFu5Y

--- a/_data/videos/hIiEu7XFu5Y_2.yml
+++ b/_data/videos/hIiEu7XFu5Y_2.yml
@@ -1,7 +1,7 @@
 title: "Hist: histogramming for analysis powered by boost-histogram"
 speaker: Shuo Liu
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-08
 startsec: 2040
 url: https://www.youtube.com/embed/hIiEu7XFu5Y

--- a/_data/videos/hIiEu7XFu5Y_2.yml
+++ b/_data/videos/hIiEu7XFu5Y_2.yml
@@ -1,0 +1,7 @@
+title: "Hist: histogramming for analysis powered by boost-histogram"
+speaker: Shuo Liu
+focus_areas: 
+projects: 
+date: 2020-09-08
+startsec: 2040
+url: https://www.youtube.com/embed/hIiEu7XFu5Y

--- a/_data/videos/kx3wvKk4Qss_0.yml
+++ b/_data/videos/kx3wvKk4Qss_0.yml
@@ -1,0 +1,7 @@
+title: "Deep dive into the Xeus-based Cling kernel for Jupyter"
+speaker: Sylvain Corlay
+focus_areas: 
+projects: 
+date: 2030-12-31
+startsec: 0
+url: https://www.youtube.com/embed/kx3wvKk4Qss

--- a/_data/videos/kx3wvKk4Qss_0.yml
+++ b/_data/videos/kx3wvKk4Qss_0.yml
@@ -1,7 +1,7 @@
 title: "Deep dive into the Xeus-based Cling kernel for Jupyter"
 speaker: Sylvain Corlay
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2030-12-31
 startsec: 0
 url: https://www.youtube.com/embed/kx3wvKk4Qss

--- a/_data/videos/q9bPLxZ9xY4_0.yml
+++ b/_data/videos/q9bPLxZ9xY4_0.yml
@@ -1,7 +1,7 @@
 title: "Parallelized Kalman-Filter-Based Reconstruction of Particle Tracks on Many-Core Architectures"
 speaker: Allison Reinsvold Hall
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-04-10
 startsec: 0
 url: https://www.youtube.com/embed/q9bPLxZ9xY4

--- a/_data/videos/q9bPLxZ9xY4_0.yml
+++ b/_data/videos/q9bPLxZ9xY4_0.yml
@@ -1,0 +1,7 @@
+title: "Parallelized Kalman-Filter-Based Reconstruction of Particle Tracks on Many-Core Architectures"
+speaker: Allison Reinsvold Hall
+focus_areas: 
+projects: 
+date: 2019-04-10
+startsec: 0
+url: https://www.youtube.com/embed/q9bPLxZ9xY4

--- a/_data/videos/qFgQQgMDxMo_0.yml
+++ b/_data/videos/qFgQQgMDxMo_0.yml
@@ -1,0 +1,7 @@
+title: "Fast Calorimeter Simulation on GPU"
+speaker: Ke Li
+focus_areas: 
+projects: 
+date: 2021-03-24
+startsec: 0
+url: https://www.youtube.com/embed/qFgQQgMDxMo

--- a/_data/videos/qFgQQgMDxMo_0.yml
+++ b/_data/videos/qFgQQgMDxMo_0.yml
@@ -1,7 +1,7 @@
 title: "Fast Calorimeter Simulation on GPU"
 speaker: Ke Li
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-03-24
 startsec: 0
 url: https://www.youtube.com/embed/qFgQQgMDxMo

--- a/_data/videos/qFgQQgMDxMo_1.yml
+++ b/_data/videos/qFgQQgMDxMo_1.yml
@@ -1,7 +1,7 @@
 title: "Track Seed Finding in ACTS"
 speaker: Tomohiro Yamazaki
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-03-24
 startsec: 1564
 url: https://www.youtube.com/embed/qFgQQgMDxMo

--- a/_data/videos/qFgQQgMDxMo_1.yml
+++ b/_data/videos/qFgQQgMDxMo_1.yml
@@ -1,0 +1,7 @@
+title: "Track Seed Finding in ACTS"
+speaker: Tomohiro Yamazaki
+focus_areas: 
+projects: 
+date: 2021-03-24
+startsec: 1564
+url: https://www.youtube.com/embed/qFgQQgMDxMo

--- a/_data/videos/qrFOC7FvN7Q_0.yml
+++ b/_data/videos/qrFOC7FvN7Q_0.yml
@@ -1,7 +1,7 @@
 title: "FAIR Framework for Physics-Inspired AI in HEP"
 speaker: Javier Duarte
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-04-21
 startsec: 0
 url: https://www.youtube.com/embed/qrFOC7FvN7Q

--- a/_data/videos/qrFOC7FvN7Q_0.yml
+++ b/_data/videos/qrFOC7FvN7Q_0.yml
@@ -1,0 +1,7 @@
+title: "FAIR Framework for Physics-Inspired AI in HEP"
+speaker: Javier Duarte
+focus_areas: 
+projects: 
+date: 2021-04-21
+startsec: 0
+url: https://www.youtube.com/embed/qrFOC7FvN7Q

--- a/_data/videos/qrFOC7FvN7Q_1.yml
+++ b/_data/videos/qrFOC7FvN7Q_1.yml
@@ -1,7 +1,7 @@
 title: "ILC Software & Computing"
 speaker: Jan Strube
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2021-04-21
 startsec: 2007
 url: https://www.youtube.com/embed/qrFOC7FvN7Q

--- a/_data/videos/qrFOC7FvN7Q_1.yml
+++ b/_data/videos/qrFOC7FvN7Q_1.yml
@@ -1,0 +1,7 @@
+title: "ILC Software & Computing"
+speaker: Jan Strube
+focus_areas: 
+projects: 
+date: 2021-04-21
+startsec: 2007
+url: https://www.youtube.com/embed/qrFOC7FvN7Q

--- a/_data/videos/sATu_MJo8L4_0.yml
+++ b/_data/videos/sATu_MJo8L4_0.yml
@@ -1,7 +1,7 @@
 title: "zfp compression on a CMS NanoAOD"
 speaker: Erik Wallin
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-21
 startsec: 0
 url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/sATu_MJo8L4_0.yml
+++ b/_data/videos/sATu_MJo8L4_0.yml
@@ -1,0 +1,7 @@
+title: "zfp compression on a CMS NanoAOD"
+speaker: Erik Wallin
+focus_areas: 
+projects: 
+date: 2020-09-21
+startsec: 0
+url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/sATu_MJo8L4_1.yml
+++ b/_data/videos/sATu_MJo8L4_1.yml
@@ -1,0 +1,7 @@
+title: "Recast"
+speaker: Vladimir Ovechkin
+focus_areas: 
+projects: 
+date: 2020-09-21
+startsec: 1016
+url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/sATu_MJo8L4_1.yml
+++ b/_data/videos/sATu_MJo8L4_1.yml
@@ -1,7 +1,7 @@
 title: "Recast"
 speaker: Vladimir Ovechkin
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-21
 startsec: 1016
 url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/sATu_MJo8L4_2.yml
+++ b/_data/videos/sATu_MJo8L4_2.yml
@@ -1,0 +1,7 @@
+title: "Improving the OSG"
+speaker: Tommy Shearer
+focus_areas: 
+projects: 
+date: 2020-09-21
+startsec: 1782
+url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/sATu_MJo8L4_2.yml
+++ b/_data/videos/sATu_MJo8L4_2.yml
@@ -1,7 +1,7 @@
 title: "Improving the OSG"
 speaker: Tommy Shearer
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-21
 startsec: 1782
 url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/sATu_MJo8L4_3.yml
+++ b/_data/videos/sATu_MJo8L4_3.yml
@@ -1,0 +1,7 @@
+title: "ServiceX: Backend Tests"
+speaker: David Liu
+focus_areas: 
+projects: 
+date: 2020-09-21
+startsec: 2789
+url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/sATu_MJo8L4_3.yml
+++ b/_data/videos/sATu_MJo8L4_3.yml
@@ -1,7 +1,7 @@
 title: "ServiceX: Backend Tests"
 speaker: David Liu
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-09-21
 startsec: 2789
 url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/tpjp6lhU7Us_0.yml
+++ b/_data/videos/tpjp6lhU7Us_0.yml
@@ -1,0 +1,7 @@
+title: "ACTS - A Common Track Software"
+speaker: Paul Gessinger
+focus_areas: 
+projects: 
+date: 2019-07-31
+startsec: 0
+url: https://www.youtube.com/embed/tpjp6lhU7Us

--- a/_data/videos/tpjp6lhU7Us_0.yml
+++ b/_data/videos/tpjp6lhU7Us_0.yml
@@ -1,7 +1,7 @@
 title: "ACTS - A Common Track Software"
 speaker: Paul Gessinger
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-07-31
 startsec: 0
 url: https://www.youtube.com/embed/tpjp6lhU7Us

--- a/_data/videos/uJNFaDsIByY_0.yml
+++ b/_data/videos/uJNFaDsIByY_0.yml
@@ -1,7 +1,7 @@
 title: "Awkward Array: Numba"
 speaker: Jim Pivarski
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-04-17
 startsec: 0
 url: https://www.youtube.com/embed/uJNFaDsIByY

--- a/_data/videos/uJNFaDsIByY_0.yml
+++ b/_data/videos/uJNFaDsIByY_0.yml
@@ -1,0 +1,7 @@
+title: "Awkward Array: Numba"
+speaker: Jim Pivarski
+focus_areas: 
+projects: 
+date: 2019-04-17
+startsec: 0
+url: https://www.youtube.com/embed/uJNFaDsIByY

--- a/_data/videos/uJNFaDsIByY_1.yml
+++ b/_data/videos/uJNFaDsIByY_1.yml
@@ -1,0 +1,7 @@
+title: "Awkward Array: Pandas"
+speaker: Michael Hedges
+focus_areas: 
+projects: 
+date: 2019-04-17
+startsec: 1611
+url: https://www.youtube.com/embed/uJNFaDsIByY

--- a/_data/videos/uJNFaDsIByY_1.yml
+++ b/_data/videos/uJNFaDsIByY_1.yml
@@ -1,7 +1,7 @@
 title: "Awkward Array: Pandas"
 speaker: Michael Hedges
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-04-17
 startsec: 1611
 url: https://www.youtube.com/embed/uJNFaDsIByY

--- a/_data/videos/uJNFaDsIByY_2.yml
+++ b/_data/videos/uJNFaDsIByY_2.yml
@@ -1,0 +1,7 @@
+title: "FCAT: Coffea"
+speaker: Lindsey Gray
+focus_areas: 
+projects: 
+date: 2019-04-17
+startsec: 2843
+url: https://www.youtube.com/embed/uJNFaDsIByY

--- a/_data/videos/uJNFaDsIByY_2.yml
+++ b/_data/videos/uJNFaDsIByY_2.yml
@@ -1,7 +1,7 @@
 title: "FCAT: Coffea"
 speaker: Lindsey Gray
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-04-17
 startsec: 2843
 url: https://www.youtube.com/embed/uJNFaDsIByY

--- a/_data/videos/wPpy08ZjdNY_0.yml
+++ b/_data/videos/wPpy08ZjdNY_0.yml
@@ -1,0 +1,7 @@
+title: "Enhancements to ROOT performance benchmarking"
+speaker: Lilit Harutyunyan
+focus_areas: 
+projects: 
+date: 2019-08-19
+startsec: 0
+url: https://www.youtube.com/embed/wPpy08ZjdNY

--- a/_data/videos/wPpy08ZjdNY_0.yml
+++ b/_data/videos/wPpy08ZjdNY_0.yml
@@ -1,7 +1,7 @@
 title: "Enhancements to ROOT performance benchmarking"
 speaker: Lilit Harutyunyan
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-08-19
 startsec: 0
 url: https://www.youtube.com/embed/wPpy08ZjdNY

--- a/_data/videos/wPpy08ZjdNY_1.yml
+++ b/_data/videos/wPpy08ZjdNY_1.yml
@@ -1,0 +1,7 @@
+title: "Integration of ZSTD compression algorithm into ROOT"
+speaker: Alfonso Castano
+focus_areas: 
+projects: 
+date: 2019-08-19
+startsec: 977
+url: https://www.youtube.com/embed/wPpy08ZjdNY

--- a/_data/videos/wPpy08ZjdNY_1.yml
+++ b/_data/videos/wPpy08ZjdNY_1.yml
@@ -1,7 +1,7 @@
 title: "Integration of ZSTD compression algorithm into ROOT"
 speaker: Alfonso Castano
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-08-19
 startsec: 977
 url: https://www.youtube.com/embed/wPpy08ZjdNY

--- a/_data/videos/wPpy08ZjdNY_2.yml
+++ b/_data/videos/wPpy08ZjdNY_2.yml
@@ -1,0 +1,7 @@
+title: "AwkwardCpp"
+speaker: Charles Escott
+focus_areas: 
+projects: 
+date: 2019-08-19
+startsec: 2390
+url: https://www.youtube.com/embed/wPpy08ZjdNY

--- a/_data/videos/wPpy08ZjdNY_2.yml
+++ b/_data/videos/wPpy08ZjdNY_2.yml
@@ -1,7 +1,7 @@
 title: "AwkwardCpp"
 speaker: Charles Escott
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-08-19
 startsec: 2390
 url: https://www.youtube.com/embed/wPpy08ZjdNY

--- a/_data/videos/wzN_rT-l1S0_0.yml
+++ b/_data/videos/wzN_rT-l1S0_0.yml
@@ -1,0 +1,7 @@
+title: "CLAD"
+speaker: Jack Qiu
+focus_areas: 
+projects: 
+date: 2019-08-21
+startsec: 0
+url: https://www.youtube.com/embed/wzN_rT-l1S0

--- a/_data/videos/wzN_rT-l1S0_0.yml
+++ b/_data/videos/wzN_rT-l1S0_0.yml
@@ -1,7 +1,7 @@
 title: "CLAD"
 speaker: Jack Qiu
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-08-21
 startsec: 0
 url: https://www.youtube.com/embed/wzN_rT-l1S0

--- a/_data/videos/wzN_rT-l1S0_1.yml
+++ b/_data/videos/wzN_rT-l1S0_1.yml
@@ -1,7 +1,7 @@
 title: "ROOT modules"
 speaker: Arpitha Raghunandan
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-08-21
 startsec: 1146
 url: https://www.youtube.com/embed/wzN_rT-l1S0

--- a/_data/videos/wzN_rT-l1S0_1.yml
+++ b/_data/videos/wzN_rT-l1S0_1.yml
@@ -1,0 +1,7 @@
+title: "ROOT modules"
+speaker: Arpitha Raghunandan
+focus_areas: 
+projects: 
+date: 2019-08-21
+startsec: 1146
+url: https://www.youtube.com/embed/wzN_rT-l1S0

--- a/_data/videos/wzN_rT-l1S0_2.yml
+++ b/_data/videos/wzN_rT-l1S0_2.yml
@@ -1,0 +1,7 @@
+title: "Fast HGCAL Simulation with Graph Networks"
+speaker: Raghav Kansal
+focus_areas: 
+projects: 
+date: 2019-08-21
+startsec: 2614
+url: https://www.youtube.com/embed/wzN_rT-l1S0

--- a/_data/videos/wzN_rT-l1S0_2.yml
+++ b/_data/videos/wzN_rT-l1S0_2.yml
@@ -1,7 +1,7 @@
 title: "Fast HGCAL Simulation with Graph Networks"
 speaker: Raghav Kansal
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-08-21
 startsec: 2614
 url: https://www.youtube.com/embed/wzN_rT-l1S0

--- a/_data/videos/y9eTBaVy43M_0.yml
+++ b/_data/videos/y9eTBaVy43M_0.yml
@@ -1,0 +1,7 @@
+title: "Accelerating Raw Data Analysis with ACCORDA"
+speaker: Chen Zou
+focus_areas: 
+projects: 
+date: 2020-05-11
+startsec: 0
+url: https://www.youtube.com/embed/y9eTBaVy43M

--- a/_data/videos/y9eTBaVy43M_0.yml
+++ b/_data/videos/y9eTBaVy43M_0.yml
@@ -1,7 +1,7 @@
 title: "Accelerating Raw Data Analysis with ACCORDA"
 speaker: Chen Zou
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-05-11
 startsec: 0
 url: https://www.youtube.com/embed/y9eTBaVy43M

--- a/_data/videos/yjlzO5oXb1w_0.yml
+++ b/_data/videos/yjlzO5oXb1w_0.yml
@@ -1,0 +1,7 @@
+title: "pyhf Hardware Acceleration Benchmarking with CPUs and GPUs"
+speaker: Bo Zheng
+focus_areas: 
+projects: 
+date: 2020-08-31
+startsec: 0
+url: https://www.youtube.com/embed/yjlzO5oXb1w

--- a/_data/videos/yjlzO5oXb1w_0.yml
+++ b/_data/videos/yjlzO5oXb1w_0.yml
@@ -1,7 +1,7 @@
 title: "pyhf Hardware Acceleration Benchmarking with CPUs and GPUs"
 speaker: Bo Zheng
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-08-31
 startsec: 0
 url: https://www.youtube.com/embed/yjlzO5oXb1w

--- a/_data/videos/yjlzO5oXb1w_1.yml
+++ b/_data/videos/yjlzO5oXb1w_1.yml
@@ -1,0 +1,7 @@
+title: "Track Seeding Example for ACTS"
+speaker: Peter Chatain
+focus_areas: ia
+projects: acts
+date: 2020-08-31
+startsec: 610
+url: https://www.youtube.com/embed/yjlzO5oXb1w

--- a/_data/videos/yjlzO5oXb1w_2.yml
+++ b/_data/videos/yjlzO5oXb1w_2.yml
@@ -1,7 +1,7 @@
 title: "Pratyush"
 speaker: Reik
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-08-31
 startsec: 1351
 url: https://www.youtube.com/embed/yjlzO5oXb1w

--- a/_data/videos/yjlzO5oXb1w_2.yml
+++ b/_data/videos/yjlzO5oXb1w_2.yml
@@ -1,0 +1,7 @@
+title: "Pratyush"
+speaker: Reik
+focus_areas: 
+projects: 
+date: 2020-08-31
+startsec: 1351
+url: https://www.youtube.com/embed/yjlzO5oXb1w

--- a/_data/videos/yjlzO5oXb1w_3.yml
+++ b/_data/videos/yjlzO5oXb1w_3.yml
@@ -1,0 +1,7 @@
+title: "Creating an infrastructure for a CUDA backend for Awkward Arrays"
+speaker: Anish Biswas
+focus_areas: 
+projects: 
+date: 2020-08-31
+startsec: 2385
+url: https://www.youtube.com/embed/yjlzO5oXb1w

--- a/_data/videos/yjlzO5oXb1w_3.yml
+++ b/_data/videos/yjlzO5oXb1w_3.yml
@@ -1,7 +1,7 @@
 title: "Creating an infrastructure for a CUDA backend for Awkward Arrays"
 speaker: Anish Biswas
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2020-08-31
 startsec: 2385
 url: https://www.youtube.com/embed/yjlzO5oXb1w

--- a/_data/videos/zNLZhlfXUNg_0.yml
+++ b/_data/videos/zNLZhlfXUNg_0.yml
@@ -1,7 +1,7 @@
 title: "Skyhook: Programmable Object Storage for Analysis"
 speaker: Jeff Lefevre
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-04-24
 startsec: 0
 url: https://www.youtube.com/embed/zNLZhlfXUNg

--- a/_data/videos/zNLZhlfXUNg_0.yml
+++ b/_data/videos/zNLZhlfXUNg_0.yml
@@ -1,0 +1,7 @@
+title: "Skyhook: Programmable Object Storage for Analysis"
+speaker: Jeff Lefevre
+focus_areas: 
+projects: 
+date: 2019-04-24
+startsec: 0
+url: https://www.youtube.com/embed/zNLZhlfXUNg

--- a/_data/videos/zNLZhlfXUNg_1.yml
+++ b/_data/videos/zNLZhlfXUNg_1.yml
@@ -1,7 +1,7 @@
 title: "Skyhook for query systems"
 speaker: Jim Pivarski
-focus_areas: 
-projects: 
+focus_areas:
+projects:
 date: 2019-04-24
 startsec: 1282
 url: https://www.youtube.com/embed/zNLZhlfXUNg

--- a/_data/videos/zNLZhlfXUNg_1.yml
+++ b/_data/videos/zNLZhlfXUNg_1.yml
@@ -1,0 +1,7 @@
+title: "Skyhook for query systems"
+speaker: Jim Pivarski
+focus_areas: 
+projects: 
+date: 2019-04-24
+startsec: 1282
+url: https://www.youtube.com/embed/zNLZhlfXUNg

--- a/_includes/get_all_videos.html
+++ b/_includes/get_all_videos.html
@@ -1,0 +1,12 @@
+{%- comment -%}
+Collect all the videos, merging lists as appropriate.
+{%- endcomment -%}
+
+{%- assign all_videos = "" | split: "," -%}
+
+{%- for video_hash in site.data.videos -%}
+  {%- assign video = video_hash[1] -%}
+  {%- assign all_videos = all_videos | push: video -%}
+{%- endfor -%}
+
+{% assign sorted_videos = all_videos | sort: "date" | reverse %}

--- a/_includes/list_videos.html
+++ b/_includes/list_videos.html
@@ -1,0 +1,88 @@
+
+{%- include get_all_videos.html -%}
+
+{% assign max_vid = 8000%}
+{% if include.nvideos %}
+{% assign max_vid = include.nvideos %}
+{% endif %}
+{% assign projects = include.projects | split: ','%}
+{% assign people = include.person | split: ','%}
+{% assign f_areas = include.focus_areas | split: ','%}
+{% assign n_vid = 0 %}
+
+    {% for video in sorted_videos %}
+    {% if n_vid == max_vid %}
+       {% continue %}
+    {% endif %}
+    {% if projects.size > 0 %}
+       {% assign good_vid =0 %}
+       {% assign vid_projects = video.projects | split: ','%}
+       {% for project in vid_projects %}
+          {% if projects contains project %}
+             {% assign good_vid = 1 %}
+          {% endif %}
+       {% endfor %}
+       {% if good_vid == 0 %}
+          {% continue %}
+       {% endif %}
+    {% endif %}
+    {% if people.size > 0 %}
+       {% assign good_vid =0 %}
+       {% assign vid_people = video.person | split: ','%}
+       {% for person in vid_people %}
+          {% if people contains person %}
+             {% assign good_vid = 1 %}
+          {% endif %}
+       {% endfor %}
+       {% if good_vid == 0 %}
+          {% continue %}
+       {% endif %}
+    {% endif %}
+    {% if f_areas.size > 0 %}
+       {% assign good_vid =0 %}
+       {% assign vid_areas = video.focus_areas | split: ','%}
+       {% for area in vid_areas %}
+          {% if f_areas contains area %}
+             {% assign good_vid = 1 %}
+          {% endif %}
+       {% endfor %}
+       {% if good_vid == 0 %}
+          {% continue %}
+       {% endif %}
+    {% endif %}
+    {% assign n_vid = n_vid | plus: 1 %}
+
+    {% if n_vid == 1 %}
+    {% if include.add_header %}
+    {{include.add_header}}
+    <br/>
+    {% endif %}
+    <div class="container-fluid">
+    <div class="videos row">
+    {% endif %}
+    
+    <div class="card videos">
+          <div class="card-body d-flex flex-column">
+            <div class="card-text card-title">
+ 	    {% assign v_speaker = video.speaker %}
+            {% for person_hash in site.data.people %}
+            {% assign person = person_hash[1] %}
+            {% if person.shortname == v_speaker %}
+            {% assign v_speaker = person.name %}
+            {% endif %}
+            {% endfor %}
+            {{v_speaker}} on {{video.title}} 
+            </div>
+            <div class="card-text card-body">
+	       <iframe width="90%" height="60%" src="{{video.url}}?start={{video.startsec}}" title="IRIS-HEP video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+	       </iframe>  <br/> 
+       	    {{ video.date | date: "%-d %b %Y" }}  
+            </div>
+         </div>
+       </div>
+    {% endfor %}
+    {% if n_vid > 0 %}
+  </div>
+</div>
+{%endif%}
+

--- a/_includes/list_videos.html
+++ b/_includes/list_videos.html
@@ -76,7 +76,7 @@
             <div class="card-text card-body">
                <iframe width="90%" height="60%" src="{{video.url}}?start={{video.startsec}}" title="IRIS-HEP video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
                </iframe>  <br/>
-       	    {{ video.date | date: "%-d %b %Y" }}
+            {{ video.date | date: "%-d %b %Y" }}
             </div>
          </div>
        </div>

--- a/_includes/list_videos.html
+++ b/_includes/list_videos.html
@@ -74,8 +74,8 @@
             {{v_speaker}} on {{video.title}}
             </div>
             <div class="card-text card-body">
-	       <iframe width="90%" height="60%" src="{{video.url}}?start={{video.startsec}}" title="IRIS-HEP video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-	       </iframe>  <br/>
+               <iframe width="90%" height="60%" src="{{video.url}}?start={{video.startsec}}" title="IRIS-HEP video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+               </iframe>  <br/>
        	    {{ video.date | date: "%-d %b %Y" }}
             </div>
          </div>

--- a/_includes/list_videos.html
+++ b/_includes/list_videos.html
@@ -64,7 +64,7 @@
     <div class="card videos">
           <div class="card-body d-flex flex-column">
             <div class="card-text card-title">
- 	    {% assign v_speaker = video.speaker %}
+            {% assign v_speaker = video.speaker %}
             {% for person_hash in site.data.people %}
             {% assign person = person_hash[1] %}
             {% if person.shortname == v_speaker %}

--- a/_includes/list_videos.html
+++ b/_includes/list_videos.html
@@ -60,7 +60,7 @@
     <div class="container-fluid">
     <div class="videos row">
     {% endif %}
-    
+
     <div class="card videos">
           <div class="card-body d-flex flex-column">
             <div class="card-text card-title">
@@ -71,12 +71,12 @@
             {% assign v_speaker = person.name %}
             {% endif %}
             {% endfor %}
-            {{v_speaker}} on {{video.title}} 
+            {{v_speaker}} on {{video.title}}
             </div>
             <div class="card-text card-body">
 	       <iframe width="90%" height="60%" src="{{video.url}}?start={{video.startsec}}" title="IRIS-HEP video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-	       </iframe>  <br/> 
-       	    {{ video.date | date: "%-d %b %Y" }}  
+	       </iframe>  <br/>
+       	    {{ video.date | date: "%-d %b %Y" }}
             </div>
          </div>
        </div>

--- a/_layouts/focus-area.html
+++ b/_layouts/focus-area.html
@@ -139,6 +139,9 @@
 
 {% endif %}
 
+{% include list_videos.html nvideos=5 add_header="<center><h3> Recent recordings</h3></center>" focus_areas=page.short_title %}
+
+
 
 <section class="">
   <div class="container-lg p-responsive py-5 py-md-6 ">

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -22,7 +22,7 @@
 
           {% include list_project_publications.html shortname=page.shortname %}
 
-	  {% include list_videos.html projects=page.shortname nvideos=6 add_header="<h3> Recent recordings</h3>"%}
+          {% include list_videos.html projects=page.shortname nvideos=6 add_header="<h3> Recent recordings</h3>"%}
 
         </main>
       </div>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -22,6 +22,8 @@
 
           {% include list_project_publications.html shortname=page.shortname %}
 
+	  {% include list_videos.html projects=page.shortname nvideos=6 add_header="<h3> Recent recordings</h3>"%}
+
         </main>
       </div>
       {% include footer.html %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -229,6 +229,43 @@ pre code {
   }
 }
 
+/* Videos cards */
+
+.row.videos {
+  margin-left: -20px;
+  margin-right: -20px;
+}
+
+.card.videos {
+  width: 18rem;
+  height: 15rem;  
+  flex-grow: 0;
+  border: none;
+  margin: 5px 5px 25px 5px;
+  border-radius: 0;
+
+  img.card-img-top {
+    border-radius: 0;
+  }
+
+  .card-body {
+      padding: 0;
+    .card-text.card-title {
+      font-weight: bolder;
+      margin: 5px 0px 5px 0px;
+      a {
+        @extend %light-purple-header;
+      }
+    }
+    .card-text.card-body {
+      position: absolute;
+      bottom: 0;
+    }
+
+  }
+}
+
+
 div#container {
   position:relative;
   height: auto !important;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -238,7 +238,7 @@ pre code {
 
 .card.videos {
   width: 18rem;
-  height: 15rem;  
+  height: 15rem;
   flex-grow: 0;
   border: none;
   margin: 5px 5px 25px 5px;

--- a/pages/videos.md
+++ b/pages/videos.md
@@ -1,11 +1,11 @@
 ---
 permalink: /videos.html
 layout: default
-title: IRIS-HEP Videos 
+title: IRIS-HEP Videos
 ---
 <center>
 <h3> Recordings of recent IRIS-HEP and other related events</h3>
-</center>  
+</center>
 
 
 {%- include list_videos.html nvideos=12 -%}

--- a/pages/videos.md
+++ b/pages/videos.md
@@ -1,0 +1,14 @@
+---
+permalink: /videos.html
+layout: default
+title: IRIS-HEP Videos 
+---
+<center>
+<h3> Recordings of recent IRIS-HEP and other related events</h3>
+</center>  
+
+
+{%- include list_videos.html nvideos=12 -%}
+
+<br>
+


### PR DESCRIPTION
This PR adds videos of talks already on the iris-hep YouTube channel and embeds them on the project and focus area pages. It also creates a /videos.html page for the 12 most recent ones (adding all seems to do bad things to my computer..). 

The yml came from the YouTube+indico apis. It does need a cleanup pass as the video descriptions are not always structured in the same way. I'd like to do that as a followup PR if we are happy with the yml structure. Only one yml file has a non-empty focus-area or project filled in 