### PR TITLE
Update Sinclert talks

### DIFF
--- a/_data/people/sinclert.yml
+++ b/_data/people/sinclert.yml
@@ -27,3 +27,4 @@ presentations:
     meetingurl: https://indico.cern.ch/event/960587/
     location: Virtual
     focus-area: as
+    project: madminer

--- a/_data/people/sinclert.yml
+++ b/_data/people/sinclert.yml
@@ -12,15 +12,18 @@ presentations:
     meeting: CERN Openlab presentations
     meetingurl: https://indico.cern.ch/event/727275/
     location: Geneva, Switzerland
+    focus-area: as
   - title: Integrating Cyberinfrastructure components
     date: 2020-02-27
     url: https://indico.cern.ch/event/894127/attachments/1996570/3331187/17_-_Sinclert-Cyberinfrastructure_components.pdf
     meeting: IRIS-HEP Poster Session
     meetingurl: https://indico.cern.ch/event/894127/
     location: Princeton, US
+    focus-area: as
   - title: Madminer on REANA
     date: 2020-10-26
     url: https://indico.cern.ch/event/960587/attachments/2129226/3585364/IRIS-HEP%20Madminer-on-reana.pdf
     meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
     meetingurl: https://indico.cern.ch/event/960587/
     location: Virtual
+    focus-area: as


### PR DESCRIPTION
Following Peter Elmer recent email, I am updating my list of presentations to include `focus-area` and `project` information.

I was unsure if _"reana"_ would count as a project (as it does not belong to IRIS / IRIS-related grants), so I have left it out of the update for now.