### PR TITLE
Explicitely name Tomohiro in ACTS team

### DIFF
--- a/pages/projects/acts.md
+++ b/pages/projects/acts.md
@@ -16,7 +16,7 @@ team:
  - gagnonlg
  - beomki-yeo
  - cvarni
- - toyamaza
+ - Tomohiro Yamazaki
  - xiaocong-ai
 ---
 


### PR DESCRIPTION
I thought the fellows would also be automatically linked, but it's not happening. Let's use Tomohiro's full name for now.