### PR TITLE
fix: missing project tag for Alexander Held

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -62,6 +62,7 @@ presentations:
     meetingurl: https://indico.fnal.gov/event/43829/
     location: (Virtual)
     focus-area: as
+    project:
   - title: "Template-based Fitting: cabinetry"
     date: 2020-10-26
     url: https://indico.cern.ch/event/960587/contributions/4070322/


### PR DESCRIPTION
In response to #757, this adds an empty project tag to a presentation that has no associated project to silence the warning.

This is ready for review / merge.