### PR TITLE
feat: allow pages to be manually ordered in projects

### DIFF
--- a/_layouts/focus-area.html
+++ b/_layouts/focus-area.html
@@ -13,27 +13,15 @@
 {{content}}
 </div>
 
-{% assign doProjects = 0 %}
-{% assign sorted = site.pages | sort_natural: 'title' %}
-{% for mypage in sorted %}
-{% if mypage.pagetype == 'project' %}
 {% assign page_focus_area = page.name | basename %}
-{% if mypage.focus-area contains page_focus_area %}
-{% assign doProjects = 1 %}
-{% break %}
-{% endif %}
-{% endif %}
-{% endfor %}
+{% assign sorted = site.pages | smart_page_sort: "focus-area", page_focus_area %}
 
-{% if doProjects ==1 %}
+{% unless sorted.empty %}
 <div class="container-fluid projects">
   <h2 class="alt-h2 text-center mb-3 mt-lg-6" id="projects">{{ page.short_title | upcase }} Projects</h2><br>
 <center>
   <div class="row">
 {% for mypage in sorted %}
-{% if mypage.pagetype == 'project' %}
-{% assign page_focus_area = page.name | basename %}
-{% if mypage.focus-area contains page_focus_area %}
 <div class="card" style="width: 17rem;">
 <a href=/projects/{{mypage.shortname}}.html>
 <img class="card-img-top" src="/assets/{{mypage.image | default: "logos/Iris-hep-5-just-graphic.png"}}" alt="Card image cap">
@@ -46,14 +34,12 @@
 </div>
 </div>
 </div>
-{% endif %}
-{% endif %}
 {% endfor %}
   </div>
 </center>
   <br>
 </div>
-{% endif %}
+{% endunless %}
 
 
 {% assign sorted_presentations = site.data['sorted_presentations'] %}

--- a/_plugins/smart_sort.rb
+++ b/_plugins/smart_sort.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module IrisHep
+  # Adding useful file filters
+  module SmartSort
+    def smart_page_sort(input, field, match)
+      input.select { |p| p['pagetype'] == 'project' && p[field].include?(match) }
+           .sort_by { |p| [p['position'] || 0, p['title'].downcase] }
+    end
+  end
+end
+
+Liquid::Template.register_filter(IrisHep::SmartSort)

--- a/pages/projects/osg-networking.md
+++ b/pages/projects/osg-networking.md
@@ -7,6 +7,7 @@ pagetype: project
 image: logos/Iris-hep-5-just-graphic.png
 blurb: Provide network monitoring for LHC and OSG sites
 focus-area: osglhc
+position: -1
 team:
 - smckee
 - djw8605

--- a/pages/projects/osg-operations.md
+++ b/pages/projects/osg-operations.md
@@ -6,6 +6,7 @@ shortname: osg-operations
 pagetype: project
 image: logos/Iris-hep-5-just-graphic.png
 blurb: Operate OSG-LHC services
+position: -1
 focus-area:
  - doma
  - osglhc

--- a/pages/projects/osg-security.md
+++ b/pages/projects/osg-security.md
@@ -6,6 +6,7 @@ shortname: osg-security
 pagetype: project
 image: logos/Iris-hep-5-just-graphic.png
 blurb: OSG Cybersecurity team
+position: -1
 focus-area: osglhc
 team:
 - mtstanfield

--- a/pages/projects/osg-software.md
+++ b/pages/projects/osg-software.md
@@ -6,6 +6,7 @@ shortname: osg-software
 pagetype: project
 image: logos/Iris-hep-5-just-graphic.png
 blurb: Provide integrated software for running dHTC services
+position: -1
 focus-area: osglhc
 team:
 - brianhlin


### PR DESCRIPTION
CC @osg-cat

This only sorts the OSG-X alphabetically, feel free to change. Projects with no "position" count as position 0, and within a position, titles are sorted alphabetically.

We could move to using Ruby filters in more places - they are faster than liquid, and simpler.
