### PR TITLE
pyhf: Add CERN Courier article to featured list

### DIFF
--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -39,7 +39,7 @@ team:
 
 - The CERN homepage featured an article on pyhf: [New open release allows theorists to explore LHC data in a new way](https://home.cern/news/news/knowledge-sharing/new-open-release-allows-theorists-explore-lhc-data-new-way):  The ATLAS collaboration releases full analysis likelihoods, a first for an LHC experiment. (January, 2020)
 - Symmetry Magazine: [ATLAS releases 'full orchestra' of analysis instruments](https://www.symmetrymagazine.org/article/atlas-releases-full-orchestra-of-analysis-instruments) (January, 2021)
-- CERN Courier May/June 2021 Issue: [LHC reinterpreters think long-term] (May, 2021)
+- CERN Courier [May/June 2021 Issue](https://cds.cern.ch/record/2765233): [LHC reinterpreters think long-term](https://cerncourier.com/wp-content/uploads/2021/04/CERNCourier2021MayJun-digitaledition.pdf) (May, 2021)
 
 ### Recent Talks and Tutorials
 

--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -35,7 +35,7 @@ team:
 [![CodeFactor](https://www.codefactor.io/repository/github/scikit-hep/pyhf/badge)](https://www.codefactor.io/repository/github/scikit-hep/pyhf)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-### Featured on CERN homepage, in Symmetry Magazine, and CERN Courier
+### Featured on CERN homepage and in Symmetry Magazine and the CERN Courier
 
 - The CERN homepage featured an article on pyhf: [New open release allows theorists to explore LHC data in a new way](https://home.cern/news/news/knowledge-sharing/new-open-release-allows-theorists-explore-lhc-data-new-way):  The ATLAS collaboration releases full analysis likelihoods, a first for an LHC experiment. (January, 2020)
 - Symmetry Magazine: [ATLAS releases 'full orchestra' of analysis instruments](https://www.symmetrymagazine.org/article/atlas-releases-full-orchestra-of-analysis-instruments) (January, 2021)

--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -35,10 +35,11 @@ team:
 [![CodeFactor](https://www.codefactor.io/repository/github/scikit-hep/pyhf/badge)](https://www.codefactor.io/repository/github/scikit-hep/pyhf)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-### Featured on CERN homepage and in Symmetry Magazine
+### Featured on CERN homepage, in Symmetry Magazine, and CERN Courier
 
 - The CERN homepage featured an article on pyhf: [New open release allows theorists to explore LHC data in a new way](https://home.cern/news/news/knowledge-sharing/new-open-release-allows-theorists-explore-lhc-data-new-way):  The ATLAS collaboration releases full analysis likelihoods, a first for an LHC experiment. (January, 2020)
 - Symmetry Magazine: [ATLAS releases 'full orchestra' of analysis instruments](https://www.symmetrymagazine.org/article/atlas-releases-full-orchestra-of-analysis-instruments) (January, 2021)
+- CERN Courier May/June 2021 Issue: [LHC reinterpreters think long-term] (May, 2021)
 
 ### Recent Talks and Tutorials
 


### PR DESCRIPTION
Add links to [May/June 2021 Issue](https://cds.cern.ch/record/2765233) of the CERN Courier that feature `pyhf` in the the article "LHC reinterpreters think long-term" (page 23) written by Sabine Kraml.

[![pyhf_mention](https://user-images.githubusercontent.com/5142394/116961504-1a6fa500-ac69-11eb-8b85-a3fb43491e0c.png)](https://cerncourier.com/wp-content/uploads/2021/04/CERNCourier2021MayJun-digitaledition.pdf)

The "colleagues" mentioned in the article are of course the other awesome `pyhf` core developers: @lukasheinrich and @kratsg. :rocket: 

```
* Add links to May/June 2021 Issue of the CERN Courier that features pyhf's role in open likelihood publishing and summary of the 6th LHC Reinterpretation Workshop
   - c.f. https://cds.cern.ch/record/2765233
   - "LHC reinterpreters think long-term" article on page 23 written by Sabine Kraml
```