### PR TITLE
refactor: use people file for focus areas

### DIFF
--- a/_data/people/936-BCruz.yml
+++ b/_data/people/936-BCruz.yml
@@ -1,8 +1,9 @@
+---
 name: Brian O. Cruz Rodríguez
 shortname: 936-BCruz
 title:
 active: true
 institution: University of Puerto Rico at Mayagüez
 website: https://github.com/936-BCruz
-photo: /assets/images/team/Brian-Cruz.jpg
+photo: "/assets/images/team/Brian-Cruz.jpg"
 presentations:

--- a/_data/people/936-BCruz.yml
+++ b/_data/people/936-BCruz.yml
@@ -1,9 +1,8 @@
----
-name: Brian O. Cruz Rodríguez
-shortname: 936-BCruz
-title:
 active: true
 institution: University of Puerto Rico at Mayagüez
-website: https://github.com/936-BCruz
+name: Brian O. Cruz Rodríguez
 photo: "/assets/images/team/Brian-Cruz.jpg"
+shortname: 936-BCruz
+title:
+website: https://github.com/936-BCruz
 presentations:

--- a/_data/people/AndrewEckart.yml
+++ b/_data/people/AndrewEckart.yml
@@ -1,11 +1,10 @@
----
-name: Andrew Eckart
-shortname: AndrewEckart
-title:
 active: true
-institution: University of Chicago
-website:
-photo: "/assets/images/team/Andrew-Eckart.jpg"
-presentations:
 focus-area:
 - doma
+institution: University of Chicago
+name: Andrew Eckart
+photo: "/assets/images/team/Andrew-Eckart.jpg"
+shortname: AndrewEckart
+title:
+website:
+presentations:

--- a/_data/people/AndrewEckart.yml
+++ b/_data/people/AndrewEckart.yml
@@ -7,3 +7,5 @@ institution: University of Chicago
 website:
 photo: "/assets/images/team/Andrew-Eckart.jpg"
 presentations:
+focus-area:
+- doma

--- a/_data/people/AndrewEckart.yml
+++ b/_data/people/AndrewEckart.yml
@@ -1,8 +1,9 @@
+---
 name: Andrew Eckart
 shortname: AndrewEckart
 title:
 active: true
 institution: University of Chicago
 website:
-photo: /assets/images/team/Andrew-Eckart.jpg
+photo: "/assets/images/team/Andrew-Eckart.jpg"
 presentations:

--- a/_data/people/AtluriLab.yml
+++ b/_data/people/AtluriLab.yml
@@ -7,3 +7,5 @@ institution: University of Cincinnati
 website:
 photo: "/assets/images/team/Gowtham-Atluri.jpg"
 presentations:
+focus-area:
+- ia

--- a/_data/people/AtluriLab.yml
+++ b/_data/people/AtluriLab.yml
@@ -1,8 +1,9 @@
+---
 name: Gowtham Atluri
 shortname: AtluriLab
 title:
 active: true
 institution: University of Cincinnati
 website:
-photo: /assets/images/team/Gowtham-Atluri.jpg
+photo: "/assets/images/team/Gowtham-Atluri.jpg"
 presentations:

--- a/_data/people/AtluriLab.yml
+++ b/_data/people/AtluriLab.yml
@@ -1,11 +1,10 @@
----
-name: Gowtham Atluri
-shortname: AtluriLab
-title:
 active: true
-institution: University of Cincinnati
-website:
-photo: "/assets/images/team/Gowtham-Atluri.jpg"
-presentations:
 focus-area:
 - ia
+institution: University of Cincinnati
+name: Gowtham Atluri
+photo: "/assets/images/team/Gowtham-Atluri.jpg"
+shortname: AtluriLab
+title:
+website:
+presentations:

--- a/_data/people/BenGalewsky.yml
+++ b/_data/people/BenGalewsky.yml
@@ -1,11 +1,15 @@
----
+active: true
+focus-area:
+- ssl
+- doma
+- as
+- ssc
+institution: National Center for Supercomputing Applications
 name: Ben Galewsky
+photo: "/assets/images/team/Ben-Galewsky.jpg"
 shortname: BenGalewsky
 title:
-active: true
-institution: National Center for Supercomputing Applications
 website: https://github.com/BenGalewsky
-photo: "/assets/images/team/Ben-Galewsky.jpg"
 presentations:
 - title: Data Engineering at the Large Hadron Collider
   date: 2020-09-21
@@ -67,8 +71,3 @@ presentations:
   meetingurl: https://2020esipwintermeeting.sched.com
   location: Bethesda, MD
   focus-area: ssc
-focus-area:
-- ssl
-- doma
-- as
-- ssc

--- a/_data/people/BenGalewsky.yml
+++ b/_data/people/BenGalewsky.yml
@@ -67,3 +67,8 @@ presentations:
   meetingurl: https://2020esipwintermeeting.sched.com
   location: Bethesda, MD
   focus-area: ssc
+focus-area:
+- ssl
+- doma
+- as
+- ssc

--- a/_data/people/BenGalewsky.yml
+++ b/_data/people/BenGalewsky.yml
@@ -1,60 +1,69 @@
+---
 name: Ben Galewsky
 shortname: BenGalewsky
 title:
 active: true
 institution: National Center for Supercomputing Applications
 website: https://github.com/BenGalewsky
-photo: /assets/images/team/Ben-Galewsky.jpg
+photo: "/assets/images/team/Ben-Galewsky.jpg"
 presentations:
-  - title: "Data Engineering at the Large Hadron Collider"
-    date: 2020-09-21
-    url: https://docs.google.com/presentation/d/1QNLn6MFVatzHOJRwQ2nyHGf2ZJAD61tvZgdVIC8Py2g/edit?usp=sharing
-    meeting: "Chicago Cloud Conference"
-    meetingurl: https://www.chicagocloudconference.com
-    location: Virtual
-    focus-area: [ssl, doma]
-  - title: "Controlling AWS Costs Using a Data Carousel"
-    date: 2020-07-21
-    url: https://www.ideals.illinois.edu/handle/2142/107801
-    meeting: "Earth Science Information Partners Summer Meeting"
-    meetingurl: https://2020esipsummermeeting.sched.com/event/e485fae5c61bd3f8e974da2793dd3760
-    location: Virtual
-    focus-area: [ssl, doma]
-  - title: "ServiceX and Kubernetes"
-    date: 2020-07-08
-    url: https://indico.cern.ch/event/813749/contributions/3932531/attachments/2070530/3476782/ServiceX_and_Kubernetes.pdf
-    meeting: "LHCG Grid Deployment Board meeting"
-    meetingurl: https://indico.cern.ch/event/813749/
-    location: Virtual
-    focus-area: [ssl, doma]
-    project: servicex
-  - title: ServiceX
-    date: 2019-06-19
-    url: https://indico.cern.ch/event/822074/contributions/3471452/attachments/1865411/3067262/ServiceX_For_AS_Workshop.pdf
-    meeting: Analysis Systems Topical Workshop
-    meetingurl: https://indico.cern.ch/event/822074
-    location: NYU
-    focus-area: [as, doma]
-    project: servicex
-  - title: "Analysis Systems team meetings/process efficacy"
-    date: 2019-09-12
-    url: https://indico.cern.ch/event/840472/contributions/3564364/attachments/1907330/3150288/go
-    meeting: IRIS-HEP Institute Retreat
-    meetingurl: https://indico.cern.ch/event/840472/overview
-    location: FNAL
-    focus-area: as
-  - title: "A Distributed, Caching, Columnar Data Delivery Service(X)"
-    date: 2019-11-04
-    url: https://indico.cern.ch/event/773049/contributions/3474438/
-    meeting: CHEP 2019 Conference
-    meetingurl: https://indico.cern.ch/event/773049
-    location: Adelaide, South Australia
-    focus-area: doma
-    project: servicex
-  - title: "Open Source Community Building"
-    date: 2020-01-08
-    url: https://esip.figshare.com/articles/Open_Source_Community_Building/11553147
-    meeting: ESIP 2020 Winter Meeting
-    meetingurl: https://2020esipwintermeeting.sched.com
-    location: Bethesda, MD
-    focus-area: ssc
+- title: Data Engineering at the Large Hadron Collider
+  date: 2020-09-21
+  url: https://docs.google.com/presentation/d/1QNLn6MFVatzHOJRwQ2nyHGf2ZJAD61tvZgdVIC8Py2g/edit?usp=sharing
+  meeting: Chicago Cloud Conference
+  meetingurl: https://www.chicagocloudconference.com
+  location: Virtual
+  focus-area:
+  - ssl
+  - doma
+- title: Controlling AWS Costs Using a Data Carousel
+  date: 2020-07-21
+  url: https://www.ideals.illinois.edu/handle/2142/107801
+  meeting: Earth Science Information Partners Summer Meeting
+  meetingurl: https://2020esipsummermeeting.sched.com/event/e485fae5c61bd3f8e974da2793dd3760
+  location: Virtual
+  focus-area:
+  - ssl
+  - doma
+- title: ServiceX and Kubernetes
+  date: 2020-07-08
+  url: https://indico.cern.ch/event/813749/contributions/3932531/attachments/2070530/3476782/ServiceX_and_Kubernetes.pdf
+  meeting: LHCG Grid Deployment Board meeting
+  meetingurl: https://indico.cern.ch/event/813749/
+  location: Virtual
+  focus-area:
+  - ssl
+  - doma
+  project: servicex
+- title: ServiceX
+  date: 2019-06-19
+  url: https://indico.cern.ch/event/822074/contributions/3471452/attachments/1865411/3067262/ServiceX_For_AS_Workshop.pdf
+  meeting: Analysis Systems Topical Workshop
+  meetingurl: https://indico.cern.ch/event/822074
+  location: NYU
+  focus-area:
+  - as
+  - doma
+  project: servicex
+- title: Analysis Systems team meetings/process efficacy
+  date: 2019-09-12
+  url: https://indico.cern.ch/event/840472/contributions/3564364/attachments/1907330/3150288/go
+  meeting: IRIS-HEP Institute Retreat
+  meetingurl: https://indico.cern.ch/event/840472/overview
+  location: FNAL
+  focus-area: as
+- title: A Distributed, Caching, Columnar Data Delivery Service(X)
+  date: 2019-11-04
+  url: https://indico.cern.ch/event/773049/contributions/3474438/
+  meeting: CHEP 2019 Conference
+  meetingurl: https://indico.cern.ch/event/773049
+  location: Adelaide, South Australia
+  focus-area: doma
+  project: servicex
+- title: Open Source Community Building
+  date: 2020-01-08
+  url: https://esip.figshare.com/articles/Open_Source_Community_Building/11553147
+  meeting: ESIP 2020 Winter Meeting
+  meetingurl: https://2020esipwintermeeting.sched.com
+  location: Bethesda, MD
+  focus-area: ssc

--- a/_data/people/GuillermoFidalgo.yml
+++ b/_data/people/GuillermoFidalgo.yml
@@ -1,8 +1,9 @@
+---
 name: Guillermo Fidalgo
 shortname: GuillermoFidalgo
 title: Graduate Student
 active: true
 institution: University of Puerto Rico at Mayaguez
 website: https://guillermofidalgo.github.io/
-photo: /assets/images/team/Guillermo-Fidalgo.jpg
+photo: "/assets/images/team/Guillermo-Fidalgo.jpg"
 presentations:

--- a/_data/people/GuillermoFidalgo.yml
+++ b/_data/people/GuillermoFidalgo.yml
@@ -1,9 +1,8 @@
----
-name: Guillermo Fidalgo
-shortname: GuillermoFidalgo
-title: Graduate Student
 active: true
 institution: University of Puerto Rico at Mayaguez
-website: https://guillermofidalgo.github.io/
+name: Guillermo Fidalgo
 photo: "/assets/images/team/Guillermo-Fidalgo.jpg"
+shortname: GuillermoFidalgo
+title: Graduate Student
+website: https://guillermofidalgo.github.io/
 presentations:

--- a/_data/people/HedgeMage.yml
+++ b/_data/people/HedgeMage.yml
@@ -1,9 +1,8 @@
----
-name: Susan Sons
-shortname: HedgeMage
-title:
 active: false
 institution: Indiana University
-website: https://cacr.iu.edu/about/people/administration/susan-sons.php
+name: Susan Sons
 photo: "/assets/images/team/Susan-Sons.jpg"
+shortname: HedgeMage
+title:
+website: https://cacr.iu.edu/about/people/administration/susan-sons.php
 presentations:

--- a/_data/people/HedgeMage.yml
+++ b/_data/people/HedgeMage.yml
@@ -1,8 +1,9 @@
+---
 name: Susan Sons
 shortname: HedgeMage
 title:
 active: false
 institution: Indiana University
 website: https://cacr.iu.edu/about/people/administration/susan-sons.php
-photo: /assets/images/team/Susan-Sons.jpg
+photo: "/assets/images/team/Susan-Sons.jpg"
 presentations:

--- a/_data/people/IHateLinus.yml
+++ b/_data/people/IHateLinus.yml
@@ -1,11 +1,10 @@
----
-name: Avi Yagil
-shortname: IHateLinus
-title:
 active: true
-institution: University of California, San Diego
-website: https://physics.ucsd.edu/fac_staff/fac_profile/faculty_description.php?person_id=688
-photo: "/assets/images/team/Avi-Yagil.jpg"
-presentations:
 focus-area:
 - ia
+institution: University of California, San Diego
+name: Avi Yagil
+photo: "/assets/images/team/Avi-Yagil.jpg"
+shortname: IHateLinus
+title:
+website: https://physics.ucsd.edu/fac_staff/fac_profile/faculty_description.php?person_id=688
+presentations:

--- a/_data/people/IHateLinus.yml
+++ b/_data/people/IHateLinus.yml
@@ -7,3 +7,5 @@ institution: University of California, San Diego
 website: https://physics.ucsd.edu/fac_staff/fac_profile/faculty_description.php?person_id=688
 photo: "/assets/images/team/Avi-Yagil.jpg"
 presentations:
+focus-area:
+- ia

--- a/_data/people/IHateLinus.yml
+++ b/_data/people/IHateLinus.yml
@@ -1,8 +1,9 @@
+---
 name: Avi Yagil
 shortname: IHateLinus
 title:
 active: true
 institution: University of California, San Diego
 website: https://physics.ucsd.edu/fac_staff/fac_profile/faculty_description.php?person_id=688
-photo: /assets/images/team/Avi-Yagil.jpg
+photo: "/assets/images/team/Avi-Yagil.jpg"
 presentations:

--- a/_data/people/JayjeetAtGithub.yml
+++ b/_data/people/JayjeetAtGithub.yml
@@ -7,3 +7,5 @@ institution: National Institute Of Technology, Durgapur
 website: https://github.com/JayjeetAtGithub
 photo: "/assets/images/team/Jayjeet-Chakraborty.png"
 presentations:
+focus-area:
+- doma

--- a/_data/people/JayjeetAtGithub.yml
+++ b/_data/people/JayjeetAtGithub.yml
@@ -1,11 +1,10 @@
----
-name: Jayjeet Chakraborty
-shortname: JayjeetAtGithub
-title:
 active: true
-institution: National Institute Of Technology, Durgapur
-website: https://github.com/JayjeetAtGithub
-photo: "/assets/images/team/Jayjeet-Chakraborty.png"
-presentations:
 focus-area:
 - doma
+institution: National Institute Of Technology, Durgapur
+name: Jayjeet Chakraborty
+photo: "/assets/images/team/Jayjeet-Chakraborty.png"
+shortname: JayjeetAtGithub
+title:
+website: https://github.com/JayjeetAtGithub
+presentations:

--- a/_data/people/JayjeetAtGithub.yml
+++ b/_data/people/JayjeetAtGithub.yml
@@ -1,8 +1,9 @@
+---
 name: Jayjeet Chakraborty
 shortname: JayjeetAtGithub
 title:
 active: true
 institution: National Institute Of Technology, Durgapur
 website: https://github.com/JayjeetAtGithub
-photo: /assets/images/team/Jayjeet-Chakraborty.png
+photo: "/assets/images/team/Jayjeet-Chakraborty.png"
 presentations:

--- a/_data/people/LincolnBryant.yml
+++ b/_data/people/LincolnBryant.yml
@@ -25,3 +25,5 @@ presentations:
   meeting: K8s-HEP Meetup ('Chicagoland')
   meetingurl: https://indico.cern.ch/event/882955/
   focus-area: ssl
+focus-area:
+- ssl

--- a/_data/people/LincolnBryant.yml
+++ b/_data/people/LincolnBryant.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ssl
+institution: University of Chicago
 name: Lincoln Bryant
+photo: "/assets/images/team/Lincoln-Bryant.png"
 shortname: LincolnBryant
 title: DevOps Engineer
-active: true
-institution: University of Chicago
 website: https://efi.uchicago.edu/people/profile/lincoln-bryant/
-photo: "/assets/images/team/Lincoln-Bryant.png"
 presentations:
 - title: 'SSL patterns: hybrid models, developer support, deployments'
   date: 2019-06-21
@@ -25,5 +26,3 @@ presentations:
   meeting: K8s-HEP Meetup ('Chicagoland')
   meetingurl: https://indico.cern.ch/event/882955/
   focus-area: ssl
-focus-area:
-- ssl

--- a/_data/people/LincolnBryant.yml
+++ b/_data/people/LincolnBryant.yml
@@ -1,26 +1,27 @@
+---
 name: Lincoln Bryant
 shortname: LincolnBryant
 title: DevOps Engineer
 active: true
 institution: University of Chicago
 website: https://efi.uchicago.edu/people/profile/lincoln-bryant/
-photo: /assets/images/team/Lincoln-Bryant.png
+photo: "/assets/images/team/Lincoln-Bryant.png"
 presentations:
-  - title: "SSL patterns: hybrid models, developer support, deployments"
-    date: 2019-06-21
-    url: https://indico.cern.ch/event/820946/contributions/3461592/attachments/1866998/3119402/2019.06.21_SSL_Patterns__Deployments_Lincoln.pdf
-    meeting: "Analysis Systems R&D on Scalable Platforms (AS-SSL Blueprint)"
-    meetingurl: https://indico.cern.ch/event/820946/
-    focus-area: ssl
-  - title: "Towards Lighter Operations"
-    date: 2019-08-07
-    url: https://indico.cern.ch/event/837130/contributions/3509789/attachments/1891363/3119277/Towards_Lighter_Operations.pdf
-    meeting: "US ATLAS Computing Facility"
-    meetingurl: https://indico.cern.ch/event/837130/
-    focus-area: ssl
-  - title: "k8s for the IRIS-HEP SSLab"
-    date: 2020-01-30
-    url: https://indico.cern.ch/event/882955/contributions/3724855/attachments/1978233/3295037/Chicago-K8S-Workshop-Jan-2020.pdf
-    meeting: "K8s-HEP Meetup ('Chicagoland')"
-    meetingurl: https://indico.cern.ch/event/882955/
-    focus-area: ssl
+- title: 'SSL patterns: hybrid models, developer support, deployments'
+  date: 2019-06-21
+  url: https://indico.cern.ch/event/820946/contributions/3461592/attachments/1866998/3119402/2019.06.21_SSL_Patterns__Deployments_Lincoln.pdf
+  meeting: Analysis Systems R&D on Scalable Platforms (AS-SSL Blueprint)
+  meetingurl: https://indico.cern.ch/event/820946/
+  focus-area: ssl
+- title: Towards Lighter Operations
+  date: 2019-08-07
+  url: https://indico.cern.ch/event/837130/contributions/3509789/attachments/1891363/3119277/Towards_Lighter_Operations.pdf
+  meeting: US ATLAS Computing Facility
+  meetingurl: https://indico.cern.ch/event/837130/
+  focus-area: ssl
+- title: k8s for the IRIS-HEP SSLab
+  date: 2020-01-30
+  url: https://indico.cern.ch/event/882955/contributions/3724855/attachments/1978233/3295037/Chicago-K8S-Workshop-Jan-2020.pdf
+  meeting: K8s-HEP Meetup ('Chicagoland')
+  meetingurl: https://indico.cern.ch/event/882955/
+  focus-area: ssl

--- a/_data/people/SebastianMacaluso.yml
+++ b/_data/people/SebastianMacaluso.yml
@@ -1,96 +1,100 @@
+---
 name: Sebastian Macaluso
 shortname: SebastianMacaluso
 title:
 active: true
 institution: New York University
 website:
-photo: /assets/images/team/Sebastian-Macaluso.jpg
+photo: "/assets/images/team/Sebastian-Macaluso.jpg"
 e-mail: sm4511@nyu.edu
 presentations:
-  - title: "Pulling Out All the Tops with Computer Vision and Deep Learning"
-    date: 2018-11-15
-    url: https://indico.cern.ch/event/745718/contributions/3174400/attachments/1754069/2843182/ML4Jets_2018_Macaluso.pdf
-    meeting: Machine Learning for Jet Physics
-    meetingurl: https://indico.cern.ch/event/745718/
-    location: Fermilab, Illinois, USA
-    focus-area: ia
-    project: ml4jets
-  - title: "SCAILFIN: Reproducible Open Benchmarks"
-    date: 2019-06-19
-    url: https://indico.cern.ch/event/822074/contributions/3471463/
-    meeting: Analysis Systems Topical Meeting
-    meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
-    location: NYU
-    focus-area: [as, ia]
-  - title: "The Machine Learning Landscape of Top Taggers"
-    date: 2019-07-23
-    url: https://indico.cern.ch/event/753914/contributions/3444496/
-    meeting: 11th International Workshop on Boosted Object Phenomenology, Reconstruction and Searches in HEP (BOOST 2019)
-    meetingurl: https://indico.cern.ch/event/753914/overview
-    location: Massachusetts Institute of Technology (MIT)
-    focus-area: ia
-    project: ml4jets
-  - title: "Looking into Jets with Machine Learning"
-    date: 2019-09-24
-    url: https://phy.princeton.edu/events/pheno-vino-seminar-sebastian-macaluso-nyu-looking-jets-machine-learning-jadwin-303
-    meeting: "Princeton Pheno & Vino Seminar"
-    meetingurl: https://phy.princeton.edu/events/pheno-vino-seminar-sebastian-macaluso-nyu-looking-jets-machine-learning-jadwin-303
-    location: Princeton University
-    focus-area: ia
-    project: ml4jets
-  - title: "Benchmarks for ML4Jets research"
-    date: 2019-09-25
-    url: https://indico.cern.ch/event/841905/
-    meeting: IRIS-HEP Topical Meeting
-    meetingurl: https://indico.cern.ch/event/841905/
-    location: Vidyo
-    focus-area: ia
-    project: ml4jets
-  - title: "Looking into Jets with Machine Learning"
-    date: 2019-11-01
-    url: https://github.com/SebastianMacaluso/TalksSlides/blob/master/physicsxML_v2.pdf
-    meeting: NYU Physics x ML
-    meetingurl: https://docs.google.com/spreadsheets/d/1eETvm0Uwr_vl6Bm7VUL6JnrHy8QraGzyK4kXztjNZlk/edit#gid=0
-    location: CDS New York University
-    focus-area: ia
-    project: ml4jets
-  - title: "Looking into Jets with Machine Learning"
-    date: 2019-11-04
-    url: https://github.com/SebastianMacaluso/TalksSlides/blob/master/UMassDS.pdf
-    meeting: "Data Science Tea UMass"
-    meetingurl: https://ds.cs.umass.edu/event/sebastian-macaluso-nyu
-    location: CDS UMass Amherst
-    focus-area: ia
-    project: ml4jets
-  - title: "Looking into Jets with Machine Learning"
-    date: 2019-11-19
-    url: https://hetg.physics.harvard.edu/seminar-schedule
-    meeting: "Particle Theory Seminar, Harvard University"
-    meetingurl: https://hetg.physics.harvard.edu/seminar-schedule
-    location: Harvard University
-    focus-area: ia
-    project: ml4jets
-  - title: "Looking into Jets with Machine Learning"
-    date: 2020-01-17
-    url: https://indico.cern.ch/event/809820/contributions/3632649
-    meeting: ML4Jets 2020
-    meetingurl: https://indico.cern.ch/event/809820/
-    location: New York University
-    focus-area: ia
-    project: ml4jets
-  - title: "New Computational Techniques and Machine Learning for Jet Physics"
-    date: 2020-09-21
-    url: https://github.com/SebastianMacaluso/TalksSlides/blob/master/LaPlata2020.pdf
-    meeting: "Particle Theory Seminar, Instituto de Fisica La Plata, UNLP"
-    meetingurl: https://github.com/SebastianMacaluso/TalksSlides/blob/master/LaPlata2020.pdf
-    location: Instituto de Fisica La Plata, La Plata, Argentina
-    focus-area: ia
-    project: ml4jets
-  - title: "Reframing Jet Physics in Probabilistic Terms"
-    date: 2021-03-01
-    url: https://github.com/SebastianMacaluso/TalksSlides/blob/master/BrownBag_March2021.pdf
-    meeting: "CCPP Brown Bag seminar, NYU"
-    meetingurl: https://as.nyu.edu/content/nyu-as/as/departments/physics/events/spring-2017/20170508-ccpp-brown-bag.html
-    location: New York University
-    focus-area: ia
-    project: ml4jets
+- title: Pulling Out All the Tops with Computer Vision and Deep Learning
+  date: 2018-11-15
+  url: https://indico.cern.ch/event/745718/contributions/3174400/attachments/1754069/2843182/ML4Jets_2018_Macaluso.pdf
+  meeting: Machine Learning for Jet Physics
+  meetingurl: https://indico.cern.ch/event/745718/
+  location: Fermilab, Illinois, USA
+  focus-area: ia
+  project: ml4jets
+- title: 'SCAILFIN: Reproducible Open Benchmarks'
+  date: 2019-06-19
+  url: https://indico.cern.ch/event/822074/contributions/3471463/
+  meeting: Analysis Systems Topical Meeting
+  meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
+  location: NYU
+  focus-area:
+  - as
+  - ia
+- title: The Machine Learning Landscape of Top Taggers
+  date: 2019-07-23
+  url: https://indico.cern.ch/event/753914/contributions/3444496/
+  meeting: 11th International Workshop on Boosted Object Phenomenology, Reconstruction
+    and Searches in HEP (BOOST 2019)
+  meetingurl: https://indico.cern.ch/event/753914/overview
+  location: Massachusetts Institute of Technology (MIT)
+  focus-area: ia
+  project: ml4jets
+- title: Looking into Jets with Machine Learning
+  date: 2019-09-24
+  url: https://phy.princeton.edu/events/pheno-vino-seminar-sebastian-macaluso-nyu-looking-jets-machine-learning-jadwin-303
+  meeting: Princeton Pheno & Vino Seminar
+  meetingurl: https://phy.princeton.edu/events/pheno-vino-seminar-sebastian-macaluso-nyu-looking-jets-machine-learning-jadwin-303
+  location: Princeton University
+  focus-area: ia
+  project: ml4jets
+- title: Benchmarks for ML4Jets research
+  date: 2019-09-25
+  url: https://indico.cern.ch/event/841905/
+  meeting: IRIS-HEP Topical Meeting
+  meetingurl: https://indico.cern.ch/event/841905/
+  location: Vidyo
+  focus-area: ia
+  project: ml4jets
+- title: Looking into Jets with Machine Learning
+  date: 2019-11-01
+  url: https://github.com/SebastianMacaluso/TalksSlides/blob/master/physicsxML_v2.pdf
+  meeting: NYU Physics x ML
+  meetingurl: https://docs.google.com/spreadsheets/d/1eETvm0Uwr_vl6Bm7VUL6JnrHy8QraGzyK4kXztjNZlk/edit#gid=0
+  location: CDS New York University
+  focus-area: ia
+  project: ml4jets
+- title: Looking into Jets with Machine Learning
+  date: 2019-11-04
+  url: https://github.com/SebastianMacaluso/TalksSlides/blob/master/UMassDS.pdf
+  meeting: Data Science Tea UMass
+  meetingurl: https://ds.cs.umass.edu/event/sebastian-macaluso-nyu
+  location: CDS UMass Amherst
+  focus-area: ia
+  project: ml4jets
+- title: Looking into Jets with Machine Learning
+  date: 2019-11-19
+  url: https://hetg.physics.harvard.edu/seminar-schedule
+  meeting: Particle Theory Seminar, Harvard University
+  meetingurl: https://hetg.physics.harvard.edu/seminar-schedule
+  location: Harvard University
+  focus-area: ia
+  project: ml4jets
+- title: Looking into Jets with Machine Learning
+  date: 2020-01-17
+  url: https://indico.cern.ch/event/809820/contributions/3632649
+  meeting: ML4Jets 2020
+  meetingurl: https://indico.cern.ch/event/809820/
+  location: New York University
+  focus-area: ia
+  project: ml4jets
+- title: New Computational Techniques and Machine Learning for Jet Physics
+  date: 2020-09-21
+  url: https://github.com/SebastianMacaluso/TalksSlides/blob/master/LaPlata2020.pdf
+  meeting: Particle Theory Seminar, Instituto de Fisica La Plata, UNLP
+  meetingurl: https://github.com/SebastianMacaluso/TalksSlides/blob/master/LaPlata2020.pdf
+  location: Instituto de Fisica La Plata, La Plata, Argentina
+  focus-area: ia
+  project: ml4jets
+- title: Reframing Jet Physics in Probabilistic Terms
+  date: 2021-03-01
+  url: https://github.com/SebastianMacaluso/TalksSlides/blob/master/BrownBag_March2021.pdf
+  meeting: CCPP Brown Bag seminar, NYU
+  meetingurl: https://as.nyu.edu/content/nyu-as/as/departments/physics/events/spring-2017/20170508-ccpp-brown-bag.html
+  location: New York University
+  focus-area: ia
+  project: ml4jets

--- a/_data/people/SebastianMacaluso.yml
+++ b/_data/people/SebastianMacaluso.yml
@@ -98,3 +98,6 @@ presentations:
   location: New York University
   focus-area: ia
   project: ml4jets
+focus-area:
+- ia
+- as

--- a/_data/people/SebastianMacaluso.yml
+++ b/_data/people/SebastianMacaluso.yml
@@ -1,12 +1,14 @@
----
+active: true
+e-mail: sm4511@nyu.edu
+focus-area:
+- ia
+- as
+institution: New York University
 name: Sebastian Macaluso
+photo: "/assets/images/team/Sebastian-Macaluso.jpg"
 shortname: SebastianMacaluso
 title:
-active: true
-institution: New York University
 website:
-photo: "/assets/images/team/Sebastian-Macaluso.jpg"
-e-mail: sm4511@nyu.edu
 presentations:
 - title: Pulling Out All the Tops with Computer Vision and Deep Learning
   date: 2018-11-15
@@ -98,6 +100,3 @@ presentations:
   location: New York University
   focus-area: ia
   project: ml4jets
-focus-area:
-- ia
-- as

--- a/_data/people/a_digirolamo.yml
+++ b/_data/people/a_digirolamo.yml
@@ -1,10 +1,9 @@
----
+active: true
+hidden: true
+institution: CERN
 name: Alessandro Di Girolamo
+photo: "/assets/images/team/Alessandro_Di_Girolamo.png"
 shortname: a_digirolamo
 title: ATLAS Computing Coordinator
-active: true
-institution: CERN
 website:
-photo: "/assets/images/team/Alessandro_Di_Girolamo.png"
-hidden: true
 presentations:

--- a/_data/people/a_digirolamo.yml
+++ b/_data/people/a_digirolamo.yml
@@ -1,9 +1,10 @@
-name:  Alessandro Di Girolamo
+---
+name: Alessandro Di Girolamo
 shortname: a_digirolamo
 title: ATLAS Computing Coordinator
 active: true
 institution: CERN
 website:
-photo: /assets/images/team/Alessandro_Di_Girolamo.png
+photo: "/assets/images/team/Alessandro_Di_Girolamo.png"
 hidden: true
 presentations:

--- a/_data/people/aaronmoate.yml
+++ b/_data/people/aaronmoate.yml
@@ -1,8 +1,9 @@
+---
 name: Aaron Moate
 shortname: aaronmoate
 title: Systems Administrator
 active: true
 institution: University of Wisconsin–Madison
 website:
-photo: /assets/images/team/Aaron-Moate.png
+photo: "/assets/images/team/Aaron-Moate.png"
 presentations:

--- a/_data/people/aaronmoate.yml
+++ b/_data/people/aaronmoate.yml
@@ -1,9 +1,8 @@
----
-name: Aaron Moate
-shortname: aaronmoate
-title: Systems Administrator
 active: true
 institution: University of Wisconsin–Madison
-website:
+name: Aaron Moate
 photo: "/assets/images/team/Aaron-Moate.png"
+shortname: aaronmoate
+title: Systems Administrator
+website:
 presentations:

--- a/_data/people/alanjoshua.yml
+++ b/_data/people/alanjoshua.yml
@@ -1,9 +1,8 @@
----
-name: Alan Aneeth Jegaraj
-shortname: alanjoshua
-title:
 active: true
 institution: University of Cincinnati
-website:
+name: Alan Aneeth Jegaraj
 photo: "/assets/images/team/Alan-AneethJegaraj.JPG"
+shortname: alanjoshua
+title:
+website:
 presentations:

--- a/_data/people/alanjoshua.yml
+++ b/_data/people/alanjoshua.yml
@@ -1,8 +1,9 @@
+---
 name: Alan Aneeth Jegaraj
 shortname: alanjoshua
 title:
 active: true
 institution: University of Cincinnati
 website:
-photo: /assets/images/team/Alan-AneethJegaraj.JPG
+photo: "/assets/images/team/Alan-AneethJegaraj.JPG"
 presentations:

--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -1,81 +1,82 @@
+---
 name: Alexander Held
 shortname: alexander-held
 title: Postdoctoral researcher
 active: true
 institution: New York University
-website:  https://github.com/alexander-held
-photo: /assets/images/team/alexander-held.jpeg
+website: https://github.com/alexander-held
+photo: "/assets/images/team/alexander-held.jpeg"
 e-mail: alexander.held@cern.ch
 presentations:
-  - title: "Template Fits: HistFitter / TRExFitter"
-    date: 2019-06-19
-    url: https://indico.cern.ch/event/822074/contributions/3471458/
-    meeting: Analysis Systems Topical Meeting
-    meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
-    location: NYU
-    focus-area: as
-    project: cabinetry
-  - title: "Harmonizing statistics tools - ideas"
-    date: 2019-10-29
-    url: https://indico.cern.ch/event/859742/contributions/3620507/
-    meeting: ATLAS Statistics Committee Meeting
-    meetingurl: https://indico.cern.ch/event/859742/
-    location: CERN
-    focus-area: as
-    project: cabinetry
-  - title: "Constraining effective field theories with machine learning"
-    date: 2019-11-07
-    url: https://indico.cern.ch/event/773049/contributions/3476179/
-    meeting: 24th International Conference on Computing in High Energy & Nuclear Physics
-    meetingurl: https://indico.cern.ch/event/773049/
-    location: Adelaide, Australia
-    focus-area: as
-    project: madminer
-  - title: "Rethinking final analysis stages (poster)"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331188/18_-_AS_Final_analysis_stages.pdf
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton, USA
-    focus-area: as
-    project: cabinetry
-  - title: "pyhf and thoughts about analysis workflow"
-    date: 2020-03-12
-    url: https://indico.cern.ch/event/897232/contributions/3784156/
-    meeting: ATLAS Statistics Committee Meeting
-    meetingurl: https://indico.cern.ch/event/897232/
-    location: CERN
-    focus-area: as
-    project: cabinetry
-  - title: "Cabinetry introduction"
-    date: 2020-05-27
-    url: https://indico.cern.ch/event/896167/contributions/3880230/
-    meeting: 2020 IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167/
-    location: (Virtual)
-    focus-area: as
-    project: cabinetry
-  - title: "Differentiable physics analyses"
-    date: 2020-08-11
-    url: https://indico.fnal.gov/event/43829/contributions/193761/
-    meeting: Snowmass Computational Frontier Workshop
-    meetingurl: https://indico.fnal.gov/event/43829/
-    location: (Virtual)
-    focus-area: as
-    project:
-  - title: "Template-based Fitting: cabinetry"
-    date: 2020-10-26
-    url: https://indico.cern.ch/event/960587/contributions/4070322/
-    meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
-    meetingurl: https://indico.cern.ch/event/960587/
-    location: (Virtual)
-    focus-area: as
-    project: cabinetry
-  - title: "The cabinetry library"
-    date: 2021-02-25
-    url: https://indico.cern.ch/event/1005890/contributions/4222699/
-    meeting: ATLAS Statistics Forum Meeting
-    meetingurl: https://indico.cern.ch/event/1005890/
-    location: (Virtual)
-    focus-area: as
-    project: cabinetry
+- title: 'Template Fits: HistFitter / TRExFitter'
+  date: 2019-06-19
+  url: https://indico.cern.ch/event/822074/contributions/3471458/
+  meeting: Analysis Systems Topical Meeting
+  meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
+  location: NYU
+  focus-area: as
+  project: cabinetry
+- title: Harmonizing statistics tools - ideas
+  date: 2019-10-29
+  url: https://indico.cern.ch/event/859742/contributions/3620507/
+  meeting: ATLAS Statistics Committee Meeting
+  meetingurl: https://indico.cern.ch/event/859742/
+  location: CERN
+  focus-area: as
+  project: cabinetry
+- title: Constraining effective field theories with machine learning
+  date: 2019-11-07
+  url: https://indico.cern.ch/event/773049/contributions/3476179/
+  meeting: 24th International Conference on Computing in High Energy & Nuclear Physics
+  meetingurl: https://indico.cern.ch/event/773049/
+  location: Adelaide, Australia
+  focus-area: as
+  project: madminer
+- title: Rethinking final analysis stages (poster)
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331188/18_-_AS_Final_analysis_stages.pdf
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton, USA
+  focus-area: as
+  project: cabinetry
+- title: pyhf and thoughts about analysis workflow
+  date: 2020-03-12
+  url: https://indico.cern.ch/event/897232/contributions/3784156/
+  meeting: ATLAS Statistics Committee Meeting
+  meetingurl: https://indico.cern.ch/event/897232/
+  location: CERN
+  focus-area: as
+  project: cabinetry
+- title: Cabinetry introduction
+  date: 2020-05-27
+  url: https://indico.cern.ch/event/896167/contributions/3880230/
+  meeting: 2020 IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167/
+  location: "(Virtual)"
+  focus-area: as
+  project: cabinetry
+- title: Differentiable physics analyses
+  date: 2020-08-11
+  url: https://indico.fnal.gov/event/43829/contributions/193761/
+  meeting: Snowmass Computational Frontier Workshop
+  meetingurl: https://indico.fnal.gov/event/43829/
+  location: "(Virtual)"
+  focus-area: as
+  project:
+- title: 'Template-based Fitting: cabinetry'
+  date: 2020-10-26
+  url: https://indico.cern.ch/event/960587/contributions/4070322/
+  meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
+  meetingurl: https://indico.cern.ch/event/960587/
+  location: "(Virtual)"
+  focus-area: as
+  project: cabinetry
+- title: The cabinetry library
+  date: 2021-02-25
+  url: https://indico.cern.ch/event/1005890/contributions/4222699/
+  meeting: ATLAS Statistics Forum Meeting
+  meetingurl: https://indico.cern.ch/event/1005890/
+  location: "(Virtual)"
+  focus-area: as
+  project: cabinetry

--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -1,12 +1,13 @@
----
+active: true
+e-mail: alexander.held@cern.ch
+focus-area:
+- as
+institution: New York University
 name: Alexander Held
+photo: "/assets/images/team/alexander-held.jpeg"
 shortname: alexander-held
 title: Postdoctoral researcher
-active: true
-institution: New York University
 website: https://github.com/alexander-held
-photo: "/assets/images/team/alexander-held.jpeg"
-e-mail: alexander.held@cern.ch
 presentations:
 - title: 'Template Fits: HistFitter / TRExFitter'
   date: 2019-06-19
@@ -80,5 +81,3 @@ presentations:
   location: "(Virtual)"
   focus-area: as
   project: cabinetry
-focus-area:
-- as

--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -80,3 +80,5 @@ presentations:
   location: "(Virtual)"
   focus-area: as
   project: cabinetry
+focus-area:
+- as

--- a/_data/people/andrewchien.yml
+++ b/_data/people/andrewchien.yml
@@ -1,9 +1,8 @@
----
-name: Andrew Chien
-shortname: andrewchien
-title:
 active: true
 institution: University of Chicago
-website: http://people.cs.uchicago.edu/~aachien/
+name: Andrew Chien
 photo: "/assets/images/team/Andrew-Chien.jpg"
+shortname: andrewchien
+title:
+website: http://people.cs.uchicago.edu/~aachien/
 presentations:

--- a/_data/people/andrewchien.yml
+++ b/_data/people/andrewchien.yml
@@ -1,8 +1,9 @@
+---
 name: Andrew Chien
 shortname: andrewchien
 title:
 active: true
 institution: University of Chicago
 website: http://people.cs.uchicago.edu/~aachien/
-photo: /assets/images/team/Andrew-Chien.jpg
+photo: "/assets/images/team/Andrew-Chien.jpg"
 presentations:

--- a/_data/people/b_cousins.yml
+++ b/_data/people/b_cousins.yml
@@ -1,12 +1,11 @@
----
+about: Former deputy spokesman of CMS, expert in statistics.
+active: true
+hidden: true
+institution: University of California, Los Angeles
 name: Bob Cousins
+photo: "/assets/images/team/b_cousins.png"
+role: Provide a global view of CMS activities.
 shortname: b_cousins
 title:
-active: true
-institution: University of California, Los Angeles
 website:
-photo: "/assets/images/team/b_cousins.png"
 presentations:
-about: Former deputy spokesman of CMS, expert in statistics.
-role: Provide a global view of CMS activities.
-hidden: true

--- a/_data/people/b_cousins.yml
+++ b/_data/people/b_cousins.yml
@@ -1,10 +1,11 @@
+---
 name: Bob Cousins
 shortname: b_cousins
 title:
 active: true
 institution: University of California, Los Angeles
 website:
-photo: /assets/images/team/b_cousins.png
+photo: "/assets/images/team/b_cousins.png"
 presentations:
 about: Former deputy spokesman of CMS, expert in statistics.
 role: Provide a global view of CMS activities.

--- a/_data/people/bbockelm.yml
+++ b/_data/people/bbockelm.yml
@@ -1,11 +1,14 @@
----
+active: true
+focus-area:
+- doma
+- osglhc
+- as
+institution: Morgridge Institute
 name: Brian Bockelman
+photo: "/assets/images/team/Brian-Bockelman.jpg"
 shortname: bbockelm
 title: Institute co-PI and DOMA R&D Area Lead
-active: true
-institution: Morgridge Institute
 website: http://iris-hep.org
-photo: "/assets/images/team/Brian-Bockelman.jpg"
 presentations:
 - title: IRIS-HEP DOMA
   date: 2019-02-06
@@ -151,7 +154,3 @@ presentations:
   url: https://indico.cern.ch/event/957103/contributions/4330982/attachments/2234425/3786796/IRIS-HEP%20-%20DOMA%20-%20EB%20retreat.pdf
   focus-area: doma
   date: 2021-04-27
-focus-area:
-- doma
-- osglhc
-- as

--- a/_data/people/bbockelm.yml
+++ b/_data/people/bbockelm.yml
@@ -151,3 +151,7 @@ presentations:
   url: https://indico.cern.ch/event/957103/contributions/4330982/attachments/2234425/3786796/IRIS-HEP%20-%20DOMA%20-%20EB%20retreat.pdf
   focus-area: doma
   date: 2021-04-27
+focus-area:
+- doma
+- osglhc
+- as

--- a/_data/people/bbockelm.yml
+++ b/_data/people/bbockelm.yml
@@ -1,149 +1,153 @@
+---
 name: Brian Bockelman
 shortname: bbockelm
 title: Institute co-PI and DOMA R&D Area Lead
 active: true
 institution: Morgridge Institute
 website: http://iris-hep.org
-photo: /assets/images/team/Brian-Bockelman.jpg
+photo: "/assets/images/team/Brian-Bockelman.jpg"
 presentations:
-  - title: "IRIS-HEP DOMA"
-    date: 2019-02-06
-    url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271528/attachments/1790472/2919593/DOMA-SB-1.pdf
-    meeting: IRIS-HEP Steering Board Meeting #1
-    meetingurl: https://indico.cern.ch/event/790759/
-    focus-area: doma
-    project: [idds, tpc]
-  - title: "WLCG DOMA TPC Updates"
-    date: 2019-03-20
-    url: https://indico.cern.ch/event/759388/contributions/3312485/attachments/1815438/2968872/DOMA-TPC-HOW2019-v4.pdf
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop (HOW2019)
-    meetingurl: https://indico.cern.ch/event/759388
-    focus-area: doma
-    project: idds
-  - title: "OSG Technology Updates for 2019"
-    date: 2019-03-20
-    url: https://indico.cern.ch/event/759388/contributions/3353317/attachments/1815443/2966874/OSG-AHM-2019.pdf
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop (HOW2019)
-    meetingurl: https://indico.cern.ch/event/759388
-    focus-area: osglhc
-  - title: "WLCG DOMA TPC Working Group"
-    date: 2019-05-28
-    meeting: US CMS Tier-2 Facilities May 2019 Meeting
-    url: https://indico.cern.ch/event/823168/contributions/3442076/attachments/1852590/3041829/WLCG-DOMA-USCMS-T2.pdf
-    focus-area: doma
-    project: tpc
-  - title: "DOMA: Preparing for Year 2 and Year 4"
-    date: 2019-09-12
-    meeting: IRIS-HEP Institute Retreat
-    url: https://indico.cern.ch/event/840472/contributions/3561604/attachments/1907178/3149976/IRIS-HEP-DOMA-RETREAT.pdf
-    focus-area: doma
-  - title: "Data Organization, Management, and Access"
-    date: 2019-09-03
-    meeting: IRIS-HEP Steering Board Meeting #3
-    url: https://indico.cern.ch/event/809178/contributions/3370588/subcontributions/277983/attachments/1901191/3138429/IRIS-HEP-DOMA-SB3.pdf
-    focus-area: doma
-  - title: "HSF Event Delivery WG - Introduction"
-    date: 2019-09-30
-    meeting: HSF & ATLAS Joint Event Delivery Workshop
-    url: https://indico.cern.ch/event/849155/sessions/323697/attachments/1917032/3169811/HSF-EventDelivery-WG-Introduction.pdf
-    focus-area: doma
-  - title: "Third-party transfers in WLCG using HTTP"
-    date: 2019-11-05
-    meeting: 24th International Conference on Computing in High Energy & Nuclear Physics
-    url: https://indico.cern.ch/event/773049/contributions/3474402/attachments/1938592/3213446/CHEP19-HTTP-TPC.pdf
-    meetingurl: https://indico.cern.ch/event/773049/
-    location: Adelaide, South Australia
-    focus-area: doma
-    project: tpc
-  - title: "DOMA Update for February 2020 Steering Board"
-    date: 2020-02-18
-    meeting: IRIS-HEP Steering Board Meeting #5
-    url: https://indico.cern.ch/event/809181/contributions/3746701/attachments/1989190/3315708/IRIS-HEP-DOMA-SB-5-v2.pdf
-    meetingurl: https://indico.cern.ch/event/809181/
-    focus-area: doma
-  - title: "Modernizing the LHC’s transfer infrastructure"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331169/1_-_Modernizing_LHC_Transfer_Infra_-_v1.pdf
-    focus-area: doma
-    project: tpc
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton University
-  - title: "Institute for Research and Innovation in Software for High Energy Physics (IRIS-HEP)"
-    date: 2020-03-09
-    meeting: HEP-CCE Kick Off Meeting
-    meetingurl: https://indico.fnal.gov/event/23262
-    location: Argonne National Laboratory
-    url: https://indico.fnal.gov/event/23262/contributions/71467/attachments/44823/53975/IRIS-HEP-CCE-Kickoff-v1.pdf
-  - title: "TPC: Status, Plans, Contribution to the HL-LHC review document"
-    meeting: WLCG DOMA F2F @ FNAL
-    meetingurl: https://indico.cern.ch/event/875110/
-    url: https://indico.cern.ch/event/875110/contributions/3772469/attachments/2000379/3338941/WLCG-DOMA-F2F-TPC-Update.pdf
-    date: 2020-03-09
-    focus-area: doma
-  - title: "IRIS-HEP and DOMA related activities"
-    meeting: WLCG DOMA F2F @ FNAL
-    meetingurl: https://indico.cern.ch/event/875110/
-    url: https://indico.cern.ch/event/875110/contributions/3772474/attachments/2000383/3338950/IRIS-HEP-WLCG-DOMA-F2F.pdf
-    date: 2020-03-09
-    focus-area: doma
-    project: tpc
-  - title: "Update on the Globus transition"
-    meeting: OSG Council March 2020 Meeting
-    meetingurl: https://indico.fnal.gov/event/23625/
-    url: https://indico.fnal.gov/event/23625/contributions/73341/attachments/45884/55174/OSG-Council-Globus-Transition.pdf
-    focus-area: osglhc
-    date: 2020-03-19
-    project: tpc
-  - title: "OSG-LHC Technical Roadmap"
-    meeting: US ATLAS Computing Facility
-    meetingurl: https://indico.cern.ch/event/903811/
-    url: https://indico.cern.ch/event/903811/contributions/3803835/attachments/2029549/3396220/USATLAS-Facilities-2020-Upgrades.pdf
-    focus-area: osglhc
-    date: 2020-04-29
-    project: tpc
-  - title: "DOMA - Years 3, and 4+5"
-    meeting: IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167
-    url: https://indico.cern.ch/event/896167/contributions/3870076/attachments/2044575/3426079/DOMA_Year_3.pdf
-    focus-area: doma
-    date: 2020-05-26
-  - title: "DOMA: Year 3 Plans, Year 4 & 5 Goals"
-    url: https://indico.cern.ch/event/896167/contributions/3874634/attachments/2047275/3431440/DOMA_Year_3_-_Plans.pdf
-    meeting: IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167
-    focus-area: doma
-    date: 2020-05-29
-  - title: "Latest updates on the WLCG Token Transition Planning"
-    meetingurl: https://indico.fnal.gov/event/47040
-    url: https://indico.fnal.gov/event/47040/contributions/209608/attachments/140707/176892/WLCG_Transition_-_OSG_AHM_2021.pdf
-    meeting: OSG All-Hands Meeting 2021
-    date: 2021-03-05
-    focus-area: osglhc
-    project: tpc
-  - title: "Follow-up on the WLCG Token Transition Timeline"
-    meetingurl: https://indico.cern.ch/event/876773/
-    meeting: February 2021 GDB
-    url: https://indico.cern.ch/event/876773/contributions/4225122/attachments/2187931/3697170/WLCG-Token-Transition-Feb-2020.pdf
-    date: 2021-02-10
-    focus-area: osglhc
-    project: tpc
-  - title: "Update on OSG Token & Transfer Transition"
-    meetingurl: https://indico.cern.ch/event/813754
-    url: https://indico.cern.ch/event/813754/contributions/4139583/attachments/2159596/3643359/OSG-Transition-Update-GDB-Dec-2020.pdf
-    meeting: December 2020 GDB
-    date: 2020-12-09
-    focus-area: osglhc
-    project: tpc
-  - title: "DOMA Update for Steering Board #8"
-    meetingurl: https://indico.cern.ch/event/894516/
-    url: https://indico.cern.ch/event/894516/contributions/3772802/attachments/2149727/3624228/IRIS-HEP-DOMA-SB-8-v1.pdf
-    meeting: IRIS-HEP Steering Board Meeting #8
-    focus-area: doma
-    date: 2020-11-24
-  - title: "DOMA Update – IRIS-HEP Exec Board Meeting"
-    meeting: IRIS-HEP PI/EB Meeting
-    meetingurl: https://indico.cern.ch/event/957103
-    url: https://indico.cern.ch/event/957103/contributions/4330982/attachments/2234425/3786796/IRIS-HEP%20-%20DOMA%20-%20EB%20retreat.pdf
-    focus-area: doma
-    date: 2021-04-27
+- title: IRIS-HEP DOMA
+  date: 2019-02-06
+  url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271528/attachments/1790472/2919593/DOMA-SB-1.pdf
+  meeting: IRIS-HEP Steering Board Meeting
+  meetingurl: https://indico.cern.ch/event/790759/
+  focus-area: doma
+  project:
+  - idds
+  - tpc
+- title: WLCG DOMA TPC Updates
+  date: 2019-03-20
+  url: https://indico.cern.ch/event/759388/contributions/3312485/attachments/1815438/2968872/DOMA-TPC-HOW2019-v4.pdf
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop (HOW2019)
+  meetingurl: https://indico.cern.ch/event/759388
+  focus-area: doma
+  project: idds
+- title: OSG Technology Updates for 2019
+  date: 2019-03-20
+  url: https://indico.cern.ch/event/759388/contributions/3353317/attachments/1815443/2966874/OSG-AHM-2019.pdf
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop (HOW2019)
+  meetingurl: https://indico.cern.ch/event/759388
+  focus-area: osglhc
+- title: WLCG DOMA TPC Working Group
+  date: 2019-05-28
+  meeting: US CMS Tier-2 Facilities May 2019 Meeting
+  url: https://indico.cern.ch/event/823168/contributions/3442076/attachments/1852590/3041829/WLCG-DOMA-USCMS-T2.pdf
+  focus-area: doma
+  project: tpc
+- title: 'DOMA: Preparing for Year 2 and Year 4'
+  date: 2019-09-12
+  meeting: IRIS-HEP Institute Retreat
+  url: https://indico.cern.ch/event/840472/contributions/3561604/attachments/1907178/3149976/IRIS-HEP-DOMA-RETREAT.pdf
+  focus-area: doma
+- title: Data Organization, Management, and Access
+  date: 2019-09-03
+  meeting: IRIS-HEP Steering Board Meeting
+  url: https://indico.cern.ch/event/809178/contributions/3370588/subcontributions/277983/attachments/1901191/3138429/IRIS-HEP-DOMA-SB3.pdf
+  focus-area: doma
+- title: HSF Event Delivery WG - Introduction
+  date: 2019-09-30
+  meeting: HSF & ATLAS Joint Event Delivery Workshop
+  url: https://indico.cern.ch/event/849155/sessions/323697/attachments/1917032/3169811/HSF-EventDelivery-WG-Introduction.pdf
+  focus-area: doma
+- title: Third-party transfers in WLCG using HTTP
+  date: 2019-11-05
+  meeting: 24th International Conference on Computing in High Energy & Nuclear Physics
+  url: https://indico.cern.ch/event/773049/contributions/3474402/attachments/1938592/3213446/CHEP19-HTTP-TPC.pdf
+  meetingurl: https://indico.cern.ch/event/773049/
+  location: Adelaide, South Australia
+  focus-area: doma
+  project: tpc
+- title: DOMA Update for February 2020 Steering Board
+  date: 2020-02-18
+  meeting: IRIS-HEP Steering Board Meeting
+  url: https://indico.cern.ch/event/809181/contributions/3746701/attachments/1989190/3315708/IRIS-HEP-DOMA-SB-5-v2.pdf
+  meetingurl: https://indico.cern.ch/event/809181/
+  focus-area: doma
+- title: Modernizing the LHC’s transfer infrastructure
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331169/1_-_Modernizing_LHC_Transfer_Infra_-_v1.pdf
+  focus-area: doma
+  project: tpc
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton University
+- title: Institute for Research and Innovation in Software for High Energy Physics
+    (IRIS-HEP)
+  date: 2020-03-09
+  meeting: HEP-CCE Kick Off Meeting
+  meetingurl: https://indico.fnal.gov/event/23262
+  location: Argonne National Laboratory
+  url: https://indico.fnal.gov/event/23262/contributions/71467/attachments/44823/53975/IRIS-HEP-CCE-Kickoff-v1.pdf
+- title: 'TPC: Status, Plans, Contribution to the HL-LHC review document'
+  meeting: WLCG DOMA F2F @ FNAL
+  meetingurl: https://indico.cern.ch/event/875110/
+  url: https://indico.cern.ch/event/875110/contributions/3772469/attachments/2000379/3338941/WLCG-DOMA-F2F-TPC-Update.pdf
+  date: 2020-03-09
+  focus-area: doma
+- title: IRIS-HEP and DOMA related activities
+  meeting: WLCG DOMA F2F @ FNAL
+  meetingurl: https://indico.cern.ch/event/875110/
+  url: https://indico.cern.ch/event/875110/contributions/3772474/attachments/2000383/3338950/IRIS-HEP-WLCG-DOMA-F2F.pdf
+  date: 2020-03-09
+  focus-area: doma
+  project: tpc
+- title: Update on the Globus transition
+  meeting: OSG Council March 2020 Meeting
+  meetingurl: https://indico.fnal.gov/event/23625/
+  url: https://indico.fnal.gov/event/23625/contributions/73341/attachments/45884/55174/OSG-Council-Globus-Transition.pdf
+  focus-area: osglhc
+  date: 2020-03-19
+  project: tpc
+- title: OSG-LHC Technical Roadmap
+  meeting: US ATLAS Computing Facility
+  meetingurl: https://indico.cern.ch/event/903811/
+  url: https://indico.cern.ch/event/903811/contributions/3803835/attachments/2029549/3396220/USATLAS-Facilities-2020-Upgrades.pdf
+  focus-area: osglhc
+  date: 2020-04-29
+  project: tpc
+- title: DOMA - Years 3, and 4+5
+  meeting: IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167
+  url: https://indico.cern.ch/event/896167/contributions/3870076/attachments/2044575/3426079/DOMA_Year_3.pdf
+  focus-area: doma
+  date: 2020-05-26
+- title: 'DOMA: Year 3 Plans, Year 4 & 5 Goals'
+  url: https://indico.cern.ch/event/896167/contributions/3874634/attachments/2047275/3431440/DOMA_Year_3_-_Plans.pdf
+  meeting: IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167
+  focus-area: doma
+  date: 2020-05-29
+- title: Latest updates on the WLCG Token Transition Planning
+  meetingurl: https://indico.fnal.gov/event/47040
+  url: https://indico.fnal.gov/event/47040/contributions/209608/attachments/140707/176892/WLCG_Transition_-_OSG_AHM_2021.pdf
+  meeting: OSG All-Hands Meeting 2021
+  date: 2021-03-05
+  focus-area: osglhc
+  project: tpc
+- title: Follow-up on the WLCG Token Transition Timeline
+  meetingurl: https://indico.cern.ch/event/876773/
+  meeting: February 2021 GDB
+  url: https://indico.cern.ch/event/876773/contributions/4225122/attachments/2187931/3697170/WLCG-Token-Transition-Feb-2020.pdf
+  date: 2021-02-10
+  focus-area: osglhc
+  project: tpc
+- title: Update on OSG Token & Transfer Transition
+  meetingurl: https://indico.cern.ch/event/813754
+  url: https://indico.cern.ch/event/813754/contributions/4139583/attachments/2159596/3643359/OSG-Transition-Update-GDB-Dec-2020.pdf
+  meeting: December 2020 GDB
+  date: 2020-12-09
+  focus-area: osglhc
+  project: tpc
+- title: 'DOMA Update for Steering Board #8'
+  meetingurl: https://indico.cern.ch/event/894516/
+  url: https://indico.cern.ch/event/894516/contributions/3772802/attachments/2149727/3624228/IRIS-HEP-DOMA-SB-8-v1.pdf
+  meeting: IRIS-HEP Steering Board Meeting
+  focus-area: doma
+  date: 2020-11-24
+- title: DOMA Update – IRIS-HEP Exec Board Meeting
+  meeting: IRIS-HEP PI/EB Meeting
+  meetingurl: https://indico.cern.ch/event/957103
+  url: https://indico.cern.ch/event/957103/contributions/4330982/attachments/2234425/3786796/IRIS-HEP%20-%20DOMA%20-%20EB%20retreat.pdf
+  focus-area: doma
+  date: 2021-04-27

--- a/_data/people/beiwang2003.yml
+++ b/_data/people/beiwang2003.yml
@@ -32,3 +32,5 @@ presentations:
   location: Princeton University
   focus-area: ia
   project:
+focus-area:
+- ia

--- a/_data/people/beiwang2003.yml
+++ b/_data/people/beiwang2003.yml
@@ -1,32 +1,34 @@
+---
 name: Bei Wang
 shortname: beiwang2003
 title: HPC Software Engineer
 active: true
 institution: Princeton University
 website:
-photo: /assets/images/team/Bei-Wang.jpg
+photo: "/assets/images/team/Bei-Wang.jpg"
 presentations:
-  - title: Parallelizing the unpacking and clustering of detector data for reconstruction of charged particle tracks on multi-core CPUs and many-core GPUs
-    date: 2020-04-22
-    url: https://indico.cern.ch/event/831165/contributions/3717156/attachments/2025214/3387680/CTD_BeiWang.pdf
-    meeting: Connecting The Dots (2020)
-    meetingurl: https://indico.cern.ch/event/831165/
-    location: Virtual
-    focus-area: ia
-    project: mkfit
-  - title: Floating Point Arithmetic Is Not Real
-    date: 2019-07-24
-    url: https://indico.cern.ch/event/814979/contributions/3401175/attachments/1831476/3107964/FloatingPointArithmetic.pdf
-    meeting: Third Computational and Data Science school for HEP (CoDaS-HEP 2019)
-    meetingurl: https://indico.cern.ch/event/814979
-    location: Princeton University
-    focus-area: ia
-    project:
-  - title: Introduction to Performance Tuning & Optimization Tools
-    date: 2019-07-25
-    url: https://indico.cern.ch/event/814979/contributions/3401196/attachments/1831466/3109819/PerformanceTools.pdf
-    meeting: Third Computational and Data Science school for HEP (CoDaS-HEP 2019)
-    meetingurl: https://indico.cern.ch/event/814979
-    location: Princeton University
-    focus-area: ia
-    project:
+- title: Parallelizing the unpacking and clustering of detector data for reconstruction
+    of charged particle tracks on multi-core CPUs and many-core GPUs
+  date: 2020-04-22
+  url: https://indico.cern.ch/event/831165/contributions/3717156/attachments/2025214/3387680/CTD_BeiWang.pdf
+  meeting: Connecting The Dots (2020)
+  meetingurl: https://indico.cern.ch/event/831165/
+  location: Virtual
+  focus-area: ia
+  project: mkfit
+- title: Floating Point Arithmetic Is Not Real
+  date: 2019-07-24
+  url: https://indico.cern.ch/event/814979/contributions/3401175/attachments/1831476/3107964/FloatingPointArithmetic.pdf
+  meeting: Third Computational and Data Science school for HEP (CoDaS-HEP 2019)
+  meetingurl: https://indico.cern.ch/event/814979
+  location: Princeton University
+  focus-area: ia
+  project:
+- title: Introduction to Performance Tuning & Optimization Tools
+  date: 2019-07-25
+  url: https://indico.cern.ch/event/814979/contributions/3401196/attachments/1831466/3109819/PerformanceTools.pdf
+  meeting: Third Computational and Data Science school for HEP (CoDaS-HEP 2019)
+  meetingurl: https://indico.cern.ch/event/814979
+  location: Princeton University
+  focus-area: ia
+  project:

--- a/_data/people/beiwang2003.yml
+++ b/_data/people/beiwang2003.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ia
+institution: Princeton University
 name: Bei Wang
+photo: "/assets/images/team/Bei-Wang.jpg"
 shortname: beiwang2003
 title: HPC Software Engineer
-active: true
-institution: Princeton University
 website:
-photo: "/assets/images/team/Bei-Wang.jpg"
 presentations:
 - title: Parallelizing the unpacking and clustering of detector data for reconstruction
     of charged particle tracks on multi-core CPUs and many-core GPUs
@@ -32,5 +33,3 @@ presentations:
   location: Princeton University
   focus-area: ia
   project:
-focus-area:
-- ia

--- a/_data/people/beomki-yeo.yml
+++ b/_data/people/beomki-yeo.yml
@@ -6,3 +6,5 @@ active: true
 institution: University of California, Berkeley
 photo: "/assets/images/team/beomki-yeo.png"
 e-mail: beomki.yeo@berkeley.edu
+focus-area:
+- ia

--- a/_data/people/beomki-yeo.yml
+++ b/_data/people/beomki-yeo.yml
@@ -1,7 +1,8 @@
+---
 name: Beomki Yeo
 shortname: beomki-yeo
 title: Post-doctoral researcher
 active: true
 institution: University of California, Berkeley
-photo: /assets/images/team/beomki-yeo.png
+photo: "/assets/images/team/beomki-yeo.png"
 e-mail: beomki.yeo@berkeley.edu

--- a/_data/people/beomki-yeo.yml
+++ b/_data/people/beomki-yeo.yml
@@ -1,10 +1,10 @@
----
-name: Beomki Yeo
-shortname: beomki-yeo
-title: Post-doctoral researcher
 active: true
-institution: University of California, Berkeley
-photo: "/assets/images/team/beomki-yeo.png"
 e-mail: beomki.yeo@berkeley.edu
 focus-area:
 - ia
+institution: University of California, Berkeley
+name: Beomki Yeo
+photo: "/assets/images/team/beomki-yeo.png"
+shortname: beomki-yeo
+title: Post-doctoral researcher
+presentations:

--- a/_data/people/brianhlin.yml
+++ b/_data/people/brianhlin.yml
@@ -192,3 +192,5 @@ presentations:
   location: Argonne National Lab
   focus-area: osglhc
   project: osg-software
+focus-area:
+- osglhc

--- a/_data/people/brianhlin.yml
+++ b/_data/people/brianhlin.yml
@@ -1,193 +1,194 @@
+---
 name: Brian Lin
 shortname: brianhlin
 title: OSG Software Team Manager
 active: true
 institution: University of Wisconsin–Madison
 website:
-photo: /assets/images/team/Brian-Lin.jpg
+photo: "/assets/images/team/Brian-Lin.jpg"
 e-mail: blin@cs.wisc.edu
 presentations:
-  - title: "OSG Services and Kubernetes"
-    date: 2021-02-11
-    url: https://docs.google.com/presentation/d/1c25EB9LrvjRxTI0Vv6XhiV7SjybGjb8frHq7Kqo7oGA/edit?usp=sharing
-    meeting: GP-ARGO Technical Meeting
-    meetingurl:
-    location: Virtual
-    focus-area: osglhc
-    project: osg-software
-  - title: "What is next for the HTCondor-CE?"
-    date: 2020-09-23
-    url: https://indico.cern.ch/event/936993/contributions/4022138/
-    meeting: HTCondor Workshop Autumn 2020
-    meetingurl: https://indico.cern.ch/event/936993/
-    location: Madison, WI
-    focus-area: osglhc
-    project: osg-software
-  - title: "HTCondor-CE Troubleshooting"
-    date: 2020-09-23
-    url: https://indico.cern.ch/event/936993/contributions/4022137/
-    meeting: HTCondor Workshop Autumn 2020
-    meetingurl: https://indico.cern.ch/event/936993/
-    location: Madison, WI
-    focus-area: osglhc
-    project: osg-software
-  - title: "HTCondor-CE Live Installation"
-    date: 2020-09-23
-    url: https://indico.cern.ch/event/936993/contributions/4022136/
-    meeting: HTCondor Workshop Autumn 2020
-    meetingurl: https://indico.cern.ch/event/936993/
-    location: Madison, WI
-    focus-area: osglhc
-    project: osg-software
-  - title: "HTCondor-CE Configuration"
-    date: 2020-09-23
-    url: https://indico.cern.ch/event/936993/contributions/4022135/
-    meeting: HTCondor Workshop Autumn 2020
-    meetingurl: https://indico.cern.ch/event/936993/
-    location: Madison, WI
-    focus-area: osglhc
-    project: osg-software
-  - title: "HTCondor-CE Overview"
-    date: 2020-09-23
-    url: https://indico.cern.ch/event/936993/contributions/4022131/
-    meeting: HTCondor Workshop Autumn 2020
-    meetingurl: https://indico.cern.ch/event/936993/
-    location: Madison, WI
-    focus-area: osglhc
-    project: osg-software
-  - title: "Introduction to HTCondor-CE"
-    date: 2020-06-17
-    url: https://indico.egi.eu/event/5137/attachments/12966/15338/2020-06-17.htcondorce-intro_FINAL.pdf
-    meeting: EGI Community Webinar Programme
-    meetingurl: https://indico.egi.eu/event/5137/
-    location: Virtual
-    focus-area: osglhc
-    project: osg-software
-  - title: "GridFTP and GSI Migration Plan (Poster)"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331191/21_-_OSG-LHC_GridFTP_and_GSI_Migration_Plan_-_FINAL.pdf
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton, New Jersey, US
-    focus-area: osglhc
-    project: osg-software
-  - title: "Infrastructure Software Delivery (Poster)"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331202/26_-_OSG-LHC_Infrastructure_Software_Delivery_-_FINAL.pdf
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton, New Jersey, US
-    focus-area: osglhc
-    project: osg-software
-  - title: "HTCondor-CE What's Next?"
-    date: 2019-09-26
-    url: https://indico.cern.ch/event/817927/contributions/3570564/
-    meeting: "European HTCondor Week"
-    meetingurl: https://indico.cern.ch/event/817927
-    location: EU Joint Research Centre
-    focus-area: osglhc
-    project: osg-software
-  - title: "HTCondor-CE Troubleshooting"
-    date: 2019-09-26
-    url: https://indico.cern.ch/event/817927/contributions/3570561/
-    meeting: "European HTCondor Week"
-    meetingurl: https://indico.cern.ch/event/817927
-    location: EU Joint Research Centre
-    focus-area: osglhc
-    project: osg-software
-  - title: "HTCondor-CE Integration with APEL and BDII"
-    date: 2019-09-26
-    url: https://indico.cern.ch/event/817927/contributions/3570558/
-    meeting: "European HTCondor Week"
-    meetingurl: https://indico.cern.ch/event/817927
-    location: EU Joint Research Centre
-    focus-area: osglhc
-    project: osg-software
-  - title: "HTCondor-CE Configuration"
-    date: 2019-09-26
-    url: https://indico.cern.ch/event/817927/contributions/3570557/
-    meeting: "European HTCondor Week"
-    meetingurl: https://indico.cern.ch/event/817927
-    location: EU Joint Research Centre
-    focus-area: osglhc
-    project: osg-software
-  - title: "HTCondor-CE Basics and Architecture"
-    date: 2019-09-26
-    url: https://indico.cern.ch/event/817927/contributions/3570555/
-    meeting: "European HTCondor Week"
-    meetingurl: https://indico.cern.ch/event/817927
-    location: EU Joint Research Centre
-    focus-area: osglhc
-    project: osg-software
-  - title: "Security Model for Containerized Grid Services"
-    date: 2019-06-27
-    url: https://indico.cern.ch/event/765245/timetable/#111-security-model-for-contain
-    meeting: "Atlas Software & Computing Week #62"
-    meetingurl: https://indico.cern.ch/event/765245
-    location: New York University
-    focus-area: osglhc
-    project: osg-software
-  - title: "XCache Packaging"
-    date: 2019-06-11
-    url: https://indico.cern.ch/event/727208/contributions/3444631/
-    meeting: XRootD Workshop
-    meetingurl: https://indico.cern.ch/event/727208
-    location: CC-IN2P3
-    focus-area: osglhc
-    project: caching
-  - title: "OSG Software: The Year in Review"
-    date: 2019-03-19
-    url: https://indico.cern.ch/event/759388/contributions/3353297/
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop
-    meetingurl: https://indico.cern.ch/event/759388/
-    location: Jefferson Lab
-    focus-area: osglhc
-    project: osg-software
-  - title: "OSG Site Installation Overview"
-    date: 2019-03-21
-    url: https://indico.cern.ch/event/759388/contributions/3364839/
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop
-    meetingurl: https://indico.cern.ch/event/759388/
-    location: Jefferson Lab
-    focus-area: osglhc
-    project: osg-software
-  - title: "HTCondor-CE Overview"
-    date: 2019-03-21
-    url: https://indico.cern.ch/event/759388/contributions/3364839/
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop
-    meetingurl: https://indico.cern.ch/event/759388/
-    location: Jefferson Lab
-    focus-area: osglhc
-    project: osg-software
-  - title: "Container Basics"
-    date: 2019-03-21
-    url: https://indico.cern.ch/event/759388/contributions/3364840/
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop
-    meetingurl: https://indico.cern.ch/event/759388/
-    location: Jefferson Lab
-    focus-area: osglhc
-    project: osg-software
-  - title: "OSG Software Containers"
-    date: 2019-03-21
-    url: https://indico.cern.ch/event/759388/contributions/3364840/
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop
-    meetingurl: https://indico.cern.ch/event/759388/
-    location: Jefferson Lab
-    focus-area: osglhc
-    project: osg-software
-  - title: "OSG-LHC and XCache"
-    date: 2018-12-12
-    url: https://indico.cern.ch/event/770941/contributions/3230458/
-    meeting: ATLAS Software & Computing Week \#61
-    meetingurl: https://indico.cern.ch/event/646947/
-    location: CERN
-    focus-area: osglhc
-    project: caching
-  - title: "OSG-LHC and ATLAS"
-    date: 2018-12-03
-    url: https://indico.cern.ch/event/766802/contributions/3223347/
-    meeting: US-ATLAS Facilities Meeting
-    meetingurl: https://indico.cern.ch/event/766802/
-    location: Argonne National Lab
-    focus-area: osglhc
-    project: osg-software
+- title: OSG Services and Kubernetes
+  date: 2021-02-11
+  url: https://docs.google.com/presentation/d/1c25EB9LrvjRxTI0Vv6XhiV7SjybGjb8frHq7Kqo7oGA/edit?usp=sharing
+  meeting: GP-ARGO Technical Meeting
+  meetingurl:
+  location: Virtual
+  focus-area: osglhc
+  project: osg-software
+- title: What is next for the HTCondor-CE?
+  date: 2020-09-23
+  url: https://indico.cern.ch/event/936993/contributions/4022138/
+  meeting: HTCondor Workshop Autumn 2020
+  meetingurl: https://indico.cern.ch/event/936993/
+  location: Madison, WI
+  focus-area: osglhc
+  project: osg-software
+- title: HTCondor-CE Troubleshooting
+  date: 2020-09-23
+  url: https://indico.cern.ch/event/936993/contributions/4022137/
+  meeting: HTCondor Workshop Autumn 2020
+  meetingurl: https://indico.cern.ch/event/936993/
+  location: Madison, WI
+  focus-area: osglhc
+  project: osg-software
+- title: HTCondor-CE Live Installation
+  date: 2020-09-23
+  url: https://indico.cern.ch/event/936993/contributions/4022136/
+  meeting: HTCondor Workshop Autumn 2020
+  meetingurl: https://indico.cern.ch/event/936993/
+  location: Madison, WI
+  focus-area: osglhc
+  project: osg-software
+- title: HTCondor-CE Configuration
+  date: 2020-09-23
+  url: https://indico.cern.ch/event/936993/contributions/4022135/
+  meeting: HTCondor Workshop Autumn 2020
+  meetingurl: https://indico.cern.ch/event/936993/
+  location: Madison, WI
+  focus-area: osglhc
+  project: osg-software
+- title: HTCondor-CE Overview
+  date: 2020-09-23
+  url: https://indico.cern.ch/event/936993/contributions/4022131/
+  meeting: HTCondor Workshop Autumn 2020
+  meetingurl: https://indico.cern.ch/event/936993/
+  location: Madison, WI
+  focus-area: osglhc
+  project: osg-software
+- title: Introduction to HTCondor-CE
+  date: 2020-06-17
+  url: https://indico.egi.eu/event/5137/attachments/12966/15338/2020-06-17.htcondorce-intro_FINAL.pdf
+  meeting: EGI Community Webinar Programme
+  meetingurl: https://indico.egi.eu/event/5137/
+  location: Virtual
+  focus-area: osglhc
+  project: osg-software
+- title: GridFTP and GSI Migration Plan (Poster)
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331191/21_-_OSG-LHC_GridFTP_and_GSI_Migration_Plan_-_FINAL.pdf
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton, New Jersey, US
+  focus-area: osglhc
+  project: osg-software
+- title: Infrastructure Software Delivery (Poster)
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331202/26_-_OSG-LHC_Infrastructure_Software_Delivery_-_FINAL.pdf
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton, New Jersey, US
+  focus-area: osglhc
+  project: osg-software
+- title: HTCondor-CE What's Next?
+  date: 2019-09-26
+  url: https://indico.cern.ch/event/817927/contributions/3570564/
+  meeting: European HTCondor Week
+  meetingurl: https://indico.cern.ch/event/817927
+  location: EU Joint Research Centre
+  focus-area: osglhc
+  project: osg-software
+- title: HTCondor-CE Troubleshooting
+  date: 2019-09-26
+  url: https://indico.cern.ch/event/817927/contributions/3570561/
+  meeting: European HTCondor Week
+  meetingurl: https://indico.cern.ch/event/817927
+  location: EU Joint Research Centre
+  focus-area: osglhc
+  project: osg-software
+- title: HTCondor-CE Integration with APEL and BDII
+  date: 2019-09-26
+  url: https://indico.cern.ch/event/817927/contributions/3570558/
+  meeting: European HTCondor Week
+  meetingurl: https://indico.cern.ch/event/817927
+  location: EU Joint Research Centre
+  focus-area: osglhc
+  project: osg-software
+- title: HTCondor-CE Configuration
+  date: 2019-09-26
+  url: https://indico.cern.ch/event/817927/contributions/3570557/
+  meeting: European HTCondor Week
+  meetingurl: https://indico.cern.ch/event/817927
+  location: EU Joint Research Centre
+  focus-area: osglhc
+  project: osg-software
+- title: HTCondor-CE Basics and Architecture
+  date: 2019-09-26
+  url: https://indico.cern.ch/event/817927/contributions/3570555/
+  meeting: European HTCondor Week
+  meetingurl: https://indico.cern.ch/event/817927
+  location: EU Joint Research Centre
+  focus-area: osglhc
+  project: osg-software
+- title: Security Model for Containerized Grid Services
+  date: 2019-06-27
+  url: https://indico.cern.ch/event/765245/timetable/#111-security-model-for-contain
+  meeting: 'Atlas Software & Computing Week #62'
+  meetingurl: https://indico.cern.ch/event/765245
+  location: New York University
+  focus-area: osglhc
+  project: osg-software
+- title: XCache Packaging
+  date: 2019-06-11
+  url: https://indico.cern.ch/event/727208/contributions/3444631/
+  meeting: XRootD Workshop
+  meetingurl: https://indico.cern.ch/event/727208
+  location: CC-IN2P3
+  focus-area: osglhc
+  project: caching
+- title: 'OSG Software: The Year in Review'
+  date: 2019-03-19
+  url: https://indico.cern.ch/event/759388/contributions/3353297/
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop
+  meetingurl: https://indico.cern.ch/event/759388/
+  location: Jefferson Lab
+  focus-area: osglhc
+  project: osg-software
+- title: OSG Site Installation Overview
+  date: 2019-03-21
+  url: https://indico.cern.ch/event/759388/contributions/3364839/
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop
+  meetingurl: https://indico.cern.ch/event/759388/
+  location: Jefferson Lab
+  focus-area: osglhc
+  project: osg-software
+- title: HTCondor-CE Overview
+  date: 2019-03-21
+  url: https://indico.cern.ch/event/759388/contributions/3364839/
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop
+  meetingurl: https://indico.cern.ch/event/759388/
+  location: Jefferson Lab
+  focus-area: osglhc
+  project: osg-software
+- title: Container Basics
+  date: 2019-03-21
+  url: https://indico.cern.ch/event/759388/contributions/3364840/
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop
+  meetingurl: https://indico.cern.ch/event/759388/
+  location: Jefferson Lab
+  focus-area: osglhc
+  project: osg-software
+- title: OSG Software Containers
+  date: 2019-03-21
+  url: https://indico.cern.ch/event/759388/contributions/3364840/
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop
+  meetingurl: https://indico.cern.ch/event/759388/
+  location: Jefferson Lab
+  focus-area: osglhc
+  project: osg-software
+- title: OSG-LHC and XCache
+  date: 2018-12-12
+  url: https://indico.cern.ch/event/770941/contributions/3230458/
+  meeting: ATLAS Software & Computing Week \#61
+  meetingurl: https://indico.cern.ch/event/646947/
+  location: CERN
+  focus-area: osglhc
+  project: caching
+- title: OSG-LHC and ATLAS
+  date: 2018-12-03
+  url: https://indico.cern.ch/event/766802/contributions/3223347/
+  meeting: US-ATLAS Facilities Meeting
+  meetingurl: https://indico.cern.ch/event/766802/
+  location: Argonne National Lab
+  focus-area: osglhc
+  project: osg-software

--- a/_data/people/brianhlin.yml
+++ b/_data/people/brianhlin.yml
@@ -1,12 +1,13 @@
----
+active: true
+e-mail: blin@cs.wisc.edu
+focus-area:
+- osglhc
+institution: University of Wisconsin–Madison
 name: Brian Lin
+photo: "/assets/images/team/Brian-Lin.jpg"
 shortname: brianhlin
 title: OSG Software Team Manager
-active: true
-institution: University of Wisconsin–Madison
 website:
-photo: "/assets/images/team/Brian-Lin.jpg"
-e-mail: blin@cs.wisc.edu
 presentations:
 - title: OSG Services and Kubernetes
   date: 2021-02-11
@@ -192,5 +193,3 @@ presentations:
   location: Argonne National Lab
   focus-area: osglhc
   project: osg-software
-focus-area:
-- osglhc

--- a/_data/people/carlosmalt.yml
+++ b/_data/people/carlosmalt.yml
@@ -1,12 +1,13 @@
----
+active: true
+e-mail: carlosm@ucsc.edu
+focus-area:
+- doma
+institution: University of California, Santa Cruz
 name: Carlos Maltzahn
+photo: "/assets/images/team/Carlos-Maltzahn.png"
 shortname: carlosmalt
 title: Adjunct Professor of Computer Science and Engineering
-active: true
-institution: University of California, Santa Cruz
 website: https://people.ucsc.edu/carlosm
-e-mail: carlosm@ucsc.edu
-photo: "/assets/images/team/Carlos-Maltzahn.png"
 presentations:
 - title: 'IN53A-04: Reproducible, Automated and Portable Computational and Data Science
     Experimentation Pipelines with Popper (with Ivo Jimenez)'
@@ -167,5 +168,3 @@ presentations:
   url: https://drive.google.com/file/d/10RReGuL0XvFDAcUqf_ftDbMVngHZtk5G/view?usp=sharing
   focus-area: doma
   project: skyhookdm
-focus-area:
-- doma

--- a/_data/people/carlosmalt.yml
+++ b/_data/people/carlosmalt.yml
@@ -167,3 +167,5 @@ presentations:
   url: https://drive.google.com/file/d/10RReGuL0XvFDAcUqf_ftDbMVngHZtk5G/view?usp=sharing
   focus-area: doma
   project: skyhookdm
+focus-area:
+- doma

--- a/_data/people/carlosmalt.yml
+++ b/_data/people/carlosmalt.yml
@@ -1,3 +1,4 @@
+---
 name: Carlos Maltzahn
 shortname: carlosmalt
 title: Adjunct Professor of Computer Science and Engineering
@@ -5,155 +6,164 @@ active: true
 institution: University of California, Santa Cruz
 website: https://people.ucsc.edu/carlosm
 e-mail: carlosm@ucsc.edu
-photo: /assets/images/team/Carlos-Maltzahn.png
+photo: "/assets/images/team/Carlos-Maltzahn.png"
 presentations:
-  - title: "IN53A-04: Reproducible, Automated and Portable Computational and Data Science Experimentation Pipelines with Popper (with Ivo Jimenez)"
-    date: 2018-12-14
-    url: https://agu.confex.com/agu/fm18/meetingapp.cgi/Paper/386821
-    meeting: "IN53A: Enabling Transparency and Reproducibility in Geoscience Through Practical Provenance and Cloud-Based Workflows I (AGU Fall Meeting)"
-    meetingurl: https://agu.confex.com/agu/fm18/meetingapp.cgi/Session/60547
-    location: Washington, DC
-    focus-area: doma
-    project: skyhookdm
-  - title: "Programmable Storage Systems: For I/O that doesn’t fit under the rug"
-    date: 2018-12-11
-    url: https://drive.google.com/file/d/1AYatbWAeFB3FnGqU3e4aqGjx9o3_FlMa/view?usp=sharing
-    meeting: Seminar at VMware
-    meetingurl: https://www.vmware.com
-    location: Palo Alto, CA
-    focus-area: doma
-    project: skyhookdm
-  - title: "Programmable Storage Systems: For I/O that doesn’t fit under the rug"
-    date: 2019-01-25
-    url: https://drive.google.com/file/d/1oLGQ3qfUKtu9zh-JgkiGuU1Hikjzbez1/view?usp=sharing
-    meeting: Seminar at Amazon AWS
-    meetingurl: https://aws.amazon.com/
-    location: East Palo Alto, CA
-    focus-area: doma
-    project: skyhookdm
-  - title: "Skyhook: programmable storage for databases"
-    date: 2019-02-26
-    url: https://users.soe.ucsc.edu/~jlefevre/skyhookdb/Skyhook-JeffNoah-Vault19.pdf
-    meeting: Vault'19
-    meetingurl: https://www.usenix.org/conference/vault19
-    focus-area: doma
-    project: skyhookdm
-  - title: How to Leverage Research Universities
-    date: 2019-03-13
-    url: https://osls19.sched.com/event/LG4s/how-to-leverage-research-universities-carlos-maltzahn-uc-santa-cruz-center-for-research-in-open-source-software
-    meeting: Linux Foundation Open Source Leadership Summit (OSLS 2019)
-    meetingurl: https://osls19.sched.com/
-    location: Half Moon Bay, CA
-    focus-area: doma
-    project: skyhookdm
-  - title: "MBWU: Benefit Quantification for Data Acess Function Offloading"
-    date: 2019-06-20
-    url: https://hps.vi4io.org/_media/events/2019/hpc-iodc-mmbwu-maltzahn.pdf
-    meeting: HPC I/O in the Data Center Workshop (HPC-IODC 2019)
-    meetingurl: https://hps.vi4io.org/events/2019/iodc
-    location: Frankfurt, Germany
-    focus-area: doma
-    project: skyhookdm
-  - title: Update on the Center for Research in Open Source Software
-    date: 2019-08-15
-    location: Los Alamos National Laboratory
-    url: https://drive.google.com/file/d/1A_nQkQQkjM9R-L3VnIt8WPeyqAD60DJM/view?usp=sharing
-    meeting: Seminar at New Mexico Consortium, Los Alamos
-    meetingurl: https://newmexicoconsortium.org/
-    focus-area: doma
-    project: skyhookdm
-  - title: Center for Research in Open Source Software
-    url: https://drive.google.com/file/d/1AdOL5qTFF4WAGbHDQ_p3WdE6b1X7DuNu/view?usp=sharing
-    date: 2019-10-19
-    meeting: Google Summer of Code Mentor Summit
-    meetingurl: https://sites.google.com/view/gsoc-mentorsummit2019/home
-    location: Munich, Germany
-    focus-area: doma
-    project: skyhookdm
-  - title: "Education, research, and technology transfer in open source software: new possibilities for universities"
-    date: 2019-10-21
-    meeting: "Friedrich-Alexander Universität, Erlangen-Nürnberg"
-    meetingurl: https://osr.cs.fau.de/2019/09/05/upcoming-talk-lehre-forschung-und-technologietransfer-in-open-source-software-neue-moglichkeiten-fur-die-universitat/
-    url: https://drive.google.com/file/d/1Agtix-92-Efxuso-kXHjgmecwYLJlyA2/view?usp=sharing
-    location: Erlangen, Germany
-    focus-area: doma
-    project: skyhookdm
-  - title: "Education, research, and technology transfer in open source software: new possibilities for universities"
-    date: 2019-10-24
-    meeting: "École Polytechnique Fédérale de Lausanne (EPFL)"
-    meetingurl: https://memento.epfl.ch/event/education-research-and-technology-transfer-in-open/
-    url: https://drive.google.com/file/d/17v7RhprpYf7y2z-GEHQdZ4Km5lJopArB/view?usp=sharing
-    location: Lausanne, Switzerland
-    focus-area: doma
-    project: skyhookdm
-  - title: "Panel presentation on Enabling Data Services for HPC"
-    date: 2019-11-19
-    meeting: "Enabling Data Services for HPC (BoF at SC19)"
-    meetingurl: https://hpc-data-services.github.io/bofs/
-    url: https://drive.google.com/file/d/1DobmSbmCmO7m33_QWv8CvBnotAX16UjY/view?usp=sharing
-    location: Denver, Colorado
-    focus-area: doma
-    project: skyhookdm
-  - title: "Scaling databases and file apis with programmable ceph object storage"
-    date: 2020-02-24
-    meeting: "2020 Linux Storage and Filesystems Conference (Vault’20, co-located with FAST’20 and NSDI’20)"
-    meetingurl: https://www.usenix.org/conference/vault20
-    url: https://www.usenix.org/sites/default/files/conference/protected-files/vault20_slides_lefevre.pdf
-    location: Santa Clara, CA
-    focus-area: doma
-    project: skyhookdm
-  - title: "SkyhookDM: Programmable Storage for Datasets"
-    date: 2020-02-27
-    meeting: "IRIS-HEP Poster Session"
-    meetingurl: https://indico.cern.ch/event/894127/
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331170/2_-_maltzahn-irishep-poster.pdf
-    location: Princeton, NJ
-    focus-area: doma
-    project: skyhookdm
-  - title: "Industry-supported seeding of developer communities around university research prototypes"
-    date: 2020-05-15
-    meeting: "OpenDP Community Meeting"
-    meetingurl: https://www.iq.harvard.edu/event/opendp-community-meeting
-    url: https://drive.google.com/file/d/1eCoe8jAcCIUNMuCWy9U4fg0Dpfl6AWe5/view?usp=sharing
-    location: Online
-    focus-area: doma
-    project: skyhookdm
-  - title: "How $2 Million Dollars Helped Build CROSS with Dr. Carlos Maltzahn"
-    date: 2020-06-05
-    meeting: "Sustain Podcast"
-    meetingurl: https://podcast.sustainoss.org/episodes
-    url: https://users.soe.ucsc.edu/~carlosm/dev/news/20200605/
-    location: Online
-    focus-area: doma
-    project: skyhookdm
-  - title: "Some lessons learned from creating and using the Ceph open source storage system"
-    date: 2020-06-11
-    meeting: "BCS Open Source Specialist Group: Open source softgware for scientific and parallel computing"
-    meetingurl: https://ossg.bcs.org/blog/event/open-source-software-for-scientific-and-parallel-computing/
-    url: https://drive.google.com/file/d/1j2jXH-XGchZcFB6uTj60Qt2AOaXz1B5c/view?usp=sharing
-    location: Online
-    focus-area: doma
-    project: skyhookdm
-  - title: "The Ceph Project"
-    date: 2020-06-30
-    meeting: "UC Berkeley Cloud Meetup 015"
-    meetingurl: https://www.meetup.com/ucberkeley_cloudmeetup/events/271035943/
-    url: https://drive.google.com/file/d/1yiVuO0Q38zlcoMjo10HfqkSvjIxn7pSL/view?usp=sharing
-    location: Online
-    focus-area: doma
-    project: skyhookdm
-  - title: "The value of open source to universities: UC Santa Cruz tests the water"
-    date: 2020-08-02
-    meeting: "Interview for a Linux Professional Institute Blog Post by Andy Oram"
-    meetingurl: https://www.lpi.org/blog
-    url: https://users.soe.ucsc.edu/~carlosm/dev/news/20200728/
-    location: Online
-    focus-area: doma
-    project: skyhookdm
-  - title: "Managing Bufferbloat in Storage Systems"
-    date: 2020-11-30
-    meeting: "Centre for High Performance Computing 2020 National Conference, online, South Africa"
-    meetingurl: https://events.chpc.ac.za/event/84/sessions/453/#20201202
-    url: https://drive.google.com/file/d/10RReGuL0XvFDAcUqf_ftDbMVngHZtk5G/view?usp=sharing
-    focus-area: doma
-    project: skyhookdm
+- title: 'IN53A-04: Reproducible, Automated and Portable Computational and Data Science
+    Experimentation Pipelines with Popper (with Ivo Jimenez)'
+  date: 2018-12-14
+  url: https://agu.confex.com/agu/fm18/meetingapp.cgi/Paper/386821
+  meeting: 'IN53A: Enabling Transparency and Reproducibility in Geoscience Through
+    Practical Provenance and Cloud-Based Workflows I (AGU Fall Meeting)'
+  meetingurl: https://agu.confex.com/agu/fm18/meetingapp.cgi/Session/60547
+  location: Washington, DC
+  focus-area: doma
+  project: skyhookdm
+- title: 'Programmable Storage Systems: For I/O that doesn’t fit under the rug'
+  date: 2018-12-11
+  url: https://drive.google.com/file/d/1AYatbWAeFB3FnGqU3e4aqGjx9o3_FlMa/view?usp=sharing
+  meeting: Seminar at VMware
+  meetingurl: https://www.vmware.com
+  location: Palo Alto, CA
+  focus-area: doma
+  project: skyhookdm
+- title: 'Programmable Storage Systems: For I/O that doesn’t fit under the rug'
+  date: 2019-01-25
+  url: https://drive.google.com/file/d/1oLGQ3qfUKtu9zh-JgkiGuU1Hikjzbez1/view?usp=sharing
+  meeting: Seminar at Amazon AWS
+  meetingurl: https://aws.amazon.com/
+  location: East Palo Alto, CA
+  focus-area: doma
+  project: skyhookdm
+- title: 'Skyhook: programmable storage for databases'
+  date: 2019-02-26
+  url: https://users.soe.ucsc.edu/~jlefevre/skyhookdb/Skyhook-JeffNoah-Vault19.pdf
+  meeting: Vault'19
+  meetingurl: https://www.usenix.org/conference/vault19
+  focus-area: doma
+  project: skyhookdm
+- title: How to Leverage Research Universities
+  date: 2019-03-13
+  url: https://osls19.sched.com/event/LG4s/how-to-leverage-research-universities-carlos-maltzahn-uc-santa-cruz-center-for-research-in-open-source-software
+  meeting: Linux Foundation Open Source Leadership Summit (OSLS 2019)
+  meetingurl: https://osls19.sched.com/
+  location: Half Moon Bay, CA
+  focus-area: doma
+  project: skyhookdm
+- title: 'MBWU: Benefit Quantification for Data Acess Function Offloading'
+  date: 2019-06-20
+  url: https://hps.vi4io.org/_media/events/2019/hpc-iodc-mmbwu-maltzahn.pdf
+  meeting: HPC I/O in the Data Center Workshop (HPC-IODC 2019)
+  meetingurl: https://hps.vi4io.org/events/2019/iodc
+  location: Frankfurt, Germany
+  focus-area: doma
+  project: skyhookdm
+- title: Update on the Center for Research in Open Source Software
+  date: 2019-08-15
+  location: Los Alamos National Laboratory
+  url: https://drive.google.com/file/d/1A_nQkQQkjM9R-L3VnIt8WPeyqAD60DJM/view?usp=sharing
+  meeting: Seminar at New Mexico Consortium, Los Alamos
+  meetingurl: https://newmexicoconsortium.org/
+  focus-area: doma
+  project: skyhookdm
+- title: Center for Research in Open Source Software
+  url: https://drive.google.com/file/d/1AdOL5qTFF4WAGbHDQ_p3WdE6b1X7DuNu/view?usp=sharing
+  date: 2019-10-19
+  meeting: Google Summer of Code Mentor Summit
+  meetingurl: https://sites.google.com/view/gsoc-mentorsummit2019/home
+  location: Munich, Germany
+  focus-area: doma
+  project: skyhookdm
+- title: 'Education, research, and technology transfer in open source software: new
+    possibilities for universities'
+  date: 2019-10-21
+  meeting: Friedrich-Alexander Universität, Erlangen-Nürnberg
+  meetingurl: https://osr.cs.fau.de/2019/09/05/upcoming-talk-lehre-forschung-und-technologietransfer-in-open-source-software-neue-moglichkeiten-fur-die-universitat/
+  url: https://drive.google.com/file/d/1Agtix-92-Efxuso-kXHjgmecwYLJlyA2/view?usp=sharing
+  location: Erlangen, Germany
+  focus-area: doma
+  project: skyhookdm
+- title: 'Education, research, and technology transfer in open source software: new
+    possibilities for universities'
+  date: 2019-10-24
+  meeting: École Polytechnique Fédérale de Lausanne (EPFL)
+  meetingurl: https://memento.epfl.ch/event/education-research-and-technology-transfer-in-open/
+  url: https://drive.google.com/file/d/17v7RhprpYf7y2z-GEHQdZ4Km5lJopArB/view?usp=sharing
+  location: Lausanne, Switzerland
+  focus-area: doma
+  project: skyhookdm
+- title: Panel presentation on Enabling Data Services for HPC
+  date: 2019-11-19
+  meeting: Enabling Data Services for HPC (BoF at SC19)
+  meetingurl: https://hpc-data-services.github.io/bofs/
+  url: https://drive.google.com/file/d/1DobmSbmCmO7m33_QWv8CvBnotAX16UjY/view?usp=sharing
+  location: Denver, Colorado
+  focus-area: doma
+  project: skyhookdm
+- title: Scaling databases and file apis with programmable ceph object storage
+  date: 2020-02-24
+  meeting: 2020 Linux Storage and Filesystems Conference (Vault’20, co-located with
+    FAST’20 and NSDI’20)
+  meetingurl: https://www.usenix.org/conference/vault20
+  url: https://www.usenix.org/sites/default/files/conference/protected-files/vault20_slides_lefevre.pdf
+  location: Santa Clara, CA
+  focus-area: doma
+  project: skyhookdm
+- title: 'SkyhookDM: Programmable Storage for Datasets'
+  date: 2020-02-27
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331170/2_-_maltzahn-irishep-poster.pdf
+  location: Princeton, NJ
+  focus-area: doma
+  project: skyhookdm
+- title: Industry-supported seeding of developer communities around university research
+    prototypes
+  date: 2020-05-15
+  meeting: OpenDP Community Meeting
+  meetingurl: https://www.iq.harvard.edu/event/opendp-community-meeting
+  url: https://drive.google.com/file/d/1eCoe8jAcCIUNMuCWy9U4fg0Dpfl6AWe5/view?usp=sharing
+  location: Online
+  focus-area: doma
+  project: skyhookdm
+- title: How $2 Million Dollars Helped Build CROSS with Dr. Carlos Maltzahn
+  date: 2020-06-05
+  meeting: Sustain Podcast
+  meetingurl: https://podcast.sustainoss.org/episodes
+  url: https://users.soe.ucsc.edu/~carlosm/dev/news/20200605/
+  location: Online
+  focus-area: doma
+  project: skyhookdm
+- title: Some lessons learned from creating and using the Ceph open source storage
+    system
+  date: 2020-06-11
+  meeting: 'BCS Open Source Specialist Group: Open source softgware for scientific
+    and parallel computing'
+  meetingurl: https://ossg.bcs.org/blog/event/open-source-software-for-scientific-and-parallel-computing/
+  url: https://drive.google.com/file/d/1j2jXH-XGchZcFB6uTj60Qt2AOaXz1B5c/view?usp=sharing
+  location: Online
+  focus-area: doma
+  project: skyhookdm
+- title: The Ceph Project
+  date: 2020-06-30
+  meeting: UC Berkeley Cloud Meetup 015
+  meetingurl: https://www.meetup.com/ucberkeley_cloudmeetup/events/271035943/
+  url: https://drive.google.com/file/d/1yiVuO0Q38zlcoMjo10HfqkSvjIxn7pSL/view?usp=sharing
+  location: Online
+  focus-area: doma
+  project: skyhookdm
+- title: 'The value of open source to universities: UC Santa Cruz tests the water'
+  date: 2020-08-02
+  meeting: Interview for a Linux Professional Institute Blog Post by Andy Oram
+  meetingurl: https://www.lpi.org/blog
+  url: https://users.soe.ucsc.edu/~carlosm/dev/news/20200728/
+  location: Online
+  focus-area: doma
+  project: skyhookdm
+- title: Managing Bufferbloat in Storage Systems
+  date: 2020-11-30
+  meeting: Centre for High Performance Computing 2020 National Conference, online,
+    South Africa
+  meetingurl: https://events.chpc.ac.za/event/84/sessions/453/#20201202
+  url: https://drive.google.com/file/d/10RReGuL0XvFDAcUqf_ftDbMVngHZtk5G/view?usp=sharing
+  focus-area: doma
+  project: skyhookdm

--- a/_data/people/cranmer.yml
+++ b/_data/people/cranmer.yml
@@ -1,432 +1,510 @@
+---
 name: Kyle Cranmer
 shortname: cranmer
 title: Analysis Systems Area Lead
 active: true
 institution: New York University
 website: http://theoryandpractice.org
-photo: /assets/images/team/Kyle-Cranmer.jpg
+photo: "/assets/images/team/Kyle-Cranmer.jpg"
 e-mail: kyle.cranmer@nyu.edu
 presentations:
-  - title: What does the Revolution in Artificial Intelligence Mean for Physics?
-    date: 2018-09-07
-    url: http://media.physics.harvard.edu/video/html5/?id=COLLOQ_CRANMER_091018
-    meeting: Harvard Physics Colloquium
-    meetingurl: http://media.physics.harvard.edu/video/html5/?id=COLLOQ_CRANMER_091018
-    location: Harvard University
-  - title: What does the Revolution in Artificial Intelligence Mean for Physics?
-    date: 2018-09-19
-    url: https://www.jlab.org/colloquium-kyle-cranmer-nyu
-    meeting: Jefferson Lab Colloquium
-    meetingurl: https://www.jlab.org/colloquium-kyle-cranmer-nyu
-    location: Jefferson Lab
-  - title: "Inverting simulation: experiences with inverse problems in particle physics"
-    date: 2019-01-25
-    url: https://earthscience.rice.edu/mathx2019/
-    meeting: MATH + X Symposium on Inverse Problems and Deep Learning in Space Exploration
-    meetingurl: https://earthscience.rice.edu/mathx2019/
-    location: Rice University
-  - title: IRIS-HEP Analysis Systems
-    date: 2019-02-06
-    url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271527/attachments/1791896/2919641/AS_overview_for_Steering_Board-2.pdf
-    meeting: IRIS-HEP Steering Board Meeting #1
-    meetingurl: https://indico.cern.ch/event/790759/
-    focus-area: as
-  - title: Panel Discussion on Machine Learning and Physics
-    date: 2019-02-12
-    url: https://www.kitp.ucsb.edu/activities/machine-c19
-    meeting: At the Crossroad of Physics and Machine Learning
-    meetingurl: https://www.kitp.ucsb.edu/activities/machine-c19
-    location: KITP
-  - title: What does the Revolution in Artificial Intelligence Mean for Physics?
-    date: 2019-03-07
-    url: https://physics.ucr.edu/previous-colloquium-and-videos
-    meeting: UC Riverside Physics Colloquium
-    meetingurl: https://physics.ucr.edu/previous-colloquium-and-videos
-    location: UC-Riverside
-  - title: Experiences with deep learning in particle physics
-    date: 2019-03-13
-    url: https://youtu.be/SrILXzFbr0M
-    meeting: Sackler Colloquia on Deep Learning and Science
-    meetingurl: http://www.nasonline.org/programs/nas-colloquia/completed_colloquia/science-of-deep-learning.html
-    location: National Academy of Science, Washington DC
-  - title: Overview of Likelihood-Free Inference for Physics
-    date: 2019-03-18
-    url: https://lfitaskforce.github.io/FlatironMeeting/
-    meeting: Likelihood-Free Inference Workshop
-    meetingurl: https://lfitaskforce.github.io/FlatironMeeting/
-    location: Flatiron Institute, NYC
-    focus-area: as
-  - title: Future areas of focus for ML in particle physics
-    date: 2019-04-15
-    url: https://indico.cern.ch/event/766872/timetable/#20190415.detailed
-    meeting: 3rd IML Machine Learning Workshop
-    meetingurl: https://indico.cern.ch/event/766872/timetable/#20190415.detailed
-    location: CERN
-    focus-area: [as, ia]
-  - title: Future areas of focus for ML in particle physics
-    date: 2019-05-01
-    url: https://sites.google.com/view/physicsxml/schedule?authuser=0
-    meeting: Gotham City Physics X ML
-    meetingurl: https://sites.google.com/view/physicsxml/schedule
-    location: Flatiron Institute
-    focus-area: [as, ia]
-  - title: The Primacy of Experiment
-    date: 2019-05-29
-    url: https://video.ias.edu/universe/2019/0529-KyleCranmer
-    meeting: The Universe Speaks in Numbers
-    meetingurl: https://www.ias.edu/events/universe-speaks
-    location: Intitute for Advanced Study
-    focus-area: [as, ia]
-  - title: Advances in Deep Learning motivated by Physics Problems
-    date: 2019-06-14
-    url:  https://sites.google.com/view/icml2019phys4dl
-    meeting: Theoretical Physics for Deep Learning
-    meetingurl:  https://sites.google.com/view/icml2019phys4dl
-    location: Long Beach, CA
-    focus-area: [as, ia]
-  - title: Reinterpretation Roadmap
-    date: 2019-06-19
-    url: https://indico.cern.ch/event/822074/timetable/#20190620
-    meeting: Analysis Systems Topical Meeting
-    meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
-    location: NYU
-    focus-area: as
-  - title: Analysis Systems Perspectives and Goals
-    date: 2019-06-21
-    url: https://indico.cern.ch/event/820946/contributions/3461589/
-    meeting: "Analysis Systems R&D on Scalable Platforms Blueprint meeting"
-    meetingurl: https://indico.cern.ch/event/820946/
-    location: NYU
-    focus-area: as
-  - title: Future areas of focus for ML in particle physics
-    date: 2019-06-24
-    url: https://indico.cern.ch/event/765245/contributions/3417214/attachments/1868012/3072530/ATLAS-SnC-future-ML.pdf
-    meeting: ATLAS Software and Computing Week
-    meetingurl: https://indico.cern.ch/event/765245/
-    location: NYU
-    focus-area: [as, ia]
-  - title: Overview and Future directions for ML in particle and astro physics
-    date: 2019-07-31
-    url: http://www.weizmann.ac.il/conferences/SRitp/Aug2019/program
-    meeting: "Hammers & Nails 2019"
-    meetingurl: http://www.weizmann.ac.il/conferences/SRitp/Aug2019/program
-    location: Weizmann Institute
-    focus-area: [as, ia]
-  - title: The interplay between physically motivated simulations and machine learning
-    date: 2019-09-09
-    url: http://www.ipam.ucla.edu/programs/workshops/machine-learning-for-physics-and-the-physics-of-learning-tutorials/?tab=speaker-list
-    meeting: Machine Learning for Physics and the Physics of Learning Long Program at IPAM
-    meetingurl: http://www.ipam.ucla.edu/programs/long-programs/machine-learning-for-physics-and-the-physics-of-learning/
-    location: IPAM
-    focus-area: [as, ia]
-  - title: Simulation-based inference, causality, and active learning
-    date: 2019-09-27
-    url: https://ai2019.ethz.ch/talks/Kyle_Cranmer.pdf
-    meeting: AI and the Scientific Method, ETH, Zurich
-    meetingurl: https://ai2019.ethz.ch/program.html
-    location: ETH, Zurich
-    focus-area: [as, ia]
-  - title: What does the Revolution in Artificial Intelligence Mean for Physics?
-    date: 2019-09-30
-    url: https://ai2019.ethz.ch/program.html
-    meeting: Joint PITT-CMU Physics Department Colloquium
-    meetingurl: https://www.cmu.edu/physics/news-events/events/physics_colloquia.html#event=32472386
-    location: Carnegie Mellon University
-    focus-area: [as, ia]
-  - title: Particle Physics in the context of Data Science
-    date: 2019-10-05
-    url: https://www.dropbox.com/s/cd6zclbyvwj1u9i/DSAA-IEEE-Keynote.pdf
-    meeting: The 6th IEEE International Conference on Data Science and Advanced Analytics
-    meetingurl: http://dsaa2019.dsaa.co
-    location: Washington, DC
-    focus-area: [as, ia]
-  - title: Simulation-based inference, interpretability, and experimental design
-    date: 2019-10-17
-    url: http://www.ipam.ucla.edu/abstract/?tid=15943&pcode=MLPWS2
-    meeting: Workshop on Interpretable Learning in Physical Sciences Part of the Long Program Machine Learning for Physics and the Physics of Learning
-    meetingurl: http://www.ipam.ucla.edu/abstract/?tid=15943&pcode=MLPWS2
-    location: UCLA
-    focus-area: [as, ia]
-  - title: "Flows three ways"
-    date: 2019-11-19
-    url: http://pcts.princeton.edu/programs/current/deep-learning-for-physics-seminar-series/121
-    meeting: Deep Learning for Physics Seminar Series at Princeton Center for Theoretical Physics
-    meetingurl: http://pctsadmin.princeton.edu/upload/document/da2474d76aeb7f5926f38436f077ff64.pdf
-    location: Princeton
-    focus-area: [as, ia]
-  - title: HEPData and IRIS-HEP
-    date: 2020-01-28
-    url: https://conference.ippp.dur.ac.uk/event/875/contributions/4770/attachments/3901/4447/HEPData-2020.pdf
-    meeting: HEPData Advisory Board
-    meetingurl: https://conference.ippp.dur.ac.uk/event/875/
-    location: IPPP Durham
-    focus-area: [as, core]
-  - title: Machine Learning for Effective Field Theories
-    date: 2020-03-03
-    url: https://indico.cern.ch/event/817757/contributions/3712508/
-    meeting: "PREFIT20: PRecision Effective FIeld Theory School"
-    meetingurl: https://indico.cern.ch/event/817757/overview
-    location:  DESY
-    focus-area: [as, ia, core]
-  - title: Machine Learning and Physics
-    date: 2020-03-05
-    url: https://indico.desy.de/indico/event/25451/
-    meeting: Special QU-PCD Colloquium at DESY (CANCELED due to COVID19)
-    meetingurl: https://indico.desy.de/indico/event/25451/
-    location: DESY
-    focus-area: [as, ia]
-  - title: Reusable workflows in particle physics
-    date: 2020-03-16
-    url: https://www.nationalacademies.org/event/03-16-2020/realizing-opportunities-for-advanced-and-automated-workflows-in-scientific-research-second-meeting
-    meeting: Workshop on Accelerating Scientific Discovery through Advanced and Automated Workflows
-    meetingurl: https://www.nationalacademies.org/event/03-16-2020/realizing-opportunities-for-advanced-and-automated-workflows-in-scientific-research-second-meeting
-    location: National Academy of Sciences
-    focus-area: [as, core]
-  - title: "Future Analysis Systems"
-    date: 2020-03-17
-    url: https://indico.cern.ch/event/896935/
-    meeting: "Joint US ATLAS - US CMS Meeting on Facility R&D"
-    meetingurl: https://indico.cern.ch/event/896935/
-    location: Remote
-    focus-area: [as, core]
-  - title: "How machine learning can help us get the most out of our highest fidelity physical models"
-    date: 2020-05-07
-    url: https://web.mit.edu/physics/events/colloquia.html
-    meeting: MIT Physics Department Colloquium
-    meetingurl: https://web.mit.edu/physics/events/colloquia.html
-    location: Irvine, CA (Virtual)
-    focus-area: [as, ia]
-  - title: Analysis Systems Overview and Plans
-    date: 2020-05-27
-    url: https://indico.cern.ch/event/896167/contributions/3870075/attachments/2044448/3424682/IRIS-HEP_Retreat_Analysis_Systems_2020-05-26.pptx.pdf
-    meeting: IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167/timetable/
-    location: (Virtual)
-    focus-area: as
-  - title: Analysis Grand Challenge Proposal
-    date: 2020-05-28
-    url: https://indico.cern.ch/event/896167/contributions/3880424/attachments/2045466/3429947/IRIS-HEP_Analysis_Grand_Challenge_2020-05-28.pptx.pdf
-    meeting: IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167/timetable/
-    location: (Virtual)
-    focus-area: as
-  - title: "IRIS-HEP Innovative Algorithms: R&D and Machine Learning for Jets"
-    date: 2020-05-28
-    url: https://indico.cern.ch/event/896167/contributions/3878892/attachments/2045327/3426480/IRIS-HEP_Retreat_NYU_IA_Contribution_2020-05-28.pdf
-    meeting: IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167/timetable/
-    location: (Virtual)
-    focus-area: as
-  - title: Analysis Systems Plans and Goals Closeout
-    date: 2020-05-29
-    url: https://indico.cern.ch/event/896167/contributions/3874633/attachments/2047251/3431547/IRIS-HEP_Retreat_Analysis_Systems_Closeout_2020-05-29.pptx.pdf
-    meeting: IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167/timetable/
-    location: (Virtual)
-    focus-area: as
-  - title: Analysis Grand Challenge Closeout
-    date: 2020-05-29
-    url: https://indico.cern.ch/event/896167/contributions/3874640/attachments/2047239/3430338/IRIS-HEP_Analysis_Grand_Challenge_2020-05-28.pptx-2.pdf
-    meeting: IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167/timetable/
-    location: (Virtual)
-    focus-area: as
-  - title: "How machine learning can help us get the most out of our highest fidelity physical models"
-    date: 2020-05-31
-    url: https://physics.tau.ac.il/events_physics_colloquium_31_5_2020
-    meeting: Tel Aviv University Physics Department Colloquium
-    meetingurl: https://physics.tau.ac.il/events_physics_colloquium_31_5_2020
-    location: Tel Aviv, Israel (Virtual)
-    focus-area: [as, ia]
-  - title: "The interplay of Math, Physics, and Machine Learning"
-    date: 2020-07-02
-    url: https://mpml.tecnico.ulisboa.pt/seminars?id=5806
-    meeting:  IST seminar series Mathematics, Physics & Machine Learning
-    meetingurl: https://mpml.tecnico.ulisboa.pt/seminars?id=5806
-    location: Lisbon, Portugal (Virtual)
-    focus-area: [as, ia]
-  - title: "How machine learning can help us get the most out of our highest fidelity physical models"
-    date: 2020-07-08
-    url: https://ai4science-amsterdam.github.io/events.html
-    meeting: "ELLIS SOCIETY: AI4Science Kickoff Workshop"
-    meetingurl: https://ai4science-amsterdam.github.io/events.html
-    location: Amsterdam, Netherlands (Virtual)
-    focus-area: [as, ia]
-  - title: "Panel Discussion: A community perspective on Equity in HEP"
-    date: 2020-07-09
-    url: https://science.osti.gov/hep/hepap/Meetings/202007
-    meeting: High Energy Physics Advisory Panel
-    meetingurl: https://science.osti.gov/hep/hepap/Meetings/202007
-    location: Virtual
-    focus-area: core
-  - title: "Likelihood-based models for Simulation-based Inference"
-    date: 2020-07-17
-    url: https://invertibleworkshop.github.io
-    meeting: ICML Workshop on Invertible Neural Networks, Normalizing Flows, and Explicit Likelihood Models
-    meetingurl: https://invertibleworkshop.github.io
-    location: Vienna, Austria (Virtual)
-    focus-area: [as, ia]
-  - title: "Graphs, Trees, and Sets: structured data in physics"
-    date: 2020-07-17
-    url: https://grlplus.github.io/schedule/
-    meeting: ICML Workshop on Graph Representation Learning
-    meetingurl: https://grlplus.github.io/schedule/
-    location: Vienna, Austria (Virtual)
-    focus-area: [as, ia]
-  - title: "How machine learning can help us get the most out of our highest fidelity physical models"
-    date: 2020-07-21
-    url: https://uni-tuebingen.de/en/165313#c1124370
-    meeting: Machine Learning in Science 2020
-    meetingurl: https://uni-tuebingen.de/en/165313#c1124370
-    location: Eberhard Karls Universität Tübingen (Virtual)
-    focus-area: [as, ia]
-  - title: "Lectures on Statistics"
-    date: 2020-08-10
-    url: https://indico.fnal.gov/event/22840/
-    meeting: 15th joint Fermilab-CERN Hadron Collider Summer School
-    meetingurl: https://indico.fnal.gov/event/22840/
-    location: Fermilab (Virtual)
-    focus-area: [as, core]
-  - title: Constraining EFTs and Dark Matter with Simulation-based Inference
-    date: 2020-08-26
-    url: https://indico.cern.ch/event/945096/
-    meeting: BSM PANDEMIC
-    meetingurl: https://www.bsmpandemic.com
-    location: Fermilab (Virtual)
-    focus-area: [as, core]
-  - title: "Reusable Workflows, active learning, and simulation-based inference"
-    date: 2020-09-22
-    url: https://uci-ml-repo.github.io/events/reprod-symposium20/#kcranmer
-    meeting: UCI Symposium on Reproducibility in Machine Learning
-    meetingurl: https://uci-ml-repo.github.io/events/reprod-symposium20/#kcranmer
-    location: Irvine, CA (Virtual)
-    focus-area: [as, ia, core]
-  - title: "How machine learning can help us get the most out of our highest fidelity physical models"
-    date: 2020-09-24
-    url: https://www.youtube.com/watch?v=J3LHO1EKFuU
-    meeting: NYU Physics Colloquium
-    meetingurl: https://physics.nyu.edu/events.html?EventsPage=colloquia
-    location: New York University (Virtual)
-    focus-area: [as, ia]
-  - title: Likelihood publishing, RECAST, and simulation-based inference
-    date: 2020-10-14
-    url: https://indico.cern.ch/event/962997/
-    meeting: PhyStat / CERN EP-IT Data science seminar
-    meetingurl: https://indico.cern.ch/event/962997/
-    location: CERN (Virtual)
-    focus-area: as
-  - title: "Vision: Physics, Machine Learning, and Computing"
-    date: 2020-10-19
-    url: http://www.ncsa.illinois.edu/Conferences/AcceleratedAINCSA/agenda.html
-    meeting: 2020 Accelerated Artificial Intelligence for Big-Data Experiments Conference
-    meetingurl: http://www.ncsa.illinois.edu/Conferences/AcceleratedAINCSA/agenda.html
-    location: NCSA (Virtual)
-    focus-area: as
-  - title: "End-to-End Analysis Vision & AS Grand Challenge"
-    date: 2020-10-26
-    url: https://indico.cern.ch/event/960587/contributions/4070317/
-    meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
-    meetingurl: https://indico.cern.ch/event/960587/
-    location: Virtual
-    focus-area: as
-  - title: New experimental analysis techniques
-    date: 2020-10-30
-    url: https://indico.cern.ch/event/900384/contributions/3796227/
-    meeting: Higgs2020
-    meetingurl: https://indico.cern.ch/event/900384/timetable/#20201030.detailed
-    location: Virtual
-    focus-area: as
-  - title: Machine Learning for high energy physics on and off the lattice
-    date: 2020-12-03
-    url: https://www.ectstar.eu/activities/seminars/colloquia/
-    meeting: "ECT* Colloqium (European Center for Theoretical Studies in Nuclear Physics and Related Areas)"
-    meetingurl: https://www.ectstar.eu/activities/seminars/colloquia/
-    location: Virtual
-    focus-area: as
-  - title: "How machine learning can help us get the most out of our highest fidelity physical models"
-    date: 2020-12-08
-    url: https://ai-roadmap.ornl.gov
-    meeting: AI for Atoms
-    meetingurl: https://ai-roadmap.ornl.gov
-    location: Oak Ridge National Laboratory (Virtual)
-    focus-area: [as, ia]
-  - title:  Some fun examples from the intersection of machine learning and physics
-    date: 2020-12-18
-    url: https://virtual-event.mlinpl.org
-    meeting: ML in PL
-    meetingurl: https://virtual-event.mlinpl.org
-    location: Poland (Virtual)
-    focus-area: [as, ia]
-  - title:  "MadMiner: Machine learning–based inference for particle physics"
-    date: 2021-01-11
-    url: https://indico.cern.ch/event/971725/#5-madminer-machine-learning-ba
-    meeting: LHC EFT Working Group
-    meetingurl: https://indico.cern.ch/event/971725/
-    location: CERN (Virtual)
-    focus-area: as
-  - title:  MadMiner tutorial
-    date: 2021-02-18
-    url: https://indico.cern.ch/event/982553/contributions/4220018/
-    meeting: (Re)interpreting the results of new physics searches at the LHC
-    meetingurl: https://indico.cern.ch/event/982553/overview
-    location: (Virtual)
-    focus-area: [as, ia]
-  - title: Quarks, hierarchical clustering, and combinatorial optimization
-    date: 2021-02-22
-    url: http://www.ipam.ucla.edu/abstract/?tid=16760&pcode=DLC2021
-    meeting: Deep Learning and Combinatorial Optimization
-    meetingurl: http://www.ipam.ucla.edu/programs/workshops/deep-learning-and-combinatorial-optimization/?tab=overview
-    location: Institute Pure and Applied Mathematics (IPAM) (virtual)
-    focus-area: ia
-  - title:  Machine Learning for Precision Measurements
-    date: 2021-03-02
-    url: https://indico.tlabs.ac.za/event/100/contributions/1727/
-    meeting: Unveiling hidden Physics Beyond the Standard Model at the LHC
-    meetingurl: https://indico.tlabs.ac.za/event/100/overview
-    location:  (Virtual)
-    focus-area: as
-  - title:  Probabalistic Machine Learning for the Physical Sciences
-    date: 2021-03-09
-    url: https://www.cs.ox.ac.uk/teaching/courses/2020-2021/advml/
-    meeting: Advanced Topics in Machine Learning Course
-    meetingurl: https://www.cs.ox.ac.uk/teaching/courses/2020-2021/advml/
-    location:  Oxford University
-    focus-area: as
-  - title:  Graph Deep Learning for Physics
-    date: 2021-03-25
-    url: https://www.youtube.com/watch?v=FjShuSoWZks
-    meeting: Università della Svizzera
-    meetingurl: https://www.usi.ch/en/feeds/15796
-    location: (Virtual) Università della Svizzera
-    focus-area: [ia, as]
-  - title: "Invited Keynote for AISTATS: Simulation-Based Inference"
-    date: 2021-04-02
-    url: https://slideslive.com/38955019
-    meeting: AISTATS
-    meetingurl: https://aistats.org/aistats2021/
-    location: (Virtual)
-    focus-area: as
-  - title: Towards a white paper on public likelihoods
-    date: 2021-04-22
-    url: https://indico.cern.ch/event/1015891/attachments/2231688/3781529/Likelihood-whitepaper-RAMP-2021.pdf
-    meeting: LHC Re-interpretation Forum
-    meetingurl: https://indico.cern.ch/event/1015891/
-    location: (Virtual)
-    focus-area: as
-  - title: An AI revolution in science? Using machine learning for scientific discovery
-    date: 2021-04-26
-    url: https://www.cst.cam.ac.uk/news/ai-revolution-science-using-machine-learning-scientific-discovery
-    meeting: University of Cambridge Accelerate Programme for Scientific Discovery
-    meetingurl: https://www.cst.cam.ac.uk/news/ai-revolution-science-using-machine-learning-scientific-discovery
-    location: (Virtual)
-    focus-area: [as, ia]
-  - title: Analysis Systems Overview
-    date: 2021-04-27
-    url: https://indico.cern.ch/event/957103/contributions/4330981/
-    meeting: IRIS-HEP Annual PI/EB Meeting
-    meetingurl: https://indico.cern.ch/event/957103/
-    location: (Virtual)
-    focus-area: as
-
-
-
+- title: What does the Revolution in Artificial Intelligence Mean for Physics?
+  date: 2018-09-07
+  url: http://media.physics.harvard.edu/video/html5/?id=COLLOQ_CRANMER_091018
+  meeting: Harvard Physics Colloquium
+  meetingurl: http://media.physics.harvard.edu/video/html5/?id=COLLOQ_CRANMER_091018
+  location: Harvard University
+- title: What does the Revolution in Artificial Intelligence Mean for Physics?
+  date: 2018-09-19
+  url: https://www.jlab.org/colloquium-kyle-cranmer-nyu
+  meeting: Jefferson Lab Colloquium
+  meetingurl: https://www.jlab.org/colloquium-kyle-cranmer-nyu
+  location: Jefferson Lab
+- title: 'Inverting simulation: experiences with inverse problems in particle physics'
+  date: 2019-01-25
+  url: https://earthscience.rice.edu/mathx2019/
+  meeting: MATH + X Symposium on Inverse Problems and Deep Learning in Space Exploration
+  meetingurl: https://earthscience.rice.edu/mathx2019/
+  location: Rice University
+- title: IRIS-HEP Analysis Systems
+  date: 2019-02-06
+  url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271527/attachments/1791896/2919641/AS_overview_for_Steering_Board-2.pdf
+  meeting: IRIS-HEP Steering Board Meeting
+  meetingurl: https://indico.cern.ch/event/790759/
+  focus-area: as
+- title: Panel Discussion on Machine Learning and Physics
+  date: 2019-02-12
+  url: https://www.kitp.ucsb.edu/activities/machine-c19
+  meeting: At the Crossroad of Physics and Machine Learning
+  meetingurl: https://www.kitp.ucsb.edu/activities/machine-c19
+  location: KITP
+- title: What does the Revolution in Artificial Intelligence Mean for Physics?
+  date: 2019-03-07
+  url: https://physics.ucr.edu/previous-colloquium-and-videos
+  meeting: UC Riverside Physics Colloquium
+  meetingurl: https://physics.ucr.edu/previous-colloquium-and-videos
+  location: UC-Riverside
+- title: Experiences with deep learning in particle physics
+  date: 2019-03-13
+  url: https://youtu.be/SrILXzFbr0M
+  meeting: Sackler Colloquia on Deep Learning and Science
+  meetingurl: http://www.nasonline.org/programs/nas-colloquia/completed_colloquia/science-of-deep-learning.html
+  location: National Academy of Science, Washington DC
+- title: Overview of Likelihood-Free Inference for Physics
+  date: 2019-03-18
+  url: https://lfitaskforce.github.io/FlatironMeeting/
+  meeting: Likelihood-Free Inference Workshop
+  meetingurl: https://lfitaskforce.github.io/FlatironMeeting/
+  location: Flatiron Institute, NYC
+  focus-area: as
+- title: Future areas of focus for ML in particle physics
+  date: 2019-04-15
+  url: https://indico.cern.ch/event/766872/timetable/#20190415.detailed
+  meeting: 3rd IML Machine Learning Workshop
+  meetingurl: https://indico.cern.ch/event/766872/timetable/#20190415.detailed
+  location: CERN
+  focus-area:
+  - as
+  - ia
+- title: Future areas of focus for ML in particle physics
+  date: 2019-05-01
+  url: https://sites.google.com/view/physicsxml/schedule?authuser=0
+  meeting: Gotham City Physics X ML
+  meetingurl: https://sites.google.com/view/physicsxml/schedule
+  location: Flatiron Institute
+  focus-area:
+  - as
+  - ia
+- title: The Primacy of Experiment
+  date: 2019-05-29
+  url: https://video.ias.edu/universe/2019/0529-KyleCranmer
+  meeting: The Universe Speaks in Numbers
+  meetingurl: https://www.ias.edu/events/universe-speaks
+  location: Intitute for Advanced Study
+  focus-area:
+  - as
+  - ia
+- title: Advances in Deep Learning motivated by Physics Problems
+  date: 2019-06-14
+  url: https://sites.google.com/view/icml2019phys4dl
+  meeting: Theoretical Physics for Deep Learning
+  meetingurl: https://sites.google.com/view/icml2019phys4dl
+  location: Long Beach, CA
+  focus-area:
+  - as
+  - ia
+- title: Reinterpretation Roadmap
+  date: 2019-06-19
+  url: https://indico.cern.ch/event/822074/timetable/#20190620
+  meeting: Analysis Systems Topical Meeting
+  meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
+  location: NYU
+  focus-area: as
+- title: Analysis Systems Perspectives and Goals
+  date: 2019-06-21
+  url: https://indico.cern.ch/event/820946/contributions/3461589/
+  meeting: Analysis Systems R&D on Scalable Platforms Blueprint meeting
+  meetingurl: https://indico.cern.ch/event/820946/
+  location: NYU
+  focus-area: as
+- title: Future areas of focus for ML in particle physics
+  date: 2019-06-24
+  url: https://indico.cern.ch/event/765245/contributions/3417214/attachments/1868012/3072530/ATLAS-SnC-future-ML.pdf
+  meeting: ATLAS Software and Computing Week
+  meetingurl: https://indico.cern.ch/event/765245/
+  location: NYU
+  focus-area:
+  - as
+  - ia
+- title: Overview and Future directions for ML in particle and astro physics
+  date: 2019-07-31
+  url: http://www.weizmann.ac.il/conferences/SRitp/Aug2019/program
+  meeting: Hammers & Nails 2019
+  meetingurl: http://www.weizmann.ac.il/conferences/SRitp/Aug2019/program
+  location: Weizmann Institute
+  focus-area:
+  - as
+  - ia
+- title: The interplay between physically motivated simulations and machine learning
+  date: 2019-09-09
+  url: http://www.ipam.ucla.edu/programs/workshops/machine-learning-for-physics-and-the-physics-of-learning-tutorials/?tab=speaker-list
+  meeting: Machine Learning for Physics and the Physics of Learning Long Program at
+    IPAM
+  meetingurl: http://www.ipam.ucla.edu/programs/long-programs/machine-learning-for-physics-and-the-physics-of-learning/
+  location: IPAM
+  focus-area:
+  - as
+  - ia
+- title: Simulation-based inference, causality, and active learning
+  date: 2019-09-27
+  url: https://ai2019.ethz.ch/talks/Kyle_Cranmer.pdf
+  meeting: AI and the Scientific Method, ETH, Zurich
+  meetingurl: https://ai2019.ethz.ch/program.html
+  location: ETH, Zurich
+  focus-area:
+  - as
+  - ia
+- title: What does the Revolution in Artificial Intelligence Mean for Physics?
+  date: 2019-09-30
+  url: https://ai2019.ethz.ch/program.html
+  meeting: Joint PITT-CMU Physics Department Colloquium
+  meetingurl: https://www.cmu.edu/physics/news-events/events/physics_colloquia.html#event=32472386
+  location: Carnegie Mellon University
+  focus-area:
+  - as
+  - ia
+- title: Particle Physics in the context of Data Science
+  date: 2019-10-05
+  url: https://www.dropbox.com/s/cd6zclbyvwj1u9i/DSAA-IEEE-Keynote.pdf
+  meeting: The 6th IEEE International Conference on Data Science and Advanced Analytics
+  meetingurl: http://dsaa2019.dsaa.co
+  location: Washington, DC
+  focus-area:
+  - as
+  - ia
+- title: Simulation-based inference, interpretability, and experimental design
+  date: 2019-10-17
+  url: http://www.ipam.ucla.edu/abstract/?tid=15943&pcode=MLPWS2
+  meeting: Workshop on Interpretable Learning in Physical Sciences Part of the Long
+    Program Machine Learning for Physics and the Physics of Learning
+  meetingurl: http://www.ipam.ucla.edu/abstract/?tid=15943&pcode=MLPWS2
+  location: UCLA
+  focus-area:
+  - as
+  - ia
+- title: Flows three ways
+  date: 2019-11-19
+  url: http://pcts.princeton.edu/programs/current/deep-learning-for-physics-seminar-series/121
+  meeting: Deep Learning for Physics Seminar Series at Princeton Center for Theoretical
+    Physics
+  meetingurl: http://pctsadmin.princeton.edu/upload/document/da2474d76aeb7f5926f38436f077ff64.pdf
+  location: Princeton
+  focus-area:
+  - as
+  - ia
+- title: HEPData and IRIS-HEP
+  date: 2020-01-28
+  url: https://conference.ippp.dur.ac.uk/event/875/contributions/4770/attachments/3901/4447/HEPData-2020.pdf
+  meeting: HEPData Advisory Board
+  meetingurl: https://conference.ippp.dur.ac.uk/event/875/
+  location: IPPP Durham
+  focus-area:
+  - as
+  - core
+- title: Machine Learning for Effective Field Theories
+  date: 2020-03-03
+  url: https://indico.cern.ch/event/817757/contributions/3712508/
+  meeting: 'PREFIT20: PRecision Effective FIeld Theory School'
+  meetingurl: https://indico.cern.ch/event/817757/overview
+  location: DESY
+  focus-area:
+  - as
+  - ia
+  - core
+- title: Machine Learning and Physics
+  date: 2020-03-05
+  url: https://indico.desy.de/indico/event/25451/
+  meeting: Special QU-PCD Colloquium at DESY (CANCELED due to COVID19)
+  meetingurl: https://indico.desy.de/indico/event/25451/
+  location: DESY
+  focus-area:
+  - as
+  - ia
+- title: Reusable workflows in particle physics
+  date: 2020-03-16
+  url: https://www.nationalacademies.org/event/03-16-2020/realizing-opportunities-for-advanced-and-automated-workflows-in-scientific-research-second-meeting
+  meeting: Workshop on Accelerating Scientific Discovery through Advanced and Automated
+    Workflows
+  meetingurl: https://www.nationalacademies.org/event/03-16-2020/realizing-opportunities-for-advanced-and-automated-workflows-in-scientific-research-second-meeting
+  location: National Academy of Sciences
+  focus-area:
+  - as
+  - core
+- title: Future Analysis Systems
+  date: 2020-03-17
+  url: https://indico.cern.ch/event/896935/
+  meeting: Joint US ATLAS - US CMS Meeting on Facility R&D
+  meetingurl: https://indico.cern.ch/event/896935/
+  location: Remote
+  focus-area:
+  - as
+  - core
+- title: How machine learning can help us get the most out of our highest fidelity
+    physical models
+  date: 2020-05-07
+  url: https://web.mit.edu/physics/events/colloquia.html
+  meeting: MIT Physics Department Colloquium
+  meetingurl: https://web.mit.edu/physics/events/colloquia.html
+  location: Irvine, CA (Virtual)
+  focus-area:
+  - as
+  - ia
+- title: Analysis Systems Overview and Plans
+  date: 2020-05-27
+  url: https://indico.cern.ch/event/896167/contributions/3870075/attachments/2044448/3424682/IRIS-HEP_Retreat_Analysis_Systems_2020-05-26.pptx.pdf
+  meeting: IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167/timetable/
+  location: "(Virtual)"
+  focus-area: as
+- title: Analysis Grand Challenge Proposal
+  date: 2020-05-28
+  url: https://indico.cern.ch/event/896167/contributions/3880424/attachments/2045466/3429947/IRIS-HEP_Analysis_Grand_Challenge_2020-05-28.pptx.pdf
+  meeting: IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167/timetable/
+  location: "(Virtual)"
+  focus-area: as
+- title: 'IRIS-HEP Innovative Algorithms: R&D and Machine Learning for Jets'
+  date: 2020-05-28
+  url: https://indico.cern.ch/event/896167/contributions/3878892/attachments/2045327/3426480/IRIS-HEP_Retreat_NYU_IA_Contribution_2020-05-28.pdf
+  meeting: IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167/timetable/
+  location: "(Virtual)"
+  focus-area: as
+- title: Analysis Systems Plans and Goals Closeout
+  date: 2020-05-29
+  url: https://indico.cern.ch/event/896167/contributions/3874633/attachments/2047251/3431547/IRIS-HEP_Retreat_Analysis_Systems_Closeout_2020-05-29.pptx.pdf
+  meeting: IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167/timetable/
+  location: "(Virtual)"
+  focus-area: as
+- title: Analysis Grand Challenge Closeout
+  date: 2020-05-29
+  url: https://indico.cern.ch/event/896167/contributions/3874640/attachments/2047239/3430338/IRIS-HEP_Analysis_Grand_Challenge_2020-05-28.pptx-2.pdf
+  meeting: IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167/timetable/
+  location: "(Virtual)"
+  focus-area: as
+- title: How machine learning can help us get the most out of our highest fidelity
+    physical models
+  date: 2020-05-31
+  url: https://physics.tau.ac.il/events_physics_colloquium_31_5_2020
+  meeting: Tel Aviv University Physics Department Colloquium
+  meetingurl: https://physics.tau.ac.il/events_physics_colloquium_31_5_2020
+  location: Tel Aviv, Israel (Virtual)
+  focus-area:
+  - as
+  - ia
+- title: The interplay of Math, Physics, and Machine Learning
+  date: 2020-07-02
+  url: https://mpml.tecnico.ulisboa.pt/seminars?id=5806
+  meeting: IST seminar series Mathematics, Physics & Machine Learning
+  meetingurl: https://mpml.tecnico.ulisboa.pt/seminars?id=5806
+  location: Lisbon, Portugal (Virtual)
+  focus-area:
+  - as
+  - ia
+- title: How machine learning can help us get the most out of our highest fidelity
+    physical models
+  date: 2020-07-08
+  url: https://ai4science-amsterdam.github.io/events.html
+  meeting: 'ELLIS SOCIETY: AI4Science Kickoff Workshop'
+  meetingurl: https://ai4science-amsterdam.github.io/events.html
+  location: Amsterdam, Netherlands (Virtual)
+  focus-area:
+  - as
+  - ia
+- title: 'Panel Discussion: A community perspective on Equity in HEP'
+  date: 2020-07-09
+  url: https://science.osti.gov/hep/hepap/Meetings/202007
+  meeting: High Energy Physics Advisory Panel
+  meetingurl: https://science.osti.gov/hep/hepap/Meetings/202007
+  location: Virtual
+  focus-area: core
+- title: Likelihood-based models for Simulation-based Inference
+  date: 2020-07-17
+  url: https://invertibleworkshop.github.io
+  meeting: ICML Workshop on Invertible Neural Networks, Normalizing Flows, and Explicit
+    Likelihood Models
+  meetingurl: https://invertibleworkshop.github.io
+  location: Vienna, Austria (Virtual)
+  focus-area:
+  - as
+  - ia
+- title: 'Graphs, Trees, and Sets: structured data in physics'
+  date: 2020-07-17
+  url: https://grlplus.github.io/schedule/
+  meeting: ICML Workshop on Graph Representation Learning
+  meetingurl: https://grlplus.github.io/schedule/
+  location: Vienna, Austria (Virtual)
+  focus-area:
+  - as
+  - ia
+- title: How machine learning can help us get the most out of our highest fidelity
+    physical models
+  date: 2020-07-21
+  url: https://uni-tuebingen.de/en/165313#c1124370
+  meeting: Machine Learning in Science 2020
+  meetingurl: https://uni-tuebingen.de/en/165313#c1124370
+  location: Eberhard Karls Universität Tübingen (Virtual)
+  focus-area:
+  - as
+  - ia
+- title: Lectures on Statistics
+  date: 2020-08-10
+  url: https://indico.fnal.gov/event/22840/
+  meeting: 15th joint Fermilab-CERN Hadron Collider Summer School
+  meetingurl: https://indico.fnal.gov/event/22840/
+  location: Fermilab (Virtual)
+  focus-area:
+  - as
+  - core
+- title: Constraining EFTs and Dark Matter with Simulation-based Inference
+  date: 2020-08-26
+  url: https://indico.cern.ch/event/945096/
+  meeting: BSM PANDEMIC
+  meetingurl: https://www.bsmpandemic.com
+  location: Fermilab (Virtual)
+  focus-area:
+  - as
+  - core
+- title: Reusable Workflows, active learning, and simulation-based inference
+  date: 2020-09-22
+  url: https://uci-ml-repo.github.io/events/reprod-symposium20/#kcranmer
+  meeting: UCI Symposium on Reproducibility in Machine Learning
+  meetingurl: https://uci-ml-repo.github.io/events/reprod-symposium20/#kcranmer
+  location: Irvine, CA (Virtual)
+  focus-area:
+  - as
+  - ia
+  - core
+- title: How machine learning can help us get the most out of our highest fidelity
+    physical models
+  date: 2020-09-24
+  url: https://www.youtube.com/watch?v=J3LHO1EKFuU
+  meeting: NYU Physics Colloquium
+  meetingurl: https://physics.nyu.edu/events.html?EventsPage=colloquia
+  location: New York University (Virtual)
+  focus-area:
+  - as
+  - ia
+- title: Likelihood publishing, RECAST, and simulation-based inference
+  date: 2020-10-14
+  url: https://indico.cern.ch/event/962997/
+  meeting: PhyStat / CERN EP-IT Data science seminar
+  meetingurl: https://indico.cern.ch/event/962997/
+  location: CERN (Virtual)
+  focus-area: as
+- title: 'Vision: Physics, Machine Learning, and Computing'
+  date: 2020-10-19
+  url: http://www.ncsa.illinois.edu/Conferences/AcceleratedAINCSA/agenda.html
+  meeting: 2020 Accelerated Artificial Intelligence for Big-Data Experiments Conference
+  meetingurl: http://www.ncsa.illinois.edu/Conferences/AcceleratedAINCSA/agenda.html
+  location: NCSA (Virtual)
+  focus-area: as
+- title: End-to-End Analysis Vision & AS Grand Challenge
+  date: 2020-10-26
+  url: https://indico.cern.ch/event/960587/contributions/4070317/
+  meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
+  meetingurl: https://indico.cern.ch/event/960587/
+  location: Virtual
+  focus-area: as
+- title: New experimental analysis techniques
+  date: 2020-10-30
+  url: https://indico.cern.ch/event/900384/contributions/3796227/
+  meeting: Higgs2020
+  meetingurl: https://indico.cern.ch/event/900384/timetable/#20201030.detailed
+  location: Virtual
+  focus-area: as
+- title: Machine Learning for high energy physics on and off the lattice
+  date: 2020-12-03
+  url: https://www.ectstar.eu/activities/seminars/colloquia/
+  meeting: ECT* Colloqium (European Center for Theoretical Studies in Nuclear Physics
+    and Related Areas)
+  meetingurl: https://www.ectstar.eu/activities/seminars/colloquia/
+  location: Virtual
+  focus-area: as
+- title: How machine learning can help us get the most out of our highest fidelity
+    physical models
+  date: 2020-12-08
+  url: https://ai-roadmap.ornl.gov
+  meeting: AI for Atoms
+  meetingurl: https://ai-roadmap.ornl.gov
+  location: Oak Ridge National Laboratory (Virtual)
+  focus-area:
+  - as
+  - ia
+- title: Some fun examples from the intersection of machine learning and physics
+  date: 2020-12-18
+  url: https://virtual-event.mlinpl.org
+  meeting: ML in PL
+  meetingurl: https://virtual-event.mlinpl.org
+  location: Poland (Virtual)
+  focus-area:
+  - as
+  - ia
+- title: 'MadMiner: Machine learning–based inference for particle physics'
+  date: 2021-01-11
+  url: https://indico.cern.ch/event/971725/#5-madminer-machine-learning-ba
+  meeting: LHC EFT Working Group
+  meetingurl: https://indico.cern.ch/event/971725/
+  location: CERN (Virtual)
+  focus-area: as
+- title: MadMiner tutorial
+  date: 2021-02-18
+  url: https://indico.cern.ch/event/982553/contributions/4220018/
+  meeting: "(Re)interpreting the results of new physics searches at the LHC"
+  meetingurl: https://indico.cern.ch/event/982553/overview
+  location: "(Virtual)"
+  focus-area:
+  - as
+  - ia
+- title: Quarks, hierarchical clustering, and combinatorial optimization
+  date: 2021-02-22
+  url: http://www.ipam.ucla.edu/abstract/?tid=16760&pcode=DLC2021
+  meeting: Deep Learning and Combinatorial Optimization
+  meetingurl: http://www.ipam.ucla.edu/programs/workshops/deep-learning-and-combinatorial-optimization/?tab=overview
+  location: Institute Pure and Applied Mathematics (IPAM) (virtual)
+  focus-area: ia
+- title: Machine Learning for Precision Measurements
+  date: 2021-03-02
+  url: https://indico.tlabs.ac.za/event/100/contributions/1727/
+  meeting: Unveiling hidden Physics Beyond the Standard Model at the LHC
+  meetingurl: https://indico.tlabs.ac.za/event/100/overview
+  location: "(Virtual)"
+  focus-area: as
+- title: Probabalistic Machine Learning for the Physical Sciences
+  date: 2021-03-09
+  url: https://www.cs.ox.ac.uk/teaching/courses/2020-2021/advml/
+  meeting: Advanced Topics in Machine Learning Course
+  meetingurl: https://www.cs.ox.ac.uk/teaching/courses/2020-2021/advml/
+  location: Oxford University
+  focus-area: as
+- title: Graph Deep Learning for Physics
+  date: 2021-03-25
+  url: https://www.youtube.com/watch?v=FjShuSoWZks
+  meeting: Università della Svizzera
+  meetingurl: https://www.usi.ch/en/feeds/15796
+  location: "(Virtual) Università della Svizzera"
+  focus-area:
+  - ia
+  - as
+- title: 'Invited Keynote for AISTATS: Simulation-Based Inference'
+  date: 2021-04-02
+  url: https://slideslive.com/38955019
+  meeting: AISTATS
+  meetingurl: https://aistats.org/aistats2021/
+  location: "(Virtual)"
+  focus-area: as
+- title: Towards a white paper on public likelihoods
+  date: 2021-04-22
+  url: https://indico.cern.ch/event/1015891/attachments/2231688/3781529/Likelihood-whitepaper-RAMP-2021.pdf
+  meeting: LHC Re-interpretation Forum
+  meetingurl: https://indico.cern.ch/event/1015891/
+  location: "(Virtual)"
+  focus-area: as
+- title: An AI revolution in science? Using machine learning for scientific discovery
+  date: 2021-04-26
+  url: https://www.cst.cam.ac.uk/news/ai-revolution-science-using-machine-learning-scientific-discovery
+  meeting: University of Cambridge Accelerate Programme for Scientific Discovery
+  meetingurl: https://www.cst.cam.ac.uk/news/ai-revolution-science-using-machine-learning-scientific-discovery
+  location: "(Virtual)"
+  focus-area:
+  - as
+  - ia
+- title: Analysis Systems Overview
+  date: 2021-04-27
+  url: https://indico.cern.ch/event/957103/contributions/4330981/
+  meeting: IRIS-HEP Annual PI/EB Meeting
+  meetingurl: https://indico.cern.ch/event/957103/
+  location: "(Virtual)"
+  focus-area: as

--- a/_data/people/cranmer.yml
+++ b/_data/people/cranmer.yml
@@ -508,3 +508,6 @@ presentations:
   meetingurl: https://indico.cern.ch/event/957103/
   location: "(Virtual)"
   focus-area: as
+focus-area:
+- as
+- ia

--- a/_data/people/cranmer.yml
+++ b/_data/people/cranmer.yml
@@ -1,12 +1,14 @@
----
+active: true
+e-mail: kyle.cranmer@nyu.edu
+focus-area:
+- as
+- ia
+institution: New York University
 name: Kyle Cranmer
+photo: "/assets/images/team/Kyle-Cranmer.jpg"
 shortname: cranmer
 title: Analysis Systems Area Lead
-active: true
-institution: New York University
 website: http://theoryandpractice.org
-photo: "/assets/images/team/Kyle-Cranmer.jpg"
-e-mail: kyle.cranmer@nyu.edu
 presentations:
 - title: What does the Revolution in Artificial Intelligence Mean for Physics?
   date: 2018-09-07
@@ -508,6 +510,3 @@ presentations:
   meetingurl: https://indico.cern.ch/event/957103/
   location: "(Virtual)"
   focus-area: as
-focus-area:
-- as
-- ia

--- a/_data/people/cvarni.yml
+++ b/_data/people/cvarni.yml
@@ -1,15 +1,16 @@
+---
 name: Carlo Varni
 title: Postdoctoral researcher
 shortname: cvarni
 active: true
 institution: University of California, Berkeley
-photo: /assets/images/team/CarloVarni.jpg
+photo: "/assets/images/team/CarloVarni.jpg"
 e-mail: carlo.varni@berkeley.edu
 presentations:
-  - title: ACTS integration into athena
-    date: 2021-03-26
-    url:
-    meeting: ACTS-ITk meeting
-    meetingurl:
-    project: acts
-    location: CERN
+- title: ACTS integration into athena
+  date: 2021-03-26
+  url:
+  meeting: ACTS-ITk meeting
+  meetingurl:
+  project: acts
+  location: CERN

--- a/_data/people/cvarni.yml
+++ b/_data/people/cvarni.yml
@@ -14,3 +14,5 @@ presentations:
   meetingurl:
   project: acts
   location: CERN
+focus-area:
+- ia

--- a/_data/people/cvarni.yml
+++ b/_data/people/cvarni.yml
@@ -1,11 +1,12 @@
----
-name: Carlo Varni
-title: Postdoctoral researcher
-shortname: cvarni
 active: true
-institution: University of California, Berkeley
-photo: "/assets/images/team/CarloVarni.jpg"
 e-mail: carlo.varni@berkeley.edu
+focus-area:
+- ia
+institution: University of California, Berkeley
+name: Carlo Varni
+photo: "/assets/images/team/CarloVarni.jpg"
+shortname: cvarni
+title: Postdoctoral researcher
 presentations:
 - title: ACTS integration into athena
   date: 2021-03-26
@@ -14,5 +15,3 @@ presentations:
   meetingurl:
   project: acts
   location: CERN
-focus-area:
-- ia

--- a/_data/people/d_brown.yml
+++ b/_data/people/d_brown.yml
@@ -1,12 +1,14 @@
+---
 name: Dave Brown
 shortname: d_brown
 title:
 active: true
 institution: Lawrence Berkeley National Laboratory
 website:
-photo: /assets/images/team/Dave_Brown.jpg
+photo: "/assets/images/team/Dave_Brown.jpg"
 presentations:
-about: HEP, Non-LHC representative. Mu2e, formerly BaBar, formerly Aleph, formerly CDF Run1
+about: HEP, Non-LHC representative. Mu2e, formerly BaBar, formerly Aleph, formerly
+  CDF Run1
 role: Provide expertise and input from a    member of the HEP community with a non-LHC
- point-of-view.
+  point-of-view.
 hidden: true

--- a/_data/people/d_brown.yml
+++ b/_data/people/d_brown.yml
@@ -1,14 +1,13 @@
----
-name: Dave Brown
-shortname: d_brown
-title:
-active: true
-institution: Lawrence Berkeley National Laboratory
-website:
-photo: "/assets/images/team/Dave_Brown.jpg"
-presentations:
 about: HEP, Non-LHC representative. Mu2e, formerly BaBar, formerly Aleph, formerly
   CDF Run1
+active: true
+hidden: true
+institution: Lawrence Berkeley National Laboratory
+name: Dave Brown
+photo: "/assets/images/team/Dave_Brown.jpg"
 role: Provide expertise and input from a    member of the HEP community with a non-LHC
   point-of-view.
-hidden: true
+shortname: d_brown
+title:
+website:
+presentations:

--- a/_data/people/d_costanzo.yml
+++ b/_data/people/d_costanzo.yml
@@ -1,10 +1,9 @@
----
+active: true
+hidden: true
+institution: Sheffield
 name: David Costanzo
+photo: "/assets/images/team/David_Costanzo.png"
 shortname: d_costanzo
 title: ATLAS Experiment
-active: true
-institution: Sheffield
 website:
-photo: "/assets/images/team/David_Costanzo.png"
-hidden: true
 presentations:

--- a/_data/people/d_costanzo.yml
+++ b/_data/people/d_costanzo.yml
@@ -1,9 +1,10 @@
+---
 name: David Costanzo
 shortname: d_costanzo
 title: ATLAS Experiment
 active: true
 institution: Sheffield
 website:
-photo: /assets/images/team/David_Costanzo.png
+photo: "/assets/images/team/David_Costanzo.png"
 hidden: true
 presentations:

--- a/_data/people/d_swanson.yml
+++ b/_data/people/d_swanson.yml
@@ -1,9 +1,10 @@
+---
 name: David Swanson
 shortname: d_swanson
 title: The OSG Council
 active: true
 institution: U. Nebraska-Lincoln
 website:
-photo: /assets/images/team/David_Swanson.jpg
+photo: "/assets/images/team/David_Swanson.jpg"
 hidden: true
 presentations:

--- a/_data/people/d_swanson.yml
+++ b/_data/people/d_swanson.yml
@@ -1,10 +1,9 @@
----
+active: true
+hidden: true
+institution: U. Nebraska-Lincoln
 name: David Swanson
+photo: "/assets/images/team/David_Swanson.jpg"
 shortname: d_swanson
 title: The OSG Council
-active: true
-institution: U. Nebraska-Lincoln
 website:
-photo: "/assets/images/team/David_Swanson.jpg"
-hidden: true
 presentations:

--- a/_data/people/dan131riley.yml
+++ b/_data/people/dan131riley.yml
@@ -62,3 +62,6 @@ presentations:
   location: Virtual
   focus-area: ia
   project: mkfit
+focus-area:
+- ssc
+- ia

--- a/_data/people/dan131riley.yml
+++ b/_data/people/dan131riley.yml
@@ -1,63 +1,64 @@
+---
 name: Dan Riley
 shortname: dan131riley
 title:
 active: true
 institution: Cornell University
 website: https://github.com/dan131riley
-photo: /assets/images/team/Dan-Riley.JPG
+photo: "/assets/images/team/Dan-Riley.JPG"
 presentations:
-  - title: Use and Abuse of Random Numbers
-    date: 2019-07-24
-    url: https://indico.cern.ch/event/814979/contributions/3401176/attachments/1831472/3107702/RandomAbuse2019.pdf
-    meeting: Third Computational and Data Science school for HEP (CoDaS-HEP 2019)
-    meetingurl: https://indico.cern.ch/event/814979
-    location: Princeton University
-    focus-area: ssc
-  - title: "mkFit update: strip tracker unpacking and clustering on CPU and GPU"
-    date: 2020-02-05
-    url: https://indico.cern.ch/event/879441/contributions/3724608/attachments/1982379/3301769/gpu-unpacking-2020-02-05.pdf
-    meeting: CMS Tracker DPG/Strip Calibration and Local Reconstruction Weekly Meeting
-    meetingurl: https://indico.cern.ch/event/879441/
-    location: CERN
-    focus-area: ia
-    project: mkfit
-  - title: "mkFit update: strip tracker unpacking and clustering on GPU"
-    date: 2020-04-28
-    url: https://indico.cern.ch/event/879448/contributions/3832308/attachments/2028104/3393518/gpu-unpacking-2020-04-28.pdf
-    meeting: CMS Tracker DPG - Tracking POG general Weekly Meeting
-    meetingurl: https://indico.cern.ch/event/879448/
-    location: Virtual
-    focus-area: ia
-    project: mkfit
-  - title: "mkFit update: strip tracker unpacking and clustering on GPU"
-    date: 2020-05-05
-    url: https://indico.cern.ch/event/909499/contributions/3850945/attachments/2032289/3401593/gpu-unpacking-2020-05-05.pdf
-    meeting: CMS HLT Upgrade TSG Weekly Meeting
-    meetingurl: https://indico.cern.ch/event/909499/
-    location: Virtual
-    focus-area: ia
-    project: mkfit
-  - title: "Local tracker reconstruction on accelerators"
-    date: 2020-06-09
-    url: https://indico.cern.ch/event/927203/contributions/3898325/attachments/2053965/3443446/gpu-tracking-2020-06-09.pdf
-    meeting: CMS Upgrade R&D/CMP Meeting
-    meetingurl: https://indico.cern.ch/event/927203/
-    location: Virtual
-    focus-area: ia
-    project: mkfit
-  - title: "mkFit update: strip tracker unpacking and clustering on GPU "
-    date: 2020-08-05
-    url: https://indico.cern.ch/event/934806/contributions/3953697/attachments/2085045/3502700/gpu-unpacking-2020-08-05.pdf
-    meeting: CMS Strip Calibration and Local Reconstruction Meeting
-    meetingurl: https://indico.cern.ch/event/934806/?showDate=all&showSession=10
-    location: Virtual
-    focus-area: ia
-    project: mkfit
-  - title: "Accelerated Strip Local reconstruction on GPUs"
-    date: 2020-12-15
-    url: https://indico.cern.ch/event/934829/contributions/4146378/attachments/2163083/3650192/gpu-unpacking-2020-12-15.pdf
-    meeting: CMS Tracker Detector Performance Group
-    meetingurl: https://indico.cern.ch/event/934829/?showDate=all&showSession=6
-    location: Virtual
-    focus-area: ia
-    project: mkfit
+- title: Use and Abuse of Random Numbers
+  date: 2019-07-24
+  url: https://indico.cern.ch/event/814979/contributions/3401176/attachments/1831472/3107702/RandomAbuse2019.pdf
+  meeting: Third Computational and Data Science school for HEP (CoDaS-HEP 2019)
+  meetingurl: https://indico.cern.ch/event/814979
+  location: Princeton University
+  focus-area: ssc
+- title: 'mkFit update: strip tracker unpacking and clustering on CPU and GPU'
+  date: 2020-02-05
+  url: https://indico.cern.ch/event/879441/contributions/3724608/attachments/1982379/3301769/gpu-unpacking-2020-02-05.pdf
+  meeting: CMS Tracker DPG/Strip Calibration and Local Reconstruction Weekly Meeting
+  meetingurl: https://indico.cern.ch/event/879441/
+  location: CERN
+  focus-area: ia
+  project: mkfit
+- title: 'mkFit update: strip tracker unpacking and clustering on GPU'
+  date: 2020-04-28
+  url: https://indico.cern.ch/event/879448/contributions/3832308/attachments/2028104/3393518/gpu-unpacking-2020-04-28.pdf
+  meeting: CMS Tracker DPG - Tracking POG general Weekly Meeting
+  meetingurl: https://indico.cern.ch/event/879448/
+  location: Virtual
+  focus-area: ia
+  project: mkfit
+- title: 'mkFit update: strip tracker unpacking and clustering on GPU'
+  date: 2020-05-05
+  url: https://indico.cern.ch/event/909499/contributions/3850945/attachments/2032289/3401593/gpu-unpacking-2020-05-05.pdf
+  meeting: CMS HLT Upgrade TSG Weekly Meeting
+  meetingurl: https://indico.cern.ch/event/909499/
+  location: Virtual
+  focus-area: ia
+  project: mkfit
+- title: Local tracker reconstruction on accelerators
+  date: 2020-06-09
+  url: https://indico.cern.ch/event/927203/contributions/3898325/attachments/2053965/3443446/gpu-tracking-2020-06-09.pdf
+  meeting: CMS Upgrade R&D/CMP Meeting
+  meetingurl: https://indico.cern.ch/event/927203/
+  location: Virtual
+  focus-area: ia
+  project: mkfit
+- title: 'mkFit update: strip tracker unpacking and clustering on GPU '
+  date: 2020-08-05
+  url: https://indico.cern.ch/event/934806/contributions/3953697/attachments/2085045/3502700/gpu-unpacking-2020-08-05.pdf
+  meeting: CMS Strip Calibration and Local Reconstruction Meeting
+  meetingurl: https://indico.cern.ch/event/934806/?showDate=all&showSession=10
+  location: Virtual
+  focus-area: ia
+  project: mkfit
+- title: Accelerated Strip Local reconstruction on GPUs
+  date: 2020-12-15
+  url: https://indico.cern.ch/event/934829/contributions/4146378/attachments/2163083/3650192/gpu-unpacking-2020-12-15.pdf
+  meeting: CMS Tracker Detector Performance Group
+  meetingurl: https://indico.cern.ch/event/934829/?showDate=all&showSession=6
+  location: Virtual
+  focus-area: ia
+  project: mkfit

--- a/_data/people/dan131riley.yml
+++ b/_data/people/dan131riley.yml
@@ -1,11 +1,13 @@
----
+active: true
+focus-area:
+- ssc
+- ia
+institution: Cornell University
 name: Dan Riley
+photo: "/assets/images/team/Dan-Riley.JPG"
 shortname: dan131riley
 title:
-active: true
-institution: Cornell University
 website: https://github.com/dan131riley
-photo: "/assets/images/team/Dan-Riley.JPG"
 presentations:
 - title: Use and Abuse of Random Numbers
   date: 2019-07-24
@@ -62,6 +64,3 @@ presentations:
   location: Virtual
   focus-area: ia
   project: mkfit
-focus-area:
-- ssc
-- ia

--- a/_data/people/danielsibemol.yml
+++ b/_data/people/danielsibemol.yml
@@ -1,9 +1,8 @@
----
-name: Daniel Vieira
-shortname: danielsibemol
-title: Postdoctoral Research Associate
 active: true
 institution: University of Cincinnati
-website:
+name: Daniel Vieira
 photo: "/assets/images/team/Daniel-Vieira.jpg"
+shortname: danielsibemol
+title: Postdoctoral Research Associate
+website:
 presentations:

--- a/_data/people/danielsibemol.yml
+++ b/_data/people/danielsibemol.yml
@@ -1,8 +1,9 @@
+---
 name: Daniel Vieira
 shortname: danielsibemol
 title: Postdoctoral Research Associate
 active: true
 institution: University of Cincinnati
 website:
-photo: /assets/images/team/Daniel-Vieira.jpg
+photo: "/assets/images/team/Daniel-Vieira.jpg"
 presentations:

--- a/_data/people/danielskatz.yml
+++ b/_data/people/danielskatz.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ssc
+institution: University of Illinois at Urbana-Champaign
 name: Daniel S. Katz
+photo: "/assets/images/team/Dan-Katz.png"
 shortname: danielskatz
 title:
-active: true
-institution: University of Illinois at Urbana-Champaign
 website: http://danielskatz.org
-photo: "/assets/images/team/Dan-Katz.png"
 presentations:
 - title: Software Sustainability
   date: 2020-09-20
@@ -14,5 +15,3 @@ presentations:
   meetingurl: https://indico.bnl.gov/event/9023/
   location: Virtual
   focus-area: ssc
-focus-area:
-- ssc

--- a/_data/people/danielskatz.yml
+++ b/_data/people/danielskatz.yml
@@ -14,3 +14,5 @@ presentations:
   meetingurl: https://indico.bnl.gov/event/9023/
   location: Virtual
   focus-area: ssc
+focus-area:
+- ssc

--- a/_data/people/danielskatz.yml
+++ b/_data/people/danielskatz.yml
@@ -1,15 +1,16 @@
+---
 name: Daniel S. Katz
 shortname: danielskatz
 title:
 active: true
 institution: University of Illinois at Urbana-Champaign
 website: http://danielskatz.org
-photo: /assets/images/team/Dan-Katz.png
+photo: "/assets/images/team/Dan-Katz.png"
 presentations:
-  - title: Software Sustainability
-    date: 2020-09-20
-    url: https://indico.bnl.gov/event/9023/contributions/40346/
-    meeting: Future Trends in Nuclear Physics Computing
-    meetingurl: https://indico.bnl.gov/event/9023/
-    location: Virtual
-    focus-area: ssc
+- title: Software Sustainability
+  date: 2020-09-20
+  url: https://indico.bnl.gov/event/9023/contributions/40346/
+  meeting: Future Trends in Nuclear Physics Computing
+  meetingurl: https://indico.bnl.gov/event/9023/
+  location: Virtual
+  focus-area: ssc

--- a/_data/people/davidlange6.yml
+++ b/_data/people/davidlange6.yml
@@ -1,49 +1,51 @@
+---
 name: David Lange
 shortname: davidlange6
 title: Innovative Algorithms Area <nobr>co-Lead</nobr>
 active: true
 institution: Princeton University
 website: https://dlange.web.cern.ch
-photo: /assets/images/team/David-Lange.png
+photo: "/assets/images/team/David-Lange.png"
 e-mail: David.Lange@cern.ch
 presentations:
-  - title: "IRIS-HEP Innovative Algorithms"
-    date: 2019-02-06
-    url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271529/attachments/1791453/2919650/Innovative_Algorithms_3.pdf
-    meeting: IRIS-HEP Steering Board Meeting #1
-    meetingurl: https://indico.cern.ch/event/790759/
-    focus-area: ia
-    project:
-  - title: "HSF Training survey"
-    date: 2019-03-21
-    url: https://indico.cern.ch/event/759388/contributions/3315848/attachments/1816082/2968198/training_how2019.pdf
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop (HOW2019)
-    meetingurl: https://indico.cern.ch/event/759388
-    focus-area: ssc
-  - title: "A Worldwide Software Collaboration?"
-    date: 2020-01-17
-    url: http://ias.ust.hk/program/shared_doc/2020/202001hep/workshop/exp/20200117_1038_pm_David_LANGE.pdf
-    meeting: "Hong Kong IAS Mini-workshop: Experiment / Detector - Software and Physics Requirements for e+e- Colliders"
-    meetingurl: http://iasprogram.ust.hk/hep/2020/activities.php
-    focus-area: ia
-    project:
-  - title: "Challenges and Evolution of the LHC computing model for HL-LHC"
-    date: 2020-03-05
-    meeting: "Boston University seminar"
-    url: https://drive.google.com/file/d/18MWhoYdzOYZ35rddDhcALezWSwBqgC1L/view?usp=sharing
-    focus-area: ia
-    project:
-  - title: "Connecting the Dots 2020 - Workshop introduction"
-    date: 2020-04-20
-    meeting: "Connecting the Dots 2020"
-    url: https://indico.cern.ch/event/831165/contributions/3758939/
-    meetingurl: https://indico.cern.ch/event/831165/
-    focus-area: ia
-    project:
-  - title: "Innovative Algorithms - Years 3, and 4+5"
-    meeting: IRIS-HEP team retreat
-    url: https://indico.cern.ch/event/896167/contributions/3870074/attachments/2044699/3426314/IA_retreat_day1_6.pdf
-    meetingurl: https://indico.cern.ch/event/896167/
-    focus-area: ia
-    date: 2020-05-26
-    project:
+- title: IRIS-HEP Innovative Algorithms
+  date: 2019-02-06
+  url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271529/attachments/1791453/2919650/Innovative_Algorithms_3.pdf
+  meeting: IRIS-HEP Steering Board Meeting
+  meetingurl: https://indico.cern.ch/event/790759/
+  focus-area: ia
+  project:
+- title: HSF Training survey
+  date: 2019-03-21
+  url: https://indico.cern.ch/event/759388/contributions/3315848/attachments/1816082/2968198/training_how2019.pdf
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop (HOW2019)
+  meetingurl: https://indico.cern.ch/event/759388
+  focus-area: ssc
+- title: A Worldwide Software Collaboration?
+  date: 2020-01-17
+  url: http://ias.ust.hk/program/shared_doc/2020/202001hep/workshop/exp/20200117_1038_pm_David_LANGE.pdf
+  meeting: 'Hong Kong IAS Mini-workshop: Experiment / Detector - Software and Physics
+    Requirements for e+e- Colliders'
+  meetingurl: http://iasprogram.ust.hk/hep/2020/activities.php
+  focus-area: ia
+  project:
+- title: Challenges and Evolution of the LHC computing model for HL-LHC
+  date: 2020-03-05
+  meeting: Boston University seminar
+  url: https://drive.google.com/file/d/18MWhoYdzOYZ35rddDhcALezWSwBqgC1L/view?usp=sharing
+  focus-area: ia
+  project:
+- title: Connecting the Dots 2020 - Workshop introduction
+  date: 2020-04-20
+  meeting: Connecting the Dots 2020
+  url: https://indico.cern.ch/event/831165/contributions/3758939/
+  meetingurl: https://indico.cern.ch/event/831165/
+  focus-area: ia
+  project:
+- title: Innovative Algorithms - Years 3, and 4+5
+  meeting: IRIS-HEP team retreat
+  url: https://indico.cern.ch/event/896167/contributions/3870074/attachments/2044699/3426314/IA_retreat_day1_6.pdf
+  meetingurl: https://indico.cern.ch/event/896167/
+  focus-area: ia
+  date: 2020-05-26
+  project:

--- a/_data/people/davidlange6.yml
+++ b/_data/people/davidlange6.yml
@@ -49,3 +49,6 @@ presentations:
   focus-area: ia
   date: 2020-05-26
   project:
+focus-area:
+- ia
+- ssc

--- a/_data/people/davidlange6.yml
+++ b/_data/people/davidlange6.yml
@@ -1,12 +1,14 @@
----
+active: true
+e-mail: David.Lange@cern.ch
+focus-area:
+- ia
+- ssc
+institution: Princeton University
 name: David Lange
+photo: "/assets/images/team/David-Lange.png"
 shortname: davidlange6
 title: Innovative Algorithms Area <nobr>co-Lead</nobr>
-active: true
-institution: Princeton University
 website: https://dlange.web.cern.ch
-photo: "/assets/images/team/David-Lange.png"
-e-mail: David.Lange@cern.ch
 presentations:
 - title: IRIS-HEP Innovative Algorithms
   date: 2019-02-06
@@ -49,6 +51,3 @@ presentations:
   focus-area: ia
   date: 2020-05-26
   project:
-focus-area:
-- ia
-- ssc

--- a/_data/people/dcraik.yml
+++ b/_data/people/dcraik.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ia
+institution: Massachusetts Institute of Technology
 name: Daniel Craik
+photo: "/assets/images/team/Daniel-Craik.jpg"
 shortname: dcraik
 title: Postdoctoral Research Associate
-active: true
-institution: Massachusetts Institute of Technology
 website:
-photo: "/assets/images/team/Daniel-Craik.jpg"
 presentations:
 - title: LHCb Status and Outlook
   date: 2019-10-16
@@ -45,5 +46,3 @@ presentations:
   url: https://slideslive.com/38926198/autoencoders-for-compression-and-simulation-in-particle-physics
   focus-area: ia
   project: allen
-focus-area:
-- ia

--- a/_data/people/dcraik.yml
+++ b/_data/people/dcraik.yml
@@ -45,3 +45,5 @@ presentations:
   url: https://slideslive.com/38926198/autoencoders-for-compression-and-simulation-in-particle-physics
   focus-area: ia
   project: allen
+focus-area:
+- ia

--- a/_data/people/dcraik.yml
+++ b/_data/people/dcraik.yml
@@ -1,46 +1,47 @@
+---
 name: Daniel Craik
 shortname: dcraik
 title: Postdoctoral Research Associate
 active: true
 institution: Massachusetts Institute of Technology
 website:
-photo: /assets/images/team/Daniel-Craik.jpg
+photo: "/assets/images/team/Daniel-Craik.jpg"
 presentations:
-  - title: LHCb Status and Outlook
-    date: 2019-10-16
-    url: https://indico.cern.ch/event/844493/contributions/3547458/attachments/1927340/3190928/20191016_dcraik_lua.pdf
-    meeting: LHC Users Association Annual Meeting 2019
-    meetingurl: https://indico.cern.ch/event/844493
-    location: Rice University
-    focus-area: ia
-    project: allen
-  - title: The Trigger and Real-time Reconstruction at LHCb
-    date: 2019-12-09
-    url: https://agenda.hep.wisc.edu/event/1391/session/11/contribution/119/material/slides/0.pdf
-    meeting: CPAD Instrumentation Frontier Workshop 2019
-    meetingurl: https://wp.physics.wisc.edu/cpad2019/
-    location: Madison, WI
-    focus-area: ia
-    project: allen
-  - title: The Allen Project
-    date: 2020-01-27
-    meeting: IRIS-HEP Topical Meeting
-    meetingurl: https://indico.cern.ch/event/871092/
-    url: https://indico.cern.ch/event/871092/contributions/3673777/attachments/1976291/3289494/20200127_dcraik_irishep_v2.pdf
-    focus-area: ia
-    project: allen
-  - title: "Allen: a GPU trigger for LHCb"
-    date: 2020-02-27
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton, NJ
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331184/13_-_iris-hep-allen-dcraik-40-30.pdf
-    focus-area: ia
-    project: allen
-  - title: Autoencoders for Compression and Simulation in Particle Physics
-    date: 2020-04-26
-    meeting: International Conference on Learning Representations 2020
-    meetingurl: https://iclr.cc/virtual/workshops_1.html
-    url: https://slideslive.com/38926198/autoencoders-for-compression-and-simulation-in-particle-physics
-    focus-area: ia
-    project: allen
+- title: LHCb Status and Outlook
+  date: 2019-10-16
+  url: https://indico.cern.ch/event/844493/contributions/3547458/attachments/1927340/3190928/20191016_dcraik_lua.pdf
+  meeting: LHC Users Association Annual Meeting 2019
+  meetingurl: https://indico.cern.ch/event/844493
+  location: Rice University
+  focus-area: ia
+  project: allen
+- title: The Trigger and Real-time Reconstruction at LHCb
+  date: 2019-12-09
+  url: https://agenda.hep.wisc.edu/event/1391/session/11/contribution/119/material/slides/0.pdf
+  meeting: CPAD Instrumentation Frontier Workshop 2019
+  meetingurl: https://wp.physics.wisc.edu/cpad2019/
+  location: Madison, WI
+  focus-area: ia
+  project: allen
+- title: The Allen Project
+  date: 2020-01-27
+  meeting: IRIS-HEP Topical Meeting
+  meetingurl: https://indico.cern.ch/event/871092/
+  url: https://indico.cern.ch/event/871092/contributions/3673777/attachments/1976291/3289494/20200127_dcraik_irishep_v2.pdf
+  focus-area: ia
+  project: allen
+- title: 'Allen: a GPU trigger for LHCb'
+  date: 2020-02-27
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton, NJ
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331184/13_-_iris-hep-allen-dcraik-40-30.pdf
+  focus-area: ia
+  project: allen
+- title: Autoencoders for Compression and Simulation in Particle Physics
+  date: 2020-04-26
+  meeting: International Conference on Learning Representations 2020
+  meetingurl: https://iclr.cc/virtual/workshops_1.html
+  url: https://slideslive.com/38926198/autoencoders-for-compression-and-simulation-in-particle-physics
+  focus-area: ia
+  project: allen

--- a/_data/people/ddavila0.yml
+++ b/_data/people/ddavila0.yml
@@ -1,26 +1,27 @@
+---
 name: Diego Davila
 shortname: ddavila0
 title: Scientific Software Developer and Researcher
 active: true
 institution: University of California, San Diego
 website:
-photo: /assets/images/team/Diego-Davila.jpg
+photo: "/assets/images/team/Diego-Davila.jpg"
 presentations:
-- title: "HTTP Third-Party Copy: Getting rid of GridFTP"
+- title: 'HTTP Third-Party Copy: Getting rid of GridFTP'
   date: 2021-03-03
   url: https://indico.fnal.gov/event/47040/contributions/208459/attachments/140622/176781/HTTP_Third-Party_Copy__Getting_rid_of_GridFTP.pdf
   meeting: OSG All-Hands Meeting 2021
   meetingurl: https://indico.fnal.gov/event/47040/overview
   focusarea: doma
   project: tpc
-- title: "Update on the adoption of WebDAV for Third Party Copy transfers"
+- title: Update on the adoption of WebDAV for Third Party Copy transfers
   date: 2021-02-24
   url: https://indico.cern.ch/event/1007732/contributions/4229157/attachments/2195647/3713100/Update%20on%20the%20adoption%20of%20WebDAV%2C%20February%202021%20%281%29.pdf
   meeting: Offline and Computing Weekly meeting
   meetingurl: https://indico.cern.ch/event/1007732/
   focusarea: doma
   project: tpc
-- title: "Progress on transferring with HTTP-TPC"
+- title: Progress on transferring with HTTP-TPC
   date: 2020-08-05
   url: https://indico.cern.ch/event/943367/contributions/3963678/attachments/2085027/3502669/Progress_on_transferring_with_HTTP-TPC.pdf
   meeting: Offline and Computing Weekly meeting

--- a/_data/people/ddavila0.yml
+++ b/_data/people/ddavila0.yml
@@ -58,3 +58,6 @@ presentations:
   location: Princeton University
   focus-area: doma
   project: modeling
+focus-area:
+- doma
+- osglhc

--- a/_data/people/ddavila0.yml
+++ b/_data/people/ddavila0.yml
@@ -1,11 +1,13 @@
----
+active: true
+focus-area:
+- doma
+- osglhc
+institution: University of California, San Diego
 name: Diego Davila
+photo: "/assets/images/team/Diego-Davila.jpg"
 shortname: ddavila0
 title: Scientific Software Developer and Researcher
-active: true
-institution: University of California, San Diego
 website:
-photo: "/assets/images/team/Diego-Davila.jpg"
 presentations:
 - title: 'HTTP Third-Party Copy: Getting rid of GridFTP'
   date: 2021-03-03
@@ -58,6 +60,3 @@ presentations:
   location: Princeton University
   focus-area: doma
   project: modeling
-focus-area:
-- doma
-- osglhc

--- a/_data/people/djw8605.yml
+++ b/_data/people/djw8605.yml
@@ -1,11 +1,13 @@
----
+active: true
+focus-area:
+- osglhc
+- doma
+institution: University of Nebraska - Lincoln
 name: Derek Weitzel
+photo: "/assets/images/team/Derek-Weitzel.jpg"
 shortname: djw8605
 title:
-active: true
-institution: University of Nebraska - Lincoln
 website: https://derekweitzel.com
-photo: "/assets/images/team/Derek-Weitzel.jpg"
 presentations:
 - title: 'Moving science data: One CDN to rule them all'
   date: 2021-03-03
@@ -73,6 +75,3 @@ presentations:
   - doma
   project: osg-operations
   location: Virtual
-focus-area:
-- osglhc
-- doma

--- a/_data/people/djw8605.yml
+++ b/_data/people/djw8605.yml
@@ -73,3 +73,6 @@ presentations:
   - doma
   project: osg-operations
   location: Virtual
+focus-area:
+- osglhc
+- doma

--- a/_data/people/djw8605.yml
+++ b/_data/people/djw8605.yml
@@ -1,64 +1,75 @@
+---
 name: Derek Weitzel
 shortname: djw8605
 title:
 active: true
 institution: University of Nebraska - Lincoln
 website: https://derekweitzel.com
-photo: /assets/images/team/Derek-Weitzel.jpg
+photo: "/assets/images/team/Derek-Weitzel.jpg"
 presentations:
-  - title: "Moving science data: One CDN to rule them all"
-    date: 2021-03-03
-    url: https://indico.fnal.gov/event/47040/contributions/208458/attachments/140618/176779/StashCache-Weitzel-2021.pdf
-    meeting: OSG All Hands Meeting 2021
-    meetingurl: https://indico.fnal.gov/event/47040/
-    focus-area: [osglhc, doma]
-    project: osg-operations
-    location: Virtual
-  - title: "OSG's use of XCache"
-    date: 2020-04-23
-    url: https://docs.google.com/presentation/d/1gpd9UH7aYXFU09-ijT1BYQnAFHGCjtfZsvWV038poqM/edit?usp=sharing
-    meeting: XCache Meeting
-    meetingurl: https://indico.fnal.gov/event/24246/
-    focus-area: [osglhc, doma]
-    project: osg-operations
-    location: Virtual
-  - title: "XRootD Validation Plan"
-    date: 2020-04-22
-    url: https://docs.google.com/presentation/d/1fa7ZmYSnfJ13Z3xjGS9XzPeD-o5w23wVSc00Ju7W1Hk/edit?usp=sharing
-    meeting: USCMS S&C Blueprint Meeting
-    meetingurl: https://indico.cern.ch/event/909034/
-    focus-area: [osglhc, doma]
-    project: osg-operations
-    location: Virtual
-  - title: "OSG Accounting and Visualization"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331192/22_-_GRACC-IRIS-HEP-poster_-_v1.pdf
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    focus-area: osglhc
-    project: osg-operations
-    location: Princeton
-  - title: "OSG GRid ACCounting system::GRACC"
-    date: 2019-09-30
-    url: https://indico.fnal.gov/event/20809/session/6/contribution/4/material/slides/0.pdf
-    meeting: Elasticsearch Workshop @FNAL
-    meetingurl: https://indico.fnal.gov/event/20809/
-    focus-area: osglhc
-    project: osg-operations
-    location: Virtual
-  - title: "StashCache: A Distributed Caching Federation for the Open Science Grid"
-    date: 2019-07-30
-    url: https://drive.google.com/file/d/1689yCyAdYI2jggzLXHNvE3h8qtYLk2-5/view?usp=sharing
-    meeting: Practice and Experience in Advanced Research Computing
-    meetingurl: https://www.pearc19.pearc.org/
-    focus-area: [osglhc, doma]
-    project: osg-operations
-    location: Chicago, IL
-  - title: "OSG Data Federation"
-    date: 2019-06-11
-    url: https://indico.cern.ch/event/727208/contributions/3444610/attachments/1860176/3057002/OSG-StashCache.pdf
-    meeting: XRootD Workshop at CC-IN2P3
-    meetingurl: https://indico.cern.ch/event/727208/overview
-    focus-area: [osglhc, doma]
-    project: osg-operations
-    location: Virtual
+- title: 'Moving science data: One CDN to rule them all'
+  date: 2021-03-03
+  url: https://indico.fnal.gov/event/47040/contributions/208458/attachments/140618/176779/StashCache-Weitzel-2021.pdf
+  meeting: OSG All Hands Meeting 2021
+  meetingurl: https://indico.fnal.gov/event/47040/
+  focus-area:
+  - osglhc
+  - doma
+  project: osg-operations
+  location: Virtual
+- title: OSG's use of XCache
+  date: 2020-04-23
+  url: https://docs.google.com/presentation/d/1gpd9UH7aYXFU09-ijT1BYQnAFHGCjtfZsvWV038poqM/edit?usp=sharing
+  meeting: XCache Meeting
+  meetingurl: https://indico.fnal.gov/event/24246/
+  focus-area:
+  - osglhc
+  - doma
+  project: osg-operations
+  location: Virtual
+- title: XRootD Validation Plan
+  date: 2020-04-22
+  url: https://docs.google.com/presentation/d/1fa7ZmYSnfJ13Z3xjGS9XzPeD-o5w23wVSc00Ju7W1Hk/edit?usp=sharing
+  meeting: USCMS S&C Blueprint Meeting
+  meetingurl: https://indico.cern.ch/event/909034/
+  focus-area:
+  - osglhc
+  - doma
+  project: osg-operations
+  location: Virtual
+- title: OSG Accounting and Visualization
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331192/22_-_GRACC-IRIS-HEP-poster_-_v1.pdf
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  focus-area: osglhc
+  project: osg-operations
+  location: Princeton
+- title: OSG GRid ACCounting system::GRACC
+  date: 2019-09-30
+  url: https://indico.fnal.gov/event/20809/session/6/contribution/4/material/slides/0.pdf
+  meeting: Elasticsearch Workshop @FNAL
+  meetingurl: https://indico.fnal.gov/event/20809/
+  focus-area: osglhc
+  project: osg-operations
+  location: Virtual
+- title: 'StashCache: A Distributed Caching Federation for the Open Science Grid'
+  date: 2019-07-30
+  url: https://drive.google.com/file/d/1689yCyAdYI2jggzLXHNvE3h8qtYLk2-5/view?usp=sharing
+  meeting: Practice and Experience in Advanced Research Computing
+  meetingurl: https://www.pearc19.pearc.org/
+  focus-area:
+  - osglhc
+  - doma
+  project: osg-operations
+  location: Chicago, IL
+- title: OSG Data Federation
+  date: 2019-06-11
+  url: https://indico.cern.ch/event/727208/contributions/3444610/attachments/1860176/3057002/OSG-StashCache.pdf
+  meeting: XRootD Workshop at CC-IN2P3
+  meetingurl: https://indico.cern.ch/event/727208/overview
+  focus-area:
+  - osglhc
+  - doma
+  project: osg-operations
+  location: Virtual

--- a/_data/people/dpiparo.yml
+++ b/_data/people/dpiparo.yml
@@ -1,10 +1,9 @@
----
+active: true
+hidden: true
+institution: CERN
 name: Danilo Piparo
+photo: "/assets/images/team/danilo-piparo.jpg"
 shortname: dpiparo
 title: CMS Experiment
-active: true
-institution: CERN
 website:
-photo: "/assets/images/team/danilo-piparo.jpg"
-hidden: true
 presentations:

--- a/_data/people/dpiparo.yml
+++ b/_data/people/dpiparo.yml
@@ -1,9 +1,10 @@
+---
 name: Danilo Piparo
 shortname: dpiparo
 title: CMS Experiment
 active: true
 institution: CERN
 website:
-photo: /assets/images/team/danilo-piparo.jpg
+photo: "/assets/images/team/danilo-piparo.jpg"
 hidden: true
 presentations:

--- a/_data/people/drankincms.yml
+++ b/_data/people/drankincms.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ia
+institution: Massachusetts Institute of Technology
 name: Dylan Rankin
+photo: "/assets/images/team/Dylan-Rankin.jpg"
 shortname: drankincms
 title:
-active: true
-institution: Massachusetts Institute of Technology
 website:
-photo: "/assets/images/team/Dylan-Rankin.jpg"
 presentations:
 - title: Using ML on FPGAs to enhance reconstruction output
   date: 2019-02-13
@@ -22,5 +23,3 @@ presentations:
   meetingurl: https://indico.cern.ch/event/942656/
   focus-area: ia
   project: caloreco-mlaas
-focus-area:
-- ia

--- a/_data/people/drankincms.yml
+++ b/_data/people/drankincms.yml
@@ -1,24 +1,24 @@
+---
 name: Dylan Rankin
 shortname: drankincms
 title:
 active: true
 institution: Massachusetts Institute of Technology
 website:
-photo: /assets/images/team/Dylan-Rankin.jpg
+photo: "/assets/images/team/Dylan-Rankin.jpg"
 presentations:
-  - title: Using ML on FPGAs to enhance reconstruction output
-    date: 2019-02-13
-    url: https://indico.cern.ch/event/797510/contributions/3313676/attachments/1795772/2927344/irishep_dsr_hls4ml_13feb2019.pdf
-    meeting: IRIS-HEP Topical Meeting
-    meetingurl: https://indico.cern.ch/event/797510/
-    location:
-    focus-area: ia
-    project: caloreco-mlaas
-  - title: Using GPUs and FPGAs as-a-service for LHC computing
-    date: 2020-09-09
-    url: https://indico.cern.ch/event/942656/contributions/3960947/attachments/2100003/3530357/irishep_aas_09sep20.pdf
-    meeting: IRIS-HEP topical meeting
-    meetingurl: https://indico.cern.ch/event/942656/
-    focus-area: ia
-    project: caloreco-mlaas
-
+- title: Using ML on FPGAs to enhance reconstruction output
+  date: 2019-02-13
+  url: https://indico.cern.ch/event/797510/contributions/3313676/attachments/1795772/2927344/irishep_dsr_hls4ml_13feb2019.pdf
+  meeting: IRIS-HEP Topical Meeting
+  meetingurl: https://indico.cern.ch/event/797510/
+  location:
+  focus-area: ia
+  project: caloreco-mlaas
+- title: Using GPUs and FPGAs as-a-service for LHC computing
+  date: 2020-09-09
+  url: https://indico.cern.ch/event/942656/contributions/3960947/attachments/2100003/3530357/irishep_aas_09sep20.pdf
+  meeting: IRIS-HEP topical meeting
+  meetingurl: https://indico.cern.ch/event/942656/
+  focus-area: ia
+  project: caloreco-mlaas

--- a/_data/people/drankincms.yml
+++ b/_data/people/drankincms.yml
@@ -22,3 +22,5 @@ presentations:
   meetingurl: https://indico.cern.ch/event/942656/
   focus-area: ia
   project: caloreco-mlaas
+focus-area:
+- ia

--- a/_data/people/e_s-kennedy.yml
+++ b/_data/people/e_s-kennedy.yml
@@ -1,13 +1,12 @@
----
-name: Elisabeth Sexton-Kennedy
-shortname: e_s-kennedy
-title:
-active: true
-institution: Fermi National Accelerator Laboratory
-website:
-photo: "/assets/images/team/e_s-kennedy.png"
-presentations:
 about: Currently CIO of FNAL, member of CMS, long experience in HEP software and computing
   starting from the early days of CDF.
-role: Provide viewpoint of FNAL and intensity frontier experiments
+active: true
 hidden: true
+institution: Fermi National Accelerator Laboratory
+name: Elisabeth Sexton-Kennedy
+photo: "/assets/images/team/e_s-kennedy.png"
+role: Provide viewpoint of FNAL and intensity frontier experiments
+shortname: e_s-kennedy
+title:
+website:
+presentations:

--- a/_data/people/e_s-kennedy.yml
+++ b/_data/people/e_s-kennedy.yml
@@ -1,13 +1,13 @@
+---
 name: Elisabeth Sexton-Kennedy
 shortname: e_s-kennedy
 title:
 active: true
 institution: Fermi National Accelerator Laboratory
 website:
-photo: /assets/images/team/e_s-kennedy.png
+photo: "/assets/images/team/e_s-kennedy.png"
 presentations:
-about: Currently CIO of FNAL, member of CMS, long
-   experience in HEP software and computing starting from the early
-   days of CDF.
+about: Currently CIO of FNAL, member of CMS, long experience in HEP software and computing
+  starting from the early days of CDF.
 role: Provide viewpoint of FNAL and intensity frontier experiments
 hidden: true

--- a/_data/people/edquist.yml
+++ b/_data/people/edquist.yml
@@ -7,3 +7,5 @@ institution: University of Wisconsin–Madison
 website:
 photo: "/assets/images/team/Carl-Edquist.jpg"
 presentations:
+focus-area:
+- osglhc

--- a/_data/people/edquist.yml
+++ b/_data/people/edquist.yml
@@ -1,8 +1,9 @@
+---
 name: Carl Edquist
 shortname: edquist
 title:
 active: true
 institution: University of Wisconsin–Madison
 website:
-photo: /assets/images/team/Carl-Edquist.jpg
+photo: "/assets/images/team/Carl-Edquist.jpg"
 presentations:

--- a/_data/people/edquist.yml
+++ b/_data/people/edquist.yml
@@ -1,11 +1,10 @@
----
-name: Carl Edquist
-shortname: edquist
-title:
 active: true
-institution: University of Wisconsin–Madison
-website:
-photo: "/assets/images/team/Carl-Edquist.jpg"
-presentations:
 focus-area:
 - osglhc
+institution: University of Wisconsin–Madison
+name: Carl Edquist
+photo: "/assets/images/team/Carl-Edquist.jpg"
+shortname: edquist
+title:
+website:
+presentations:

--- a/_data/people/efajardo.yml
+++ b/_data/people/efajardo.yml
@@ -1,11 +1,13 @@
----
+active: false
+focus-area:
+- doma
+- osglhc
+institution: University of California, San Diego
 name: Edgar Fajardo
+photo: "/assets/images/team/Edgar-Fajardo.jpeg"
 shortname: efajardo
 title: OSG Software Team Developer
-active: false
-institution: University of California, San Diego
 website:
-photo: "/assets/images/team/Edgar-Fajardo.jpeg"
 presentations:
 - title: GeoIP HTTPS Redirector
   date: 2021-02-25
@@ -111,6 +113,3 @@ presentations:
   - doma
   - osglhc
   projet: tpc
-focus-area:
-- doma
-- osglhc

--- a/_data/people/efajardo.yml
+++ b/_data/people/efajardo.yml
@@ -1,12 +1,13 @@
+---
 name: Edgar Fajardo
 shortname: efajardo
 title: OSG Software Team Developer
 active: false
 institution: University of California, San Diego
 website:
-photo: /assets/images/team/Edgar-Fajardo.jpeg
+photo: "/assets/images/team/Edgar-Fajardo.jpeg"
 presentations:
-- title: "GeoIP HTTPS Redirector"
+- title: GeoIP HTTPS Redirector
   date: 2021-02-25
   url: https://indico.fnal.gov/event/48049/attachments/140452/176530/GeoIP_Redirector.pdf
   meeting: XCache DevOps Meeting
@@ -36,14 +37,16 @@ presentations:
   location: IN2P3
   focus-area: doma
   project: tpc
-- title: Moving the California distributed CMS xcache from bare metal into containers using Kubernetes
+- title: Moving the California distributed CMS xcache from bare metal into containers
+    using Kubernetes
   date: 2019-11-05
   url: https://indico.cern.ch/event/773049/contributions/3474397/
   meeting: CHEP 2019
   location: Adelaide
   focus-area: doma
   project: caching
-- title: Creating a content delivery network for general science on the backbone of the Internet using xcaches.
+- title: Creating a content delivery network for general science on the backbone of
+    the Internet using xcaches.
   date: 2019-11-05
   url: https://indico.cern.ch/event/773049/contributions/3474397/
   meeting: CHEP 2019
@@ -78,7 +81,7 @@ presentations:
   meetingurl: https://indico.fnal.gov/event/24246/
   focus-area: doma
   project: caching
-- title: "Stashcache: CDN for Science"
+- title: 'Stashcache: CDN for Science'
   date: 2020-09-02
   url: https://indico.fnal.gov/event/22127/contributions/194782/attachments/133874/165317/StashCache__CDN_for_science_1.pdf
   meeting: OSG All Hands Meeting
@@ -104,5 +107,7 @@ presentations:
   url: https://indico.cern.ch/event/967159/contributions/4070185/attachments/2127549/3582326/go
   meeting: DOMA / TPC Meeting
   meetingurl: https://indico.cern.ch/event/967159/
-  focus-area: [doma, osglhc]
+  focus-area:
+  - doma
+  - osglhc
   projet: tpc

--- a/_data/people/efajardo.yml
+++ b/_data/people/efajardo.yml
@@ -111,3 +111,6 @@ presentations:
   - doma
   - osglhc
   projet: tpc
+focus-area:
+- doma
+- osglhc

--- a/_data/people/etorro.yml
+++ b/_data/people/etorro.yml
@@ -12,3 +12,5 @@ presentations:
   meetingurl: https://indico.cern.ch/event/773049/
   meeting: CHEP 2019
   focus-area: as
+focus-area:
+- as

--- a/_data/people/etorro.yml
+++ b/_data/people/etorro.yml
@@ -1,10 +1,11 @@
----
+active: false
+focus-area:
+- as
+institution: University of Washington
 name: Emma Torro
+photo: "/assets/images/team/ETorro.png"
 shortname: etorro
 title: Post-doc
-active: false
-institution: University of Washington
-photo: "/assets/images/team/ETorro.png"
 presentations:
 - title: A Functional Declarative Analysis Language in Python (poster)
   date: 2019-11-05
@@ -12,5 +13,3 @@ presentations:
   meetingurl: https://indico.cern.ch/event/773049/
   meeting: CHEP 2019
   focus-area: as
-focus-area:
-- as

--- a/_data/people/etorro.yml
+++ b/_data/people/etorro.yml
@@ -1,13 +1,14 @@
+---
 name: Emma Torro
 shortname: etorro
 title: Post-doc
 active: false
 institution: University of Washington
-photo: /assets/images/team/ETorro.png
+photo: "/assets/images/team/ETorro.png"
 presentations:
-  - title: "A Functional Declarative Analysis Language in Python (poster)"
-    date: 2019-11-05
-    url: https://indico.cern.ch/event/773049/contributions/3476177/
-    meetingurl: https://indico.cern.ch/event/773049/
-    meeting: "CHEP 2019"
-    focus-area: as
+- title: A Functional Declarative Analysis Language in Python (poster)
+  date: 2019-11-05
+  url: https://indico.cern.ch/event/773049/contributions/3476177/
+  meetingurl: https://indico.cern.ch/event/773049/
+  meeting: CHEP 2019
+  focus-area: as

--- a/_data/people/evanmassaro.yml
+++ b/_data/people/evanmassaro.yml
@@ -1,14 +1,15 @@
+---
 name: Evan Massaro
 shortname: evanmassaro
 title:
 active: true
 institution: Massachusetts Institute of Technology
 website:
-photo: /assets/images/team/Evan-Massaro.jpg
+photo: "/assets/images/team/Evan-Massaro.jpg"
 presentations:
-  - title: Modeling computing resource needs/costs
-    date: 2020-02-03
-    url: https://indico.cern.ch/event/865098/contributions/3644997/attachments/1980699/3298308/CMS_resource_modeling.pdf
-    meeting: IRIS-HEP Topical Meeting
-    meetingurl: https://indico.cern.ch/event/865098/
-    location: 40/R-B10 (CERN)
+- title: Modeling computing resource needs/costs
+  date: 2020-02-03
+  url: https://indico.cern.ch/event/865098/contributions/3644997/attachments/1980699/3298308/CMS_resource_modeling.pdf
+  meeting: IRIS-HEP Topical Meeting
+  meetingurl: https://indico.cern.ch/event/865098/
+  location: 40/R-B10 (CERN)

--- a/_data/people/evanmassaro.yml
+++ b/_data/people/evanmassaro.yml
@@ -1,11 +1,10 @@
----
-name: Evan Massaro
-shortname: evanmassaro
-title:
 active: true
 institution: Massachusetts Institute of Technology
-website:
+name: Evan Massaro
 photo: "/assets/images/team/Evan-Massaro.jpg"
+shortname: evanmassaro
+title:
+website:
 presentations:
 - title: Modeling computing resource needs/costs
   date: 2020-02-03

--- a/_data/people/fatala22.yml
+++ b/_data/people/fatala22.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ssc
+institution: University of Puerto Rico at Mayaguez
 name: Sudhir Malik
+photo: "/assets/images/team/Sudhir-Malik.png"
 shortname: fatala22
 title: Training, Education and Outreach Coordinator
-active: true
-institution: University of Puerto Rico at Mayaguez
 website: http://charma.uprm.edu/~malik/
-photo: "/assets/images/team/Sudhir-Malik.png"
 presentations:
 - title: IRIS-HEP Training Challenge
   date: 2021-04-27
@@ -97,5 +98,3 @@ presentations:
   meetingurl: https://indico.cern.ch/event/840472/
   location: Fermilab
   focus-area: ssc
-focus-area:
-- ssc

--- a/_data/people/fatala22.yml
+++ b/_data/people/fatala22.yml
@@ -1,97 +1,99 @@
+---
 name: Sudhir Malik
 shortname: fatala22
 title: Training, Education and Outreach Coordinator
 active: true
 institution: University of Puerto Rico at Mayaguez
 website: http://charma.uprm.edu/~malik/
-photo: /assets/images/team/Sudhir-Malik.png
+photo: "/assets/images/team/Sudhir-Malik.png"
 presentations:
-  - title: "IRIS-HEP Training Challenge"
-    date: 2021-04-27
-    url: https://indico.cern.ch/event/957103/contributions/4330986/attachments/2234461/3787011/IRIS_HEP_Training_Plans2021.pdf
-    meeting: IRIS-HEP PI/EB Meeting
-    meetingurl: https://indico.cern.ch/event/957103/
-    focus-area: ssc
-    location: Virtual
-  - title: "HSF: Training"
-    date: 2021-01-12
-    url: https://indico.jlab.org/event/420/contributions/7597/attachments/6352/8417/HSF_Training_SoftCompRoundTable_12Jan_2021.pdf
-    meeting: Software & Computing Round Table (2021) - Nuclear Physics
-    meetingurl: https://indico.jlab.org/event/420/
-    focus-area: ssc
-  - title: "Strategies and needs for training"
-    date: 2019-11-21
-    url: https://indico.cern.ch/event/813325/contributions/3603530/attachments/1949453/3235462/Training_FIRST-LAWSCEHP2019_Mexico.pdf
-    meeting: Latin American Workshop on Software and Computing challenges in High-Energy Particle Physics (LAWSCHEP 2019)
-    meetingurl: https://indico.cern.ch/event/813325/
-    focus-area: ssc
-  - title: "Training WG update"
-    date: 2018-07-11
-    url: https://indico.cern.ch/event/785587/contributions/3266731/attachments/1776030/3097240/HSF_TEO_WG_update_11July_2019-2.pdf
-    meeting: HEP Software Foundation Weekly Meeting
-    meetingurl: https://indico.cern.ch/event/785587/
-    focus-area: ssc
-  - title: "Training and Outreach"
-    date: 2018-10-31
-    url: https://indico.cern.ch/event/755573/contributions/3175492/attachments/1745033/2827577/TEO_IRIS_HEP_KickOff_31Oct2018.pdf
-    meeting: IRIS-HEP Kickoff Workshop
-    meetingurl: https://indico.cern.ch/event/755573/
-    location: University of Chicago
-    focus-area: ssc
-  - title: "A Framework for Integrated Research Software Training in HEP"
-    date: 2018-12-11
-    url: https://indico.fnal.gov/event/18104/session/23/contribution/19/material/0/0.pdf
-    meeting: 2018 CPAD Instrumentation Frontier Workshop
-    meetingurl: https://indico.fnal.gov/event/18104/
-    focus-area: ssc
-  - title: "Training Activities - FIRST-HEP and IRIS-HEP"
-    date: 2019-02-04
-    url: https://indico.cern.ch/event/794278/contributions/3299576/attachments/1790342/2916570/IRIS_TopicalMeeting_TrainingforSoftwareCoDASHEP.pdf
-    meeting: IRIS-HEP Topical Meeting
-    meetingurl: https://indico.cern.ch/event/794278/
-    focus-area: ssc
-  - title: "IRIS-HEP Software Sustainability Core"
-    date: 2019-02-06
-    url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271531/attachments/1791306/2919793/IRIS_steering_update_6Feb2019.pdf
-    meeting: IRIS-HEP Steering Board Meeting #1
-    meetingurl: https://indico.cern.ch/event/790759/
-    focus-area: ssc
-  - title: "FIRST-HEP Training Program"
-    date: 2019-03-21
-    url: https://indico.cern.ch/event/759388/contributions/3315849/attachments/1816168/2968373/FIRST-HEP-JLAB-HOW2019.pdf
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop
-    meetingurl: https://indico.cern.ch/event/759388/overview
-    location: Jefferson Lab
-    focus-area: ssc
-  - title: "Training Working Group Update"
-    date: 2019-04-25
-    url: https://indico.cern.ch/event/785576/contributions/3266720/attachments/1776008/3004837/HSF_TEO_WG_update_25April2019.pdf
-    meeting: HEP Software Foundation Weekly Meeting
-    meetingurl: https://indico.cern.ch/event/785576/
-    focus-area: ssc
-  - title: "Training and Outreach"
-    date: 2019-05-20
-    url: https://indico.cern.ch/event/812745/contributions/3437349/attachments/1847280/3031287/IRIS-HEP_ExecBoard_SSC_20May2019.pdf
-    meeting: IRIS-HEP Executive Board Meeting
-    meetingurl: https://indico.cern.ch/event/812745/
-    focus-area: ssc
-  - title: "Software Sustainability Core"
-    date: 2019-09-03
-    url: https://indico.cern.ch/event/809178/contributions/3370588/subcontributions/277985/attachments/1901696/3139916/IRIS-HEP_SteeringBoard_SSC_3Sep2019.pdf
-    meeting: IRIS-HEP Steering Board Meeting
-    meetingurl: https://indico.cern.ch/event/809178/
-    focus-area: ssc
-  - title: "SSC - News, Status, Plans"
-    date: 2019-09-13
-    url: https://indico.cern.ch/event/840472/contributions/3561673/attachments/1907927/3151527/IRIS-HEP_RetreatAdvisory_SSC_CloseOut_9to13Sep2019.pdf
-    meeting: IRIS-HEP Institute Retreat
-    meetingurl: https://indico.cern.ch/event/840472/
-    location: Fermilab
-    focus-area: ssc
-  - title: "IRIS-HEP area SSC"
-    date: 2019-09-13
-    url: https://indico.cern.ch/event/840472/contributions/3564743/attachments/1907744/3151135/IRIS-HEP_RetreatAdvisory_SSC_9to13Sep2019.pdf
-    meeting: IRIS-HEP Institute Retreat
-    meetingurl: https://indico.cern.ch/event/840472/
-    location: Fermilab
-    focus-area: ssc
+- title: IRIS-HEP Training Challenge
+  date: 2021-04-27
+  url: https://indico.cern.ch/event/957103/contributions/4330986/attachments/2234461/3787011/IRIS_HEP_Training_Plans2021.pdf
+  meeting: IRIS-HEP PI/EB Meeting
+  meetingurl: https://indico.cern.ch/event/957103/
+  focus-area: ssc
+  location: Virtual
+- title: 'HSF: Training'
+  date: 2021-01-12
+  url: https://indico.jlab.org/event/420/contributions/7597/attachments/6352/8417/HSF_Training_SoftCompRoundTable_12Jan_2021.pdf
+  meeting: Software & Computing Round Table (2021) - Nuclear Physics
+  meetingurl: https://indico.jlab.org/event/420/
+  focus-area: ssc
+- title: Strategies and needs for training
+  date: 2019-11-21
+  url: https://indico.cern.ch/event/813325/contributions/3603530/attachments/1949453/3235462/Training_FIRST-LAWSCEHP2019_Mexico.pdf
+  meeting: Latin American Workshop on Software and Computing challenges in High-Energy
+    Particle Physics (LAWSCHEP 2019)
+  meetingurl: https://indico.cern.ch/event/813325/
+  focus-area: ssc
+- title: Training WG update
+  date: 2018-07-11
+  url: https://indico.cern.ch/event/785587/contributions/3266731/attachments/1776030/3097240/HSF_TEO_WG_update_11July_2019-2.pdf
+  meeting: HEP Software Foundation Weekly Meeting
+  meetingurl: https://indico.cern.ch/event/785587/
+  focus-area: ssc
+- title: Training and Outreach
+  date: 2018-10-31
+  url: https://indico.cern.ch/event/755573/contributions/3175492/attachments/1745033/2827577/TEO_IRIS_HEP_KickOff_31Oct2018.pdf
+  meeting: IRIS-HEP Kickoff Workshop
+  meetingurl: https://indico.cern.ch/event/755573/
+  location: University of Chicago
+  focus-area: ssc
+- title: A Framework for Integrated Research Software Training in HEP
+  date: 2018-12-11
+  url: https://indico.fnal.gov/event/18104/session/23/contribution/19/material/0/0.pdf
+  meeting: 2018 CPAD Instrumentation Frontier Workshop
+  meetingurl: https://indico.fnal.gov/event/18104/
+  focus-area: ssc
+- title: Training Activities - FIRST-HEP and IRIS-HEP
+  date: 2019-02-04
+  url: https://indico.cern.ch/event/794278/contributions/3299576/attachments/1790342/2916570/IRIS_TopicalMeeting_TrainingforSoftwareCoDASHEP.pdf
+  meeting: IRIS-HEP Topical Meeting
+  meetingurl: https://indico.cern.ch/event/794278/
+  focus-area: ssc
+- title: IRIS-HEP Software Sustainability Core
+  date: 2019-02-06
+  url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271531/attachments/1791306/2919793/IRIS_steering_update_6Feb2019.pdf
+  meeting: IRIS-HEP Steering Board Meeting
+  meetingurl: https://indico.cern.ch/event/790759/
+  focus-area: ssc
+- title: FIRST-HEP Training Program
+  date: 2019-03-21
+  url: https://indico.cern.ch/event/759388/contributions/3315849/attachments/1816168/2968373/FIRST-HEP-JLAB-HOW2019.pdf
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop
+  meetingurl: https://indico.cern.ch/event/759388/overview
+  location: Jefferson Lab
+  focus-area: ssc
+- title: Training Working Group Update
+  date: 2019-04-25
+  url: https://indico.cern.ch/event/785576/contributions/3266720/attachments/1776008/3004837/HSF_TEO_WG_update_25April2019.pdf
+  meeting: HEP Software Foundation Weekly Meeting
+  meetingurl: https://indico.cern.ch/event/785576/
+  focus-area: ssc
+- title: Training and Outreach
+  date: 2019-05-20
+  url: https://indico.cern.ch/event/812745/contributions/3437349/attachments/1847280/3031287/IRIS-HEP_ExecBoard_SSC_20May2019.pdf
+  meeting: IRIS-HEP Executive Board Meeting
+  meetingurl: https://indico.cern.ch/event/812745/
+  focus-area: ssc
+- title: Software Sustainability Core
+  date: 2019-09-03
+  url: https://indico.cern.ch/event/809178/contributions/3370588/subcontributions/277985/attachments/1901696/3139916/IRIS-HEP_SteeringBoard_SSC_3Sep2019.pdf
+  meeting: IRIS-HEP Steering Board Meeting
+  meetingurl: https://indico.cern.ch/event/809178/
+  focus-area: ssc
+- title: SSC - News, Status, Plans
+  date: 2019-09-13
+  url: https://indico.cern.ch/event/840472/contributions/3561673/attachments/1907927/3151527/IRIS-HEP_RetreatAdvisory_SSC_CloseOut_9to13Sep2019.pdf
+  meeting: IRIS-HEP Institute Retreat
+  meetingurl: https://indico.cern.ch/event/840472/
+  location: Fermilab
+  focus-area: ssc
+- title: IRIS-HEP area SSC
+  date: 2019-09-13
+  url: https://indico.cern.ch/event/840472/contributions/3564743/attachments/1907744/3151135/IRIS-HEP_RetreatAdvisory_SSC_9to13Sep2019.pdf
+  meeting: IRIS-HEP Institute Retreat
+  meetingurl: https://indico.cern.ch/event/840472/
+  location: Fermilab
+  focus-area: ssc

--- a/_data/people/fatala22.yml
+++ b/_data/people/fatala22.yml
@@ -97,3 +97,5 @@ presentations:
   meetingurl: https://indico.cern.ch/event/840472/
   location: Fermilab
   focus-area: ssc
+focus-area:
+- ssc

--- a/_data/people/fkw888.yml
+++ b/_data/people/fkw888.yml
@@ -1,323 +1,325 @@
+---
 name: Frank Wuerthwein
 shortname: fkw888
 title: OSG-LHC Area Lead and OSG Executive Director
 active: true
 institution: University of California, San Diego
 website: https://www-physics.ucsd.edu/fac_staff/fac_profile/faculty_description.php?person_id=494
-photo: /assets/images/team/Frank-Wuerthwein.jpg
+photo: "/assets/images/team/Frank-Wuerthwein.jpg"
 presentations:
-  - title: State of the OSG
-    date: 2021-03-01
-    url: https://indico.fnal.gov/event/47040/contributions/208345/attachments/140505/176605/stateOfOSG2021-final.pdf
-    meeting: OSG All-Hands Meeting 2021
-    meetingurl: https://indico.fnal.gov/event/47040/overview
-    focus-area: osglhc
-  - title: OSG as an agile computing environment
-    date: 2021-03-03
-    url: https://indico.fnal.gov/event/47040/contributions/208665/attachments/140609/176764/agileOSGMarch3rd2021.pdf
-    meeting: OSG All-Hands Meeting 2021
-    meetingurl: https://indico.fnal.gov/event/47040/overview
-    focus-area: osglhc
-  - title: OSG
-    date: 2021-03-04
-    url: https://indico.egi.eu/event/5429/contributions/15038/attachments/13725/16929/egiMarch4th2021.pdf
-    meeting: Cloud & HTC infrastructure integration workshop
-    meetingurl: https://indico.egi.eu/event/5429/
-    focus-area: osglhc
-  - title: Introduction to OSG on Campuses
-    date: 2020-09-01
-    url: https://indico.fnal.gov/event/22127/contributions/195602/attachments/133834/165258/osg4campuses.pptx
-    meeting: OSG All-Hands Meeting 2020
-    meetingurl: https://indico.fnal.gov/event/22127/overview
-    focus-area: osglhc
-  - title: State of OSG
-    date: 2020-08-31
-    url: https://indico.fnal.gov/event/22127/contributions/194197/attachments/133778/165164/stateOfOSG2020.pptx
-    meeting: OSG All-Hands Meeting 2020
-    meetingurl: https://indico.fnal.gov/event/22127/overview
-    focus-area: osglhc
-  - title: ESnet Requirements Documents Presentations at the USCMS Blueprint Meetings
-    date: 2020-08-19
-    meeting: S&C Blueprint Meeting
-    url: https://indico.cern.ch/event/925509/
-    meetingurl: https://indico.cern.ch/event/925509/
-    focus-area: osglhc
-  - title: ESnet Requirements Documents Presentations at the USCMS Blueprint Meetings
-    date: 2020-08-12
-    url: https://indico.cern.ch/event/925508/contributions/3889401/attachments/2087275/3506722/blueprintAugust12th2020.pdf
-    meeting: S&C Blueprint Meeting
-    meetingurl: https://indico.cern.ch/event/925508/
-    focus-area: osglhc
-  - title: Summary of CompF4
-    date: 2020-08-11
-    url: https://indico.fnal.gov/event/43829/contributions/192481/attachments/134058/165615/snowmassAugust11th2020.pdf
-    meeting: Snowmass computational frontier workshop
-    meetingurl: https://indico.fnal.gov/event/43829/overview
-    focus-area: [doma, osglhc]
-  - title: Discussion of CompF4 Group Mandate
-    date: 2020-08-10
-    url: https://indico.fnal.gov/event/43829/contributions/193062/attachments/132700/163227/snowmassAugust10th2020.pdf
-    meeting: Snowmass computational frontier workshop
-    meetingurl: https://indico.fnal.gov/event/43829/overview
-    focus-area: [doma, osglhc]
-  - title: High Throughput Science Workshop
-    date: 2020-07-31
-    url: https://pearc20.sched.com/event/cnY6?iframe=no
-    meeting: PEARC 2020
-    meetingurl: https://pearc.acm.org/pearc20/
-    focus-area: osglhc
-  - title: "Brainstorming Data Lake Challenge — CMS Use Cases"
-    date: 2020-07-15
-    url: https://indico.cern.ch/event/939368/contributions/3947031/attachments/2074743/3483695/domaGeneralJuly15th2020.pdf
-    meeting: WLCG DOMA general meeting
-    meetingurl: https://indico.cern.ch/event/939368/
-    focus-area: doma
-    project: modeling
-  - title: ESnet Requirements Documents Presentations at the USCMS Blueprint Meetings
-    date: 2020-07-01
-    url: https://indico.cern.ch/event/925502/contributions/3889389/attachments/2067358/3469748/go
-    meeting: S&C Blueprint Meeting
-    meetingurl: https://indico.cern.ch/event/925502/
-    focus-area: osglhc
-  - title: Proposed New Scope of DOMA Access
-    date: 2020-06-24
-    url: https://indico.cern.ch/event/932079/contributions/3917107/attachments/2063364/3462051/domaAccess-June24th2020.pdf
-    meeting: WLCG DOMA general meeting
-    meetingurl: https://indico.cern.ch/event/932079/
-    location: Zoom
-    focus-area: doma
-  - title: "Data use by the CMS experiment at the LHC"
-    date: 2020-06-15
-    meetingurl: https://sdm.lbl.gov/net/#frank2020
-    url: https://sdm.lbl.gov/net/FrankWurthwein-esnet-200515.pdf
-    meeting: ESNet Seminar
-    location: Zoom, US
-    focus-area: doma
-    project: modeling
-  - title: Idea for a Production Data Challenge
-    date: 2020-05-28
-    url: https://indico.cern.ch/event/896167/contributions/3880422/attachments/2045464/3430061/irishep-challenge-May28th2020.pdf
-    meeting: IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167/
-    focus-area: doma
-  - title: "OSG - Years 3, and 4+5"
-    date: 2020-05-26
-    url: https://indico.cern.ch/event/896167/contributions/3870078/attachments/2044555/3424906/osg-lhc-staff-retreat-May26-2020.pdf
-    meeting: IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167/
-    focus-area: osglhc
-  - title: "Idea for a production focused Data Challenge"
-    date: 2020-05-05
-    meetingurl: https://indico.cern.ch/event/912400/
-    url: https://indico.cern.ch/event/912400/contributions/3837180/attachments/2025219/3400807/DOMA-Access-May5th2020.pdf
-    meeting: DOMA Access Meeting WLCG
-    focus-area: doma
-  - title: "GPU Cloud Bursting for Multi-Messenger Astrophysics with IceCube"
-    date: 2020-04-30
-    meetingurl: https://pages.awscloud.com/gpu-cloud-bursting.html
-    url: https://d1.awsstatic.com/WWPS/pdf/Running-a-GPU-burst-for-Multi-Messenger-Astrophysics-with-IceCube.pdf
-    meeting: "AWS Education: Research Seminar Series"
-    focus-area: doma
-  - title: ESnet Requirements Documents Presentations at the USCMS Blueprint Meetings
-    date: 2020-04-29
-    url: https://indico.cern.ch/event/913135/contributions/3840110/attachments/2026606/3390423/uscms_blueprint_200415.pdf
-    meeting: S&C Blueprint Meeting
-    meetingurl: https://indico.cern.ch/event/913135/
-    focus-area: osglhc
-  - title: "Draft Proposals for Workplan towards the ESNet review"
-    date: 2020-04-15
-    meetingurl: https://indico.cern.ch/event/907734/
-    url: https://indico.cern.ch/event/907734/contributions/3819195/attachments/2020624/3378498/uscms_blueprint_200415.pdf
-    meeting: S&C Blueprint Meeting
-    focus-area: osglhc
-# Needs a URL
-#  - title: "HL-LHC Data Challenges"
-#    date: 2020-04-13
-#    meeting: "Large Scale Networking (LSN) Workshop on Huge Data"
-#    meetingurl: https://protocols.netlab.uky.edu/~hugedata2020//index.html
-#    focus-area: doma
-#    project: modeling
-  - title: "Thoughts on Prep for ESNet workshop"
-    date: 2020-03-18
-    meetingurl: https://indico.cern.ch/event/896371/
-    url: https://indico.cern.ch/event/896371/contributions/3779617/attachments/2005089/3349622/networkingBlueprintMarch18th2020.pdf
-    meeting: S&C Blueprint Meeting
-    focus-area: osglhc
-  - title: The ECoM2x Process
-    date: 2020-03-17
-    url: https://indico.cern.ch/event/896935/contributions/3784451/attachments/2004410/3347247/ecom2x-March17th.pdf
-    meeting: "Joint US ATLAS - US CMS Meeting on Facility R&D"
-    meetingurl: https://indico.cern.ch/event/896935/
-    focus-area: doma
-    project: modeling
-  - title: "Running a 380PFLOP32s GPU burst for Multi-Messenger Astrophysics with IceCube across all available GPUs in the Cloud"
-    date: 2020-01-27
-    url: https://www.slideshare.net/igor_sfiligoi/nrp-engagement-webinar-running-a-51k-gpu-multicloud-burstfor-mma-with-icecube
-    meeting: NRP Engagement webinar
-    meetingurl: https://spaces.at.internet2.edu/display/NRPWG/National+Research+Platform+%28NRP%29+Space
-    location: WebEx, US
-  - title: "Running a GPU burst for Multi-Messenger Astrophysics with IceCube across all available GPUs in the Cloud"
-    date: 2019-12-04
-    url: https://www.slideshare.net/FrankWuerthwein/building-and-running-the-cloud-gpu-vacuum-cleaner
-    meeting: Middleware and Grid Interagency Cooperation (MAGIC)  meeting
-    meetingurl: https://www.nitrd.gov/nitrdgroups/index.php?title=MAGIC
-    location: WebEx, US
-    focus-area: osglhc
-  - title: "Running a GPU burst for Multi-Messenger Astrophysics with IceCube across all available GPUs in the Cloud"
-    date: 2019-11-19
-    url: https://www.slideshare.net/igor_sfiligoi/running-a-gpu-burst-for-multimessenger-astrophysics-with-icecube-across-all-available-gpus-in-the-cloud
-    meeting: SC 19 Multiple Booths
-    meetingurl: https://sc19.supercomputing.org
-    location: Denver, CO, USA
-    focus-area: osglhc
-  - title: "OSG News"
-    date: 2019-10-10
-    url: https://indico.fnal.gov/event/21410/contribution/2/material/slides/0.pdf
-    meeting: OSG Council Face to Face meeting
-    focus-area: osglhc
-    meetingurl: https://indico.fnal.gov/event/21410/
-  - title: "Introduction to OSG and OSG Participants"
-    date: 2019-09-23
-    url: Not available online
-    meeting: 2019 NSF CC* and CICI PI Pre-Workshop Breakout on OSG
-    focus-area: osglhc
-    meetingurl: https://www.thequilt.net/public-event/2019-nsf-cc-and-cici-pi-pre-workshop-breakouts/#osgd
-  - title: "Advancing Open Science through distributed High Throughput Computing - The OSG Data Federation"
-    date: 2019-09-18
-    url: http://grp-workshop-2019.ucsd.edu/presentations/4_WUERTHWEIN-GRP-2019-OSG.pdf
-    meeting: Global Research Platform Workshop
-    focus-area: osglhc
-    meetingurl: http://grp-workshop-2019.ucsd.edu
-  - title: "OSG XCache Discussion"
-    date: 2019-09-12
-    url: https://indico.cern.ch/event/840472/sessions/323302/attachments/1907227/3150065/irishep-retreatSeptember2019.pdf
-    meeting: IRIS-HEP retreat
-    focus-area: osglhc
-    meetingurl: https://indico.cern.ch/event/840472/
-    project: caching
-  - title: "Advancing Open Science through distributed High Througput Computing"
-    date: 2019-09-11
-    url: https://indico.cern.ch/event/739882/contributions/3520011/attachments/1906491/3148700/gdbSeptember2019.pdf
-    meeting: WLCG Grid Deployment Board Meeting
-    focus-area: osglhc
-    meetingurl: https://indico.cern.ch/event/739882/
-  - title: "OSG - IRISHEP Advisory Panel"
-    date: 2019-09-09
-    url: https://indico.cern.ch/event/840467/contributions/3545009/attachments/1904432/3144878/irishep-AdvisoryBoard-September2019.pdf
-    meeting: IRIS-HEP Advisory Panel Meeting #1
-    focus-area: osglhc
-    meetingurl: https://indico.cern.ch/event/840467/
-  - title: "OSG - Steering Board"
-    date: 2019-09-03
-    url: https://indico.cern.ch/event/809178/contributions/3370588/subcontributions/287759/attachments/1901941/3139925/irishep-steeringBoard-September3-2019.pdf
-    meeting: IRIS-HEP Steering Board Meeting #3
-    focus-area: osglhc
-    meetingurl: https://indico.cern.ch/event/809178/
-  - title: "XCache Initiatives and Experiences"
-    date: 2019-07-08
-    meeting: "pre-GDB meeting on XCache"
-    url: http://uaf-8.t2.ucsd.edu/~fkw/DataLakeSitePerspectiveJune8th2019.pptx
-    project: caching
-  - title: "Reducing Disk Needs with a Data Lake Concept"
-    date: 2019-07-05
-    meeting: "ECoM2x meeting CMS"
-    url: http://uaf-8.t2.ucsd.edu/~fkw/ecom2xJuly5th2019.pptx
-    project: modeling
-    focus-area: doma
-  - title: "Advancing Open Science through distributed High Throughput Computing"
-    date: 2019-06-25
-    meeting: "NERSC Seminar talk"
-    url: http://uaf-8.t2.ucsd.edu/~fkw/nerscJune25th2019.pptx
-    focus-area: osglhc
-  - title: "OSG Accounting Task Force"
-    date: 2019-06-12
-    meeting: "OSG Area Coordinators Meeting"
-    location: Virtual
-    url: http://uaf-8.t2.ucsd.edu/~fkw/osgAccountingTaskForceJune122019.pptx
-    focus-area: osglhc
-  - title: "OSG-LHC"
-    date: 2019-06-12
-    meeting: "NSF IRIS-HEP meeting"
-    url: https://indico.cern.ch/event/820235/contributions/3428170/attachments/1861231/3058984/OSG-LHCforNSFJune12th2019.pdf
-    meetingurl: https://indico.cern.ch/event/820235/
-    focus-area: osglhc
-  - title: "UCSD in IRIS-HEP DOMA"
-    date: 2019-06-07
-    meeting: "DOMA IRIS-HEP meeting"
-    meetingurl: https://indico.cern.ch/event/818793/
-    url: https://indico.cern.ch/event/818793/contributions/3420719/attachments/1859017/3054548/iris-hep-domaJune7th2019.pdf
-    focus-area: osglhc
-  - title: "Advancing Science through distributed High Throughput Computing"
-    date: 2019-06-05
-    meeting: "SDX Workshop at Qualcom Institute"
-    meetingurl: https://www.eventbrite.com/e/integrating-open-science-grid-osg-with-sdx-projects-workshop-june-5-6-2019-tickets-58800356449
-    location: San Diego, CA
-    url: http://uaf-8.t2.ucsd.edu/~fkw/sdxJune5th2019.pptx
-    focus-area: osglhc
-  - title: "Data Lake — A site perspective"
-    date: 2019-06-04
-    meeting: "DOMA Access Meeting WLCG"
-    url: http://uaf-8.t2.ucsd.edu/~fkw/DataLakeSitePerspectiveJune4th2019.pptx
-    project: modeling
-    focus-area: doma
-  - title: "OSG Value Proposition for Campuses"
-    date: 2019-05-21
-    url: https://drive.google.com/file/d/1WgaZMtm_DNB2qt8_-GJkVs66mlI4cORE/view?usp=drive_web
-    meeting: "Great Plains Network Annual Meeting"
-    meetingurl: https://conferences.k-state.edu/gpn/
-    location: Kansas City, MO
-    focus-area: osglhc
-  - title: "Advancing Open Science through distributed High Throughput Computing"
-    date: 2019-05-21
-    url: https://drive.google.com/file/d/1qZStE92CfkdN3i0zjboF-vl3Llgx4r1D/view?usp=drive_web
-    meeting: "Great Plains Network Annual Meeting"
-    meetingurl: https://conferences.k-state.edu/gpn/
-    location: Kansas City, MO
-    focus-area: osglhc
-  - title: "Big Science with Big Instruments"
-    date: 2019-05-15
-    meeting: "AWS Seminar talk"
-    url: https://d1.awsstatic.com/WWPS/pdf/Science_at_the_Petascale.pdf
-    focus-area: osglhc
-  - title: "Advancing Open Science through distributed High Throughput Computing"
-    date: 2019-04-12
-    url: https://drive.google.com/file/d/1M8w5ndUURkrsDDomhPFpGco4e0efHCVq/view?usp=sharing
-    meeting: "CI Engineering Brown Bag"
-    location: webinar
-    focus-area: osglhc
-  - title: "Data Access at HPC: ATLAS/CMS Perspective"
-    date: 2019-03-20
-    url: https://indico.cern.ch/event/759388/contributions/3312490/
-    meeting: "HOW2019 (Joint HSF/OSG/WLCG Workshop)"
-    meetingurl: https://indico.cern.ch/event/759388/
-    location: Jefferson Lab
-    focus-area: doma
-  - title: "Data Access in DOMA"
-    date: 2019-03-20
-    url: https://indico.cern.ch/event/759388/contributions/3312487/
-    meeting: "HOW2019 (Joint HSF/OSG/WLCG Workshop)"
-    meetingurl: https://indico.cern.ch/event/759388/
-    location: Jefferson Lab
-    focus-area: doma
-    project: caching
-  - title: "State of OSG"
-    date: 2019-03-19
-    url: https://indico.cern.ch/event/759388/contributions/3353296/
-    meeting: "HOW2019 (Joint HSF/OSG/WLCG Workshop)"
-    meetingurl: https://indico.cern.ch/event/759388/
-    location: Jefferson Lab
-    focus-area: osglhc
-  - title: "The OSG Data Federation"
-    date: 2019-03-07
-    url: https://meetings.internet2.edu/2019-global-summit/speakers/6556/
-    meeting: "Internet2 Global Summit 2019"
-    meetingurl: https://meetings.internet2.edu/2019-global-summit/detail/10005368/
-    location: Washington, DC
-    focus-area: osglhc
-    project: caching
-  - title: "OSG-LHC"
-    date: 2019-02-06
-    url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271532
-    meeting: IRIS-HEP Steering Board Meeting #1
-    focus-area: osglhc
-    meetingurl: https://indico.cern.ch/event/790759/
+- title: State of the OSG
+  date: 2021-03-01
+  url: https://indico.fnal.gov/event/47040/contributions/208345/attachments/140505/176605/stateOfOSG2021-final.pdf
+  meeting: OSG All-Hands Meeting 2021
+  meetingurl: https://indico.fnal.gov/event/47040/overview
+  focus-area: osglhc
+- title: OSG as an agile computing environment
+  date: 2021-03-03
+  url: https://indico.fnal.gov/event/47040/contributions/208665/attachments/140609/176764/agileOSGMarch3rd2021.pdf
+  meeting: OSG All-Hands Meeting 2021
+  meetingurl: https://indico.fnal.gov/event/47040/overview
+  focus-area: osglhc
+- title: OSG
+  date: 2021-03-04
+  url: https://indico.egi.eu/event/5429/contributions/15038/attachments/13725/16929/egiMarch4th2021.pdf
+  meeting: Cloud & HTC infrastructure integration workshop
+  meetingurl: https://indico.egi.eu/event/5429/
+  focus-area: osglhc
+- title: Introduction to OSG on Campuses
+  date: 2020-09-01
+  url: https://indico.fnal.gov/event/22127/contributions/195602/attachments/133834/165258/osg4campuses.pptx
+  meeting: OSG All-Hands Meeting 2020
+  meetingurl: https://indico.fnal.gov/event/22127/overview
+  focus-area: osglhc
+- title: State of OSG
+  date: 2020-08-31
+  url: https://indico.fnal.gov/event/22127/contributions/194197/attachments/133778/165164/stateOfOSG2020.pptx
+  meeting: OSG All-Hands Meeting 2020
+  meetingurl: https://indico.fnal.gov/event/22127/overview
+  focus-area: osglhc
+- title: ESnet Requirements Documents Presentations at the USCMS Blueprint Meetings
+  date: 2020-08-19
+  meeting: S&C Blueprint Meeting
+  url: https://indico.cern.ch/event/925509/
+  meetingurl: https://indico.cern.ch/event/925509/
+  focus-area: osglhc
+- title: ESnet Requirements Documents Presentations at the USCMS Blueprint Meetings
+  date: 2020-08-12
+  url: https://indico.cern.ch/event/925508/contributions/3889401/attachments/2087275/3506722/blueprintAugust12th2020.pdf
+  meeting: S&C Blueprint Meeting
+  meetingurl: https://indico.cern.ch/event/925508/
+  focus-area: osglhc
+- title: Summary of CompF4
+  date: 2020-08-11
+  url: https://indico.fnal.gov/event/43829/contributions/192481/attachments/134058/165615/snowmassAugust11th2020.pdf
+  meeting: Snowmass computational frontier workshop
+  meetingurl: https://indico.fnal.gov/event/43829/overview
+  focus-area:
+  - doma
+  - osglhc
+- title: Discussion of CompF4 Group Mandate
+  date: 2020-08-10
+  url: https://indico.fnal.gov/event/43829/contributions/193062/attachments/132700/163227/snowmassAugust10th2020.pdf
+  meeting: Snowmass computational frontier workshop
+  meetingurl: https://indico.fnal.gov/event/43829/overview
+  focus-area:
+  - doma
+  - osglhc
+- title: High Throughput Science Workshop
+  date: 2020-07-31
+  url: https://pearc20.sched.com/event/cnY6?iframe=no
+  meeting: PEARC 2020
+  meetingurl: https://pearc.acm.org/pearc20/
+  focus-area: osglhc
+- title: Brainstorming Data Lake Challenge — CMS Use Cases
+  date: 2020-07-15
+  url: https://indico.cern.ch/event/939368/contributions/3947031/attachments/2074743/3483695/domaGeneralJuly15th2020.pdf
+  meeting: WLCG DOMA general meeting
+  meetingurl: https://indico.cern.ch/event/939368/
+  focus-area: doma
+  project: modeling
+- title: ESnet Requirements Documents Presentations at the USCMS Blueprint Meetings
+  date: 2020-07-01
+  url: https://indico.cern.ch/event/925502/contributions/3889389/attachments/2067358/3469748/go
+  meeting: S&C Blueprint Meeting
+  meetingurl: https://indico.cern.ch/event/925502/
+  focus-area: osglhc
+- title: Proposed New Scope of DOMA Access
+  date: 2020-06-24
+  url: https://indico.cern.ch/event/932079/contributions/3917107/attachments/2063364/3462051/domaAccess-June24th2020.pdf
+  meeting: WLCG DOMA general meeting
+  meetingurl: https://indico.cern.ch/event/932079/
+  location: Zoom
+  focus-area: doma
+- title: Data use by the CMS experiment at the LHC
+  date: 2020-06-15
+  meetingurl: https://sdm.lbl.gov/net/#frank2020
+  url: https://sdm.lbl.gov/net/FrankWurthwein-esnet-200515.pdf
+  meeting: ESNet Seminar
+  location: Zoom, US
+  focus-area: doma
+  project: modeling
+- title: Idea for a Production Data Challenge
+  date: 2020-05-28
+  url: https://indico.cern.ch/event/896167/contributions/3880422/attachments/2045464/3430061/irishep-challenge-May28th2020.pdf
+  meeting: IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167/
+  focus-area: doma
+- title: OSG - Years 3, and 4+5
+  date: 2020-05-26
+  url: https://indico.cern.ch/event/896167/contributions/3870078/attachments/2044555/3424906/osg-lhc-staff-retreat-May26-2020.pdf
+  meeting: IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167/
+  focus-area: osglhc
+- title: Idea for a production focused Data Challenge
+  date: 2020-05-05
+  meetingurl: https://indico.cern.ch/event/912400/
+  url: https://indico.cern.ch/event/912400/contributions/3837180/attachments/2025219/3400807/DOMA-Access-May5th2020.pdf
+  meeting: DOMA Access Meeting WLCG
+  focus-area: doma
+- title: GPU Cloud Bursting for Multi-Messenger Astrophysics with IceCube
+  date: 2020-04-30
+  meetingurl: https://pages.awscloud.com/gpu-cloud-bursting.html
+  url: https://d1.awsstatic.com/WWPS/pdf/Running-a-GPU-burst-for-Multi-Messenger-Astrophysics-with-IceCube.pdf
+  meeting: 'AWS Education: Research Seminar Series'
+  focus-area: doma
+- title: ESnet Requirements Documents Presentations at the USCMS Blueprint Meetings
+  date: 2020-04-29
+  url: https://indico.cern.ch/event/913135/contributions/3840110/attachments/2026606/3390423/uscms_blueprint_200415.pdf
+  meeting: S&C Blueprint Meeting
+  meetingurl: https://indico.cern.ch/event/913135/
+  focus-area: osglhc
+- title: Draft Proposals for Workplan towards the ESNet review
+  date: 2020-04-15
+  meetingurl: https://indico.cern.ch/event/907734/
+  url: https://indico.cern.ch/event/907734/contributions/3819195/attachments/2020624/3378498/uscms_blueprint_200415.pdf
+  meeting: S&C Blueprint Meeting
+  focus-area: osglhc
+- title: Thoughts on Prep for ESNet workshop
+  date: 2020-03-18
+  meetingurl: https://indico.cern.ch/event/896371/
+  url: https://indico.cern.ch/event/896371/contributions/3779617/attachments/2005089/3349622/networkingBlueprintMarch18th2020.pdf
+  meeting: S&C Blueprint Meeting
+  focus-area: osglhc
+- title: The ECoM2x Process
+  date: 2020-03-17
+  url: https://indico.cern.ch/event/896935/contributions/3784451/attachments/2004410/3347247/ecom2x-March17th.pdf
+  meeting: Joint US ATLAS - US CMS Meeting on Facility R&D
+  meetingurl: https://indico.cern.ch/event/896935/
+  focus-area: doma
+  project: modeling
+- title: Running a 380PFLOP32s GPU burst for Multi-Messenger Astrophysics with IceCube
+    across all available GPUs in the Cloud
+  date: 2020-01-27
+  url: https://www.slideshare.net/igor_sfiligoi/nrp-engagement-webinar-running-a-51k-gpu-multicloud-burstfor-mma-with-icecube
+  meeting: NRP Engagement webinar
+  meetingurl: https://spaces.at.internet2.edu/display/NRPWG/National+Research+Platform+%28NRP%29+Space
+  location: WebEx, US
+- title: Running a GPU burst for Multi-Messenger Astrophysics with IceCube across
+    all available GPUs in the Cloud
+  date: 2019-12-04
+  url: https://www.slideshare.net/FrankWuerthwein/building-and-running-the-cloud-gpu-vacuum-cleaner
+  meeting: Middleware and Grid Interagency Cooperation (MAGIC)  meeting
+  meetingurl: https://www.nitrd.gov/nitrdgroups/index.php?title=MAGIC
+  location: WebEx, US
+  focus-area: osglhc
+- title: Running a GPU burst for Multi-Messenger Astrophysics with IceCube across
+    all available GPUs in the Cloud
+  date: 2019-11-19
+  url: https://www.slideshare.net/igor_sfiligoi/running-a-gpu-burst-for-multimessenger-astrophysics-with-icecube-across-all-available-gpus-in-the-cloud
+  meeting: SC 19 Multiple Booths
+  meetingurl: https://sc19.supercomputing.org
+  location: Denver, CO, USA
+  focus-area: osglhc
+- title: OSG News
+  date: 2019-10-10
+  url: https://indico.fnal.gov/event/21410/contribution/2/material/slides/0.pdf
+  meeting: OSG Council Face to Face meeting
+  focus-area: osglhc
+  meetingurl: https://indico.fnal.gov/event/21410/
+- title: Introduction to OSG and OSG Participants
+  date: 2019-09-23
+  url: Not available online
+  meeting: 2019 NSF CC* and CICI PI Pre-Workshop Breakout on OSG
+  focus-area: osglhc
+  meetingurl: https://www.thequilt.net/public-event/2019-nsf-cc-and-cici-pi-pre-workshop-breakouts/#osgd
+- title: Advancing Open Science through distributed High Throughput Computing - The
+    OSG Data Federation
+  date: 2019-09-18
+  url: http://grp-workshop-2019.ucsd.edu/presentations/4_WUERTHWEIN-GRP-2019-OSG.pdf
+  meeting: Global Research Platform Workshop
+  focus-area: osglhc
+  meetingurl: http://grp-workshop-2019.ucsd.edu
+- title: OSG XCache Discussion
+  date: 2019-09-12
+  url: https://indico.cern.ch/event/840472/sessions/323302/attachments/1907227/3150065/irishep-retreatSeptember2019.pdf
+  meeting: IRIS-HEP retreat
+  focus-area: osglhc
+  meetingurl: https://indico.cern.ch/event/840472/
+  project: caching
+- title: Advancing Open Science through distributed High Througput Computing
+  date: 2019-09-11
+  url: https://indico.cern.ch/event/739882/contributions/3520011/attachments/1906491/3148700/gdbSeptember2019.pdf
+  meeting: WLCG Grid Deployment Board Meeting
+  focus-area: osglhc
+  meetingurl: https://indico.cern.ch/event/739882/
+- title: OSG - IRISHEP Advisory Panel
+  date: 2019-09-09
+  url: https://indico.cern.ch/event/840467/contributions/3545009/attachments/1904432/3144878/irishep-AdvisoryBoard-September2019.pdf
+  meeting: IRIS-HEP Advisory Panel Meeting
+  focus-area: osglhc
+  meetingurl: https://indico.cern.ch/event/840467/
+- title: OSG - Steering Board
+  date: 2019-09-03
+  url: https://indico.cern.ch/event/809178/contributions/3370588/subcontributions/287759/attachments/1901941/3139925/irishep-steeringBoard-September3-2019.pdf
+  meeting: IRIS-HEP Steering Board Meeting
+  focus-area: osglhc
+  meetingurl: https://indico.cern.ch/event/809178/
+- title: XCache Initiatives and Experiences
+  date: 2019-07-08
+  meeting: pre-GDB meeting on XCache
+  url: http://uaf-8.t2.ucsd.edu/~fkw/DataLakeSitePerspectiveJune8th2019.pptx
+  project: caching
+- title: Reducing Disk Needs with a Data Lake Concept
+  date: 2019-07-05
+  meeting: ECoM2x meeting CMS
+  url: http://uaf-8.t2.ucsd.edu/~fkw/ecom2xJuly5th2019.pptx
+  project: modeling
+  focus-area: doma
+- title: Advancing Open Science through distributed High Throughput Computing
+  date: 2019-06-25
+  meeting: NERSC Seminar talk
+  url: http://uaf-8.t2.ucsd.edu/~fkw/nerscJune25th2019.pptx
+  focus-area: osglhc
+- title: OSG Accounting Task Force
+  date: 2019-06-12
+  meeting: OSG Area Coordinators Meeting
+  location: Virtual
+  url: http://uaf-8.t2.ucsd.edu/~fkw/osgAccountingTaskForceJune122019.pptx
+  focus-area: osglhc
+- title: OSG-LHC
+  date: 2019-06-12
+  meeting: NSF IRIS-HEP meeting
+  url: https://indico.cern.ch/event/820235/contributions/3428170/attachments/1861231/3058984/OSG-LHCforNSFJune12th2019.pdf
+  meetingurl: https://indico.cern.ch/event/820235/
+  focus-area: osglhc
+- title: UCSD in IRIS-HEP DOMA
+  date: 2019-06-07
+  meeting: DOMA IRIS-HEP meeting
+  meetingurl: https://indico.cern.ch/event/818793/
+  url: https://indico.cern.ch/event/818793/contributions/3420719/attachments/1859017/3054548/iris-hep-domaJune7th2019.pdf
+  focus-area: osglhc
+- title: Advancing Science through distributed High Throughput Computing
+  date: 2019-06-05
+  meeting: SDX Workshop at Qualcom Institute
+  meetingurl: https://www.eventbrite.com/e/integrating-open-science-grid-osg-with-sdx-projects-workshop-june-5-6-2019-tickets-58800356449
+  location: San Diego, CA
+  url: http://uaf-8.t2.ucsd.edu/~fkw/sdxJune5th2019.pptx
+  focus-area: osglhc
+- title: Data Lake — A site perspective
+  date: 2019-06-04
+  meeting: DOMA Access Meeting WLCG
+  url: http://uaf-8.t2.ucsd.edu/~fkw/DataLakeSitePerspectiveJune4th2019.pptx
+  project: modeling
+  focus-area: doma
+- title: OSG Value Proposition for Campuses
+  date: 2019-05-21
+  url: https://drive.google.com/file/d/1WgaZMtm_DNB2qt8_-GJkVs66mlI4cORE/view?usp=drive_web
+  meeting: Great Plains Network Annual Meeting
+  meetingurl: https://conferences.k-state.edu/gpn/
+  location: Kansas City, MO
+  focus-area: osglhc
+- title: Advancing Open Science through distributed High Throughput Computing
+  date: 2019-05-21
+  url: https://drive.google.com/file/d/1qZStE92CfkdN3i0zjboF-vl3Llgx4r1D/view?usp=drive_web
+  meeting: Great Plains Network Annual Meeting
+  meetingurl: https://conferences.k-state.edu/gpn/
+  location: Kansas City, MO
+  focus-area: osglhc
+- title: Big Science with Big Instruments
+  date: 2019-05-15
+  meeting: AWS Seminar talk
+  url: https://d1.awsstatic.com/WWPS/pdf/Science_at_the_Petascale.pdf
+  focus-area: osglhc
+- title: Advancing Open Science through distributed High Throughput Computing
+  date: 2019-04-12
+  url: https://drive.google.com/file/d/1M8w5ndUURkrsDDomhPFpGco4e0efHCVq/view?usp=sharing
+  meeting: CI Engineering Brown Bag
+  location: webinar
+  focus-area: osglhc
+- title: 'Data Access at HPC: ATLAS/CMS Perspective'
+  date: 2019-03-20
+  url: https://indico.cern.ch/event/759388/contributions/3312490/
+  meeting: HOW2019 (Joint HSF/OSG/WLCG Workshop)
+  meetingurl: https://indico.cern.ch/event/759388/
+  location: Jefferson Lab
+  focus-area: doma
+- title: Data Access in DOMA
+  date: 2019-03-20
+  url: https://indico.cern.ch/event/759388/contributions/3312487/
+  meeting: HOW2019 (Joint HSF/OSG/WLCG Workshop)
+  meetingurl: https://indico.cern.ch/event/759388/
+  location: Jefferson Lab
+  focus-area: doma
+  project: caching
+- title: State of OSG
+  date: 2019-03-19
+  url: https://indico.cern.ch/event/759388/contributions/3353296/
+  meeting: HOW2019 (Joint HSF/OSG/WLCG Workshop)
+  meetingurl: https://indico.cern.ch/event/759388/
+  location: Jefferson Lab
+  focus-area: osglhc
+- title: The OSG Data Federation
+  date: 2019-03-07
+  url: https://meetings.internet2.edu/2019-global-summit/speakers/6556/
+  meeting: Internet2 Global Summit 2019
+  meetingurl: https://meetings.internet2.edu/2019-global-summit/detail/10005368/
+  location: Washington, DC
+  focus-area: osglhc
+  project: caching
+- title: OSG-LHC
+  date: 2019-02-06
+  url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271532
+  meeting: IRIS-HEP Steering Board Meeting
+  focus-area: osglhc
+  meetingurl: https://indico.cern.ch/event/790759/

--- a/_data/people/fkw888.yml
+++ b/_data/people/fkw888.yml
@@ -323,3 +323,6 @@ presentations:
   meeting: IRIS-HEP Steering Board Meeting
   focus-area: osglhc
   meetingurl: https://indico.cern.ch/event/790759/
+focus-area:
+- osglhc
+- doma

--- a/_data/people/fkw888.yml
+++ b/_data/people/fkw888.yml
@@ -1,11 +1,13 @@
----
+active: true
+focus-area:
+- osglhc
+- doma
+institution: University of California, San Diego
 name: Frank Wuerthwein
+photo: "/assets/images/team/Frank-Wuerthwein.jpg"
 shortname: fkw888
 title: OSG-LHC Area Lead and OSG Executive Director
-active: true
-institution: University of California, San Diego
 website: https://www-physics.ucsd.edu/fac_staff/fac_profile/faculty_description.php?person_id=494
-photo: "/assets/images/team/Frank-Wuerthwein.jpg"
 presentations:
 - title: State of the OSG
   date: 2021-03-01
@@ -323,6 +325,3 @@ presentations:
   meeting: IRIS-HEP Steering Board Meeting
   focus-area: osglhc
   meetingurl: https://indico.cern.ch/event/790759/
-focus-area:
-- osglhc
-- doma

--- a/_data/people/floe.yml
+++ b/_data/people/floe.yml
@@ -1,9 +1,8 @@
----
-name: Floe Fusin-Wischusen
-shortname: floe
-title: PICSciE Institute Manager
 active: true
 institution: Princeton University
-website: https://researchcomputing.princeton.edu/people/ma-florevel-floe-fusin-wischusen
+name: Floe Fusin-Wischusen
 photo: "/assets/images/team/Floe-Fusin-Wischusen.jpg"
+shortname: floe
+title: PICSciE Institute Manager
+website: https://researchcomputing.princeton.edu/people/ma-florevel-floe-fusin-wischusen
 presentations:

--- a/_data/people/floe.yml
+++ b/_data/people/floe.yml
@@ -1,8 +1,9 @@
+---
 name: Floe Fusin-Wischusen
 shortname: floe
 title: PICSciE Institute Manager
 active: true
 institution: Princeton University
 website: https://researchcomputing.princeton.edu/people/ma-florevel-floe-fusin-wischusen
-photo: /assets/images/team/Floe-Fusin-Wischusen.jpg
+photo: "/assets/images/team/Floe-Fusin-Wischusen.jpg"
 presentations:

--- a/_data/people/g_raven.yml
+++ b/_data/people/g_raven.yml
@@ -1,10 +1,9 @@
----
+active: true
+hidden: true
+institution: VU/NIKHEF
 name: Gerhard Raven
+photo: "/assets/images/team/Gerhard-Raven.jpg"
 shortname: g_raven
 title: LHCb Experiment
-active: true
-institution: VU/NIKHEF
 website:
-photo: "/assets/images/team/Gerhard-Raven.jpg"
-hidden: true
 presentations:

--- a/_data/people/g_raven.yml
+++ b/_data/people/g_raven.yml
@@ -1,9 +1,10 @@
+---
 name: Gerhard Raven
 shortname: g_raven
 title: LHCb Experiment
 active: true
 institution: VU/NIKHEF
 website:
-photo: /assets/images/team/Gerhard-Raven.jpg
+photo: "/assets/images/team/Gerhard-Raven.jpg"
 hidden: true
 presentations:

--- a/_data/people/g_stewart.yml
+++ b/_data/people/g_stewart.yml
@@ -1,10 +1,9 @@
----
+active: true
+hidden: true
+institution: CERN
 name: Graeme Stewart
+photo: "/assets/images/team/Graeme-Stewart.jpeg"
 shortname: g_stewart
 title: HEP Software Foundation (HSF)
-active: true
-institution: CERN
 website:
-photo: "/assets/images/team/Graeme-Stewart.jpeg"
-hidden: true
 presentations:

--- a/_data/people/g_stewart.yml
+++ b/_data/people/g_stewart.yml
@@ -1,9 +1,10 @@
+---
 name: Graeme Stewart
 shortname: g_stewart
 title: HEP Software Foundation (HSF)
 active: true
 institution: CERN
 website:
-photo: /assets/images/team/Graeme-Stewart.jpeg
+photo: "/assets/images/team/Graeme-Stewart.jpeg"
 hidden: true
 presentations:

--- a/_data/people/gagnonlg.yml
+++ b/_data/people/gagnonlg.yml
@@ -1,10 +1,10 @@
----
-name: Louis-Guillaume Gagnon
-title:
-shortname: gagnonlg
 active: true
 e-mail: gagnonlg@lbl.gov
-institution: University of California, Berkeley
-photo: "/assets/images/team/LouisGuillaumeGagnon.jpg"
 focus-area:
 - ia
+institution: University of California, Berkeley
+name: Louis-Guillaume Gagnon
+photo: "/assets/images/team/LouisGuillaumeGagnon.jpg"
+shortname: gagnonlg
+title:
+presentations:

--- a/_data/people/gagnonlg.yml
+++ b/_data/people/gagnonlg.yml
@@ -6,3 +6,5 @@ active: true
 e-mail: gagnonlg@lbl.gov
 institution: University of California, Berkeley
 photo: "/assets/images/team/LouisGuillaumeGagnon.jpg"
+focus-area:
+- ia

--- a/_data/people/gagnonlg.yml
+++ b/_data/people/gagnonlg.yml
@@ -1,7 +1,8 @@
+---
 name: Louis-Guillaume Gagnon
 title:
 shortname: gagnonlg
 active: true
 e-mail: gagnonlg@lbl.gov
 institution: University of California, Berkeley
-photo: /assets/images/team/LouisGuillaumeGagnon.jpg
+photo: "/assets/images/team/LouisGuillaumeGagnon.jpg"

--- a/_data/people/gordonwatts.yml
+++ b/_data/people/gordonwatts.yml
@@ -1,231 +1,243 @@
+---
 name: Gordon Watts
 shortname: gordonwatts
 title: Institute co-PI and Deputy Executive Director
 active: true
 institution: University of Washington
 website: https://phys.washington.edu/people/gordon-watts
-photo: /assets/images/team/Gordon-Watts.jpg
+photo: "/assets/images/team/Gordon-Watts.jpg"
 e-mail: gwatts@uw.edu
 presentations:
-  - title: "IRIS-HEP Steering Board Meeting #1"
-    date: 2019-02-06
-    url: https://indico.cern.ch/event/790759/contributions/3284632/attachments/1791853/2919742/2019-02-06_-_Steering_Board_Intro.pdf
-    meeting: IRIS-HEP Steering Board Meeting #1
-    meetingurl: https://indico.cern.ch/event/790759/
-    location: Vidyo
-    focus-area: core
-  - title: "LINQ To ROOT"
-    date: 2019-02-13
-    url: https://indico.cern.ch/event/789007/contributions/3317126/attachments/1795120/2927037/2019-02-13_-_Analysis_Languages.pdf
-    meeting: 1st DAWG Technology and Innovation Survey (HSF)
-    meetingurl: https://indico.cern.ch/event/789007/
-    focus-area: as
-    project: func-adl
-  - title: "The C# LINQ Analysis Language"
-    date: 2019-02-25
-    url: https://indico.cern.ch/event/799590/contributions/3322885/attachments/1801294/2938216/2019-02-25_-_The_C_LINQ_Analysis_Language.pdf
-    meeting: IRIS-HEP Topical Meeting on Analysis Description Languages
-    meetingurl: https://indico.cern.ch/event/799590/
-    location: Vidyo
-    focus-area: as
-    project: func-adl
-  - title: "Aligning the MATHUSA Test Stand Detector: Using Tensorflow"
-    date: 2019-03-11
-    url: https://indico.cern.ch/event/708041/contributions/3272137/attachments/1813161/2962373/2019-03-11_-_ACAT_TF_and_Alignment.pdf
-    meeting: ACAT 2019
-    meetingurl: https://indico.cern.ch/event/708041
-    focus-area: as
-    location: Sass-Fee, Switzerland
-  - title: "Beyond the Roadmap: HL-LHC HEP Software"
-    date: 2019-03-14
-    url: https://indico.cern.ch/event/708041/contributions/3308813/attachments/1811660
-    meeting: ACAT 2019
-    meetingurl: https://indico.cern.ch/event/708041
-    focus-area: core
-  - title: IRIS-HEP and ATLAS
-    date: 2019-02-20
-    url: https://indico.cern.ch/event/799375/contributions/3321753/attachments/1799577/2934794/2019-02-20_-_US_ATLAS_IB_Meeting.pdf
-    meeting: US ATLAS IB Meeting
-    meetingurl: https://indico.cern.ch/event/799375/
-    focus-area: core
-  - title: Thinking about Analysis Languages and Recent Progress
-    date: 2019-05-07
-    url: https://indico.cern.ch/event/769263/contributions/3406076/
-    meeting: Analysis Description Languages
-    meetingurl: https://indico.cern.ch/event/769263
-    focus-area: as
-    project: func-adl
-  - title: Analysis in Run 4
-    date: 2019-06-27
-    url: https://indico.cern.ch/event/765245/contributions/3442554/
-    meeting: ATLAS Software and Computing Week #62
-    meetingurl: https://indico.cern.ch/event/765245
-    focus-area: as
-  - title: Functional/Declarative Selection Languages
-    date: 2019-06-19
-    url: https://indico.cern.ch/event/822074/contributions/3471457/
-    meeting: Analysis Systems Topical Workshop
-    meetingurl: https://indico.cern.ch/event/822074/
-    focus-area: as
-    project: func-adl
-  - title: IRIS-HEP View
-    date: 2019-07-22
-    url: https://indico.cern.ch/event/835581/contributions/3508561
-    meeting: Computing infrastructures for future data analysis
-    meetingurl: https://indico.cern.ch/event/835581
-    focus-area: core
-  - title: func-adl to C++/xAOD backend
-    date: 2019-09-13
-    url: https://indico.cern.ch/event/840472/contributions/3563333/
-    meeting: IRIS-HEP Institute Retreat
-    meetingurl: https://indico.cern.ch/event/840472
-    focus-area: as
-    project: func-adl
-  - title: Milestones - We don't need roads...
-    date: 2019-09-12
-    url: https://indico.cern.ch/event/840472/contributions/3561605/
-    meeting: IRIS-HEP Institute Retreat
-    meetingurl: https://indico.cern.ch/event/840472
-    focus-area: core
-  - title: "Declarative programming: A paradigm shift in data analysis in preparation for the HL-LHC"
-    date: 2019-09-26
-    url: https://doi.org/10.5281/zenodo.3471337
-    meetingurl: https://escience2019.sdsc.edu/
-    meeting: eScience2019
-    focus-area: as
-    project: func-adl
-  - title: "Run 3/Run 4 Perspectives - Event Delivery Impacts?"
-    date: 2019-09-30
-    url: https://indico.cern.ch/event/849155/contributions/3576913/
-    meetingurl: https://indico.cern.ch/event/849155/
-    meeting: "HSF & ATLAS Joint Event Delivery Workshop"
-    focus-area: as
-  - title: "Lightning Talk: A Living HEP Analysis"
-    date: 2019-10-16
-    url: https://indico.cern.ch/event/833895/sessions/319481/
-    meetingurl: https://indico.cern.ch/event/833895
-    meeting: "PyHEP"
-    focus-area: as
-    project: func-adl
-  - title: "Aligning the MATHUSLA Detector Test Stand with Tensor Flow"
-    date: 2019-11-07
-    url: https://indico.cern.ch/event/773049/contributions/3476185/
-    meetingurl: https://indico.cern.ch/event/773049/
-    meeting: "CHEP 2019"
-    focus-area: as
-  - title: "Using Analysis Declarative Languages for the HL-LHC"
-    date: 2019-11-05
-    url: https://indico.cern.ch/event/773049/contributions/3476174/
-    meetingurl: https://indico.cern.ch/event/773049/
-    meeting: "CHEP 2019"
-    focus-area: as
-    project: func-adl
-  - title: "Analysis workflows"
-    date: 2019-11-02
-    url: https://indico.cern.ch/event/805983/contributions/3569725/
-    meetingurl: https://indico.cern.ch/event/805983/
-    meeting: "CHEP 2019"
-    focus-area: as
-  - title: "The IRIS-HEP Institute in the US"
-    date: 2019-11-20
-    url: https://indico.cern.ch/event/813325/contributions/3601405/
-    meetingurl: https://indico.cern.ch/event/813325/sessions/330057/
-    meeting: "Latin American Workshop on Software and Computing (S&C) Challenges in High-Energy Particle Physics (HEP)"
-    focus-area: core
-    location: Mexico City
-  - title: "Analysis Tools in the 2020's and 2030's"
-    date: 2019-11-21
-    url: https://indico.cern.ch/event/813325/contributions/3603496/
-    meetingurl: https://indico.cern.ch/event/813325/sessions/330057/
-    meeting: "Latin American Workshop on Software and Computing (S&C) Challenges in High-Energy Particle Physics (HEP)"
-    focus-area: as
-    location: Mexico City
-  - title: "S2I2: Institute for Research and Innovation in Software for High Energy Physics (IRIS-HEP)"
-    date: 2020-02-14
-    url: https://figshare.com/articles/Untitled_ItemS2I2_Institute_for_Research_and_Innovation_in_Software_for_High_Energy_Physics_IRIS-HEP_/11839302
-    meetingurl: https://cssi-pi-community.github.io/2020-meeting/#talks
-    meeting: "2020 NSF CSSI PI MEETING"
-    focus-area: core
-    location: Seattle, WA
-  - title: "IRIS-HEP: The Year 3 Program"
-    date: 2020-04-30
-    url: https://indico.cern.ch/event/914348/contributions/3844844/attachments/2030393/3398156/2020-04-30_-_CMS_PET_Meeting.pdf
-    meetingurl: https://indico.cern.ch/event/914348/
-    meeting: "US CMS IRIS-HEP Year 3 Program"
-    focus-area: core
-    location: Virtual
-  - title: "hep_tables: An Introduction"
-    date: 2020-05-08
-    url: https://zenodo.org/record/3818031#.XrXbwjiSn-g
-    meetingurl: https://indico.cern.ch/event/917018/
-    meeting: "Coffea Developers Meeting"
-    focus-area: as
-    project: hep-tables
-    location: Virtual
-  - title: "Parallel Sessions: Plans and Goals"
-    date: 2020-05-26
-    url: https://indico.cern.ch/event/896167/contributions/3870080/
-    meetingurl: https://indico.cern.ch/event/896167/
-    meeting: "IRIS-HEP Team Retreat"
-    focus-area: ["doma", "as"]
-    project: servicex
-    location: Virtual
-  - title: "ServiceX Front End Status"
-    date: 2020-10-02
-    url: https://indico.cern.ch/event/961949/contributions/4048043/
-    meetingurl: https://indico.cern.ch/event/961949
-    meeting: "ServiceX Meeting"
-    focus-area: ["doma", "as"]
-    project: servicex
-    location: Virtual
-  - title: "ServiceX Front End Status"
-    date: 2020-10-16
-    url: https://indico.cern.ch/event/967053/contributions/4070082
-    meetingurl: https://indico.cern.ch/event/967053
-    meeting: "ServiceX Meeting"
-    focus-area: ["doma", "as"]
-    project: servicex
-    location: Virtual
-  - title: "An Integrated Data Query Pipeline: HEPTables"
-    date: 2020-10-26
-    url: https://indico.cern.ch/event/960587/contributions/4077336/
-    meetingurl: https://indico.cern.ch/event/960587
-    meeting: "IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop"
-    focus-area: as
-    project: hep-tables
-    location: Virtual
-  - title: "Analysis tools and infrastructure"
-    date: 2020-10-27
-    url: https://indico.ihep.ac.cn/event/11444/session/12/contribution/174
-    meetingurl: https://indico.ihep.ac.cn/event/11444
-    meeting: "The 2020 International Workshop on the High Energy Circular Electron Positron Collider"
-    focus-area: core
-    location: Virtual
-  - title: "IRIS-HEP: Analysis in the HL-LHC Era"
-    date: 2020-12-15
-    url: https://indico.cern.ch/event/975046/contributions/4115843
-    meetingurl: https://indico.cern.ch/event/975046
-    meeting: "WFM SW Technical Interchange Meeting"
-    focus-area: as
-    location: Virtual
-  - title: "Using Modern Computing to Get the Most out of the LHC"
-    date: 2021-02-18
-    url: https://indico.cern.ch/event/1010438/
-    meetingurl: https://indico.cern.ch/event/1010438/
-    meeting: "UW EPE Seminar"
-    focus-area: core
-    location: "University of Washington"
-  - title: "Computing in HEP for the HL-LHC"
-    date: 2021-02-25
-    url: https://zenodo.org/record/4579182#.YD_sGn2Ib-g
-    meetingurl: https://zenodo.org/record/4579182#.YD_sGn2Ib-g
-    meeting: "University of California, Santa Cruz, Physics Department Colloquia"
-    focus-area: core
-    location: "University of California, Santa Cruz"
-  - title: "IRIS-HEP and ATLAS Analysis Software"
-    date: 2021-04-09
-    url: https://zenodo.org/record/4678961#.YHJMhCRlD-g
-    meetingurl: https://indico.cern.ch/event/1012997/
-    meeting: "ATLAS Analysis Model Group (AMG) Meeting"
-    focus-area: as
-    location: "CERN"
+- title: 'IRIS-HEP Steering Board Meeting #1'
+  date: 2019-02-06
+  url: https://indico.cern.ch/event/790759/contributions/3284632/attachments/1791853/2919742/2019-02-06_-_Steering_Board_Intro.pdf
+  meeting: IRIS-HEP Steering Board Meeting
+  meetingurl: https://indico.cern.ch/event/790759/
+  location: Vidyo
+  focus-area: core
+- title: LINQ To ROOT
+  date: 2019-02-13
+  url: https://indico.cern.ch/event/789007/contributions/3317126/attachments/1795120/2927037/2019-02-13_-_Analysis_Languages.pdf
+  meeting: 1st DAWG Technology and Innovation Survey (HSF)
+  meetingurl: https://indico.cern.ch/event/789007/
+  focus-area: as
+  project: func-adl
+- title: The C# LINQ Analysis Language
+  date: 2019-02-25
+  url: https://indico.cern.ch/event/799590/contributions/3322885/attachments/1801294/2938216/2019-02-25_-_The_C_LINQ_Analysis_Language.pdf
+  meeting: IRIS-HEP Topical Meeting on Analysis Description Languages
+  meetingurl: https://indico.cern.ch/event/799590/
+  location: Vidyo
+  focus-area: as
+  project: func-adl
+- title: 'Aligning the MATHUSA Test Stand Detector: Using Tensorflow'
+  date: 2019-03-11
+  url: https://indico.cern.ch/event/708041/contributions/3272137/attachments/1813161/2962373/2019-03-11_-_ACAT_TF_and_Alignment.pdf
+  meeting: ACAT 2019
+  meetingurl: https://indico.cern.ch/event/708041
+  focus-area: as
+  location: Sass-Fee, Switzerland
+- title: 'Beyond the Roadmap: HL-LHC HEP Software'
+  date: 2019-03-14
+  url: https://indico.cern.ch/event/708041/contributions/3308813/attachments/1811660
+  meeting: ACAT 2019
+  meetingurl: https://indico.cern.ch/event/708041
+  focus-area: core
+- title: IRIS-HEP and ATLAS
+  date: 2019-02-20
+  url: https://indico.cern.ch/event/799375/contributions/3321753/attachments/1799577/2934794/2019-02-20_-_US_ATLAS_IB_Meeting.pdf
+  meeting: US ATLAS IB Meeting
+  meetingurl: https://indico.cern.ch/event/799375/
+  focus-area: core
+- title: Thinking about Analysis Languages and Recent Progress
+  date: 2019-05-07
+  url: https://indico.cern.ch/event/769263/contributions/3406076/
+  meeting: Analysis Description Languages
+  meetingurl: https://indico.cern.ch/event/769263
+  focus-area: as
+  project: func-adl
+- title: Analysis in Run 4
+  date: 2019-06-27
+  url: https://indico.cern.ch/event/765245/contributions/3442554/
+  meeting: ATLAS Software and Computing Week
+  meetingurl: https://indico.cern.ch/event/765245
+  focus-area: as
+- title: Functional/Declarative Selection Languages
+  date: 2019-06-19
+  url: https://indico.cern.ch/event/822074/contributions/3471457/
+  meeting: Analysis Systems Topical Workshop
+  meetingurl: https://indico.cern.ch/event/822074/
+  focus-area: as
+  project: func-adl
+- title: IRIS-HEP View
+  date: 2019-07-22
+  url: https://indico.cern.ch/event/835581/contributions/3508561
+  meeting: Computing infrastructures for future data analysis
+  meetingurl: https://indico.cern.ch/event/835581
+  focus-area: core
+- title: func-adl to C++/xAOD backend
+  date: 2019-09-13
+  url: https://indico.cern.ch/event/840472/contributions/3563333/
+  meeting: IRIS-HEP Institute Retreat
+  meetingurl: https://indico.cern.ch/event/840472
+  focus-area: as
+  project: func-adl
+- title: Milestones - We don't need roads...
+  date: 2019-09-12
+  url: https://indico.cern.ch/event/840472/contributions/3561605/
+  meeting: IRIS-HEP Institute Retreat
+  meetingurl: https://indico.cern.ch/event/840472
+  focus-area: core
+- title: 'Declarative programming: A paradigm shift in data analysis in preparation
+    for the HL-LHC'
+  date: 2019-09-26
+  url: https://doi.org/10.5281/zenodo.3471337
+  meetingurl: https://escience2019.sdsc.edu/
+  meeting: eScience2019
+  focus-area: as
+  project: func-adl
+- title: Run 3/Run 4 Perspectives - Event Delivery Impacts?
+  date: 2019-09-30
+  url: https://indico.cern.ch/event/849155/contributions/3576913/
+  meetingurl: https://indico.cern.ch/event/849155/
+  meeting: HSF & ATLAS Joint Event Delivery Workshop
+  focus-area: as
+- title: 'Lightning Talk: A Living HEP Analysis'
+  date: 2019-10-16
+  url: https://indico.cern.ch/event/833895/sessions/319481/
+  meetingurl: https://indico.cern.ch/event/833895
+  meeting: PyHEP
+  focus-area: as
+  project: func-adl
+- title: Aligning the MATHUSLA Detector Test Stand with Tensor Flow
+  date: 2019-11-07
+  url: https://indico.cern.ch/event/773049/contributions/3476185/
+  meetingurl: https://indico.cern.ch/event/773049/
+  meeting: CHEP 2019
+  focus-area: as
+- title: Using Analysis Declarative Languages for the HL-LHC
+  date: 2019-11-05
+  url: https://indico.cern.ch/event/773049/contributions/3476174/
+  meetingurl: https://indico.cern.ch/event/773049/
+  meeting: CHEP 2019
+  focus-area: as
+  project: func-adl
+- title: Analysis workflows
+  date: 2019-11-02
+  url: https://indico.cern.ch/event/805983/contributions/3569725/
+  meetingurl: https://indico.cern.ch/event/805983/
+  meeting: CHEP 2019
+  focus-area: as
+- title: The IRIS-HEP Institute in the US
+  date: 2019-11-20
+  url: https://indico.cern.ch/event/813325/contributions/3601405/
+  meetingurl: https://indico.cern.ch/event/813325/sessions/330057/
+  meeting: Latin American Workshop on Software and Computing (S&C) Challenges in High-Energy
+    Particle Physics (HEP)
+  focus-area: core
+  location: Mexico City
+- title: Analysis Tools in the 2020's and 2030's
+  date: 2019-11-21
+  url: https://indico.cern.ch/event/813325/contributions/3603496/
+  meetingurl: https://indico.cern.ch/event/813325/sessions/330057/
+  meeting: Latin American Workshop on Software and Computing (S&C) Challenges in High-Energy
+    Particle Physics (HEP)
+  focus-area: as
+  location: Mexico City
+- title: 'S2I2: Institute for Research and Innovation in Software for High Energy
+    Physics (IRIS-HEP)'
+  date: 2020-02-14
+  url: https://figshare.com/articles/Untitled_ItemS2I2_Institute_for_Research_and_Innovation_in_Software_for_High_Energy_Physics_IRIS-HEP_/11839302
+  meetingurl: https://cssi-pi-community.github.io/2020-meeting/#talks
+  meeting: 2020 NSF CSSI PI MEETING
+  focus-area: core
+  location: Seattle, WA
+- title: 'IRIS-HEP: The Year 3 Program'
+  date: 2020-04-30
+  url: https://indico.cern.ch/event/914348/contributions/3844844/attachments/2030393/3398156/2020-04-30_-_CMS_PET_Meeting.pdf
+  meetingurl: https://indico.cern.ch/event/914348/
+  meeting: US CMS IRIS-HEP Year 3 Program
+  focus-area: core
+  location: Virtual
+- title: 'hep_tables: An Introduction'
+  date: 2020-05-08
+  url: https://zenodo.org/record/3818031#.XrXbwjiSn-g
+  meetingurl: https://indico.cern.ch/event/917018/
+  meeting: Coffea Developers Meeting
+  focus-area: as
+  project: hep-tables
+  location: Virtual
+- title: 'Parallel Sessions: Plans and Goals'
+  date: 2020-05-26
+  url: https://indico.cern.ch/event/896167/contributions/3870080/
+  meetingurl: https://indico.cern.ch/event/896167/
+  meeting: IRIS-HEP Team Retreat
+  focus-area:
+  - doma
+  - as
+  project: servicex
+  location: Virtual
+- title: ServiceX Front End Status
+  date: 2020-10-02
+  url: https://indico.cern.ch/event/961949/contributions/4048043/
+  meetingurl: https://indico.cern.ch/event/961949
+  meeting: ServiceX Meeting
+  focus-area:
+  - doma
+  - as
+  project: servicex
+  location: Virtual
+- title: ServiceX Front End Status
+  date: 2020-10-16
+  url: https://indico.cern.ch/event/967053/contributions/4070082
+  meetingurl: https://indico.cern.ch/event/967053
+  meeting: ServiceX Meeting
+  focus-area:
+  - doma
+  - as
+  project: servicex
+  location: Virtual
+- title: 'An Integrated Data Query Pipeline: HEPTables'
+  date: 2020-10-26
+  url: https://indico.cern.ch/event/960587/contributions/4077336/
+  meetingurl: https://indico.cern.ch/event/960587
+  meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
+  focus-area: as
+  project: hep-tables
+  location: Virtual
+- title: Analysis tools and infrastructure
+  date: 2020-10-27
+  url: https://indico.ihep.ac.cn/event/11444/session/12/contribution/174
+  meetingurl: https://indico.ihep.ac.cn/event/11444
+  meeting: The 2020 International Workshop on the High Energy Circular Electron Positron
+    Collider
+  focus-area: core
+  location: Virtual
+- title: 'IRIS-HEP: Analysis in the HL-LHC Era'
+  date: 2020-12-15
+  url: https://indico.cern.ch/event/975046/contributions/4115843
+  meetingurl: https://indico.cern.ch/event/975046
+  meeting: WFM SW Technical Interchange Meeting
+  focus-area: as
+  location: Virtual
+- title: Using Modern Computing to Get the Most out of the LHC
+  date: 2021-02-18
+  url: https://indico.cern.ch/event/1010438/
+  meetingurl: https://indico.cern.ch/event/1010438/
+  meeting: UW EPE Seminar
+  focus-area: core
+  location: University of Washington
+- title: Computing in HEP for the HL-LHC
+  date: 2021-02-25
+  url: https://zenodo.org/record/4579182#.YD_sGn2Ib-g
+  meetingurl: https://zenodo.org/record/4579182#.YD_sGn2Ib-g
+  meeting: University of California, Santa Cruz, Physics Department Colloquia
+  focus-area: core
+  location: University of California, Santa Cruz
+- title: IRIS-HEP and ATLAS Analysis Software
+  date: 2021-04-09
+  url: https://zenodo.org/record/4678961#.YHJMhCRlD-g
+  meetingurl: https://indico.cern.ch/event/1012997/
+  meeting: ATLAS Analysis Model Group (AMG) Meeting
+  focus-area: as
+  location: CERN

--- a/_data/people/gordonwatts.yml
+++ b/_data/people/gordonwatts.yml
@@ -1,12 +1,14 @@
----
+active: true
+e-mail: gwatts@uw.edu
+focus-area:
+- as
+- doma
+institution: University of Washington
 name: Gordon Watts
+photo: "/assets/images/team/Gordon-Watts.jpg"
 shortname: gordonwatts
 title: Institute co-PI and Deputy Executive Director
-active: true
-institution: University of Washington
 website: https://phys.washington.edu/people/gordon-watts
-photo: "/assets/images/team/Gordon-Watts.jpg"
-e-mail: gwatts@uw.edu
 presentations:
 - title: 'IRIS-HEP Steering Board Meeting #1'
   date: 2019-02-06
@@ -241,6 +243,3 @@ presentations:
   meeting: ATLAS Analysis Model Group (AMG) Meeting
   focus-area: as
   location: CERN
-focus-area:
-- as
-- doma

--- a/_data/people/gordonwatts.yml
+++ b/_data/people/gordonwatts.yml
@@ -241,3 +241,6 @@ presentations:
   meeting: ATLAS Analysis Model Group (AMG) Meeting
   focus-area: as
   location: CERN
+focus-area:
+- as
+- doma

--- a/_data/people/haxxardoux.yml
+++ b/_data/people/haxxardoux.yml
@@ -1,7 +1,8 @@
-name:  Will Tepe
+---
+name: Will Tepe
 shortname: haxxardoux
 title: Undergraduate Research Assistant
 active: true
 institution: University of Cincinnati
-photo: /assets/images/team/Will-Tepe.jpg
+photo: "/assets/images/team/Will-Tepe.jpg"
 hidden: true

--- a/_data/people/haxxardoux.yml
+++ b/_data/people/haxxardoux.yml
@@ -1,8 +1,8 @@
----
+active: true
+hidden: true
+institution: University of Cincinnati
 name: Will Tepe
+photo: "/assets/images/team/Will-Tepe.jpg"
 shortname: haxxardoux
 title: Undergraduate Research Assistant
-active: true
-institution: University of Cincinnati
-photo: "/assets/images/team/Will-Tepe.jpg"
-hidden: true
+presentations:

--- a/_data/people/heather-gray.yml
+++ b/_data/people/heather-gray.yml
@@ -57,3 +57,5 @@ presentations:
   meetingurl: https://indico.physics.lbl.gov/indico/event/712/timetable/#20190114
   focus-area: ia
   project: acts
+focus-area:
+- ia

--- a/_data/people/heather-gray.yml
+++ b/_data/people/heather-gray.yml
@@ -1,57 +1,59 @@
+---
 name: Heather Gray
 shortname: heather-gray
 title: Innovative Algorithms Area <nobr>co-Lead</nobr>
 active: true
 institution: University of California, Berkeley
 website: https://atlas.cern/authors/heather-gray
-photo: /assets/images/team/Heather-Gray.png
+photo: "/assets/images/team/Heather-Gray.png"
 presentations:
-  - title: "HEP Software over the next decade"
-    date: 2021-05-17
-    meeting: vCHEP
-    meetingurl: https://indico.cern.ch/event/948465/
-    url: https://indico.cern.ch/event/948465/
-    focus-area: ia
-    project: acts
-  - title: "IRIS-HEP Report: Innovative Algorithms"
-    date: 2020-08-11
-    meeting: Snowmass Computational Frontier Workshop
-    meetingurl: https://indico.fnal.gov/event/43829/overview
-    url: https://indico.fnal.gov/event/43829/contributions/193723/
-    focus-area: ia
-    project:
-  - title: "Machine learning in high-energy particle physics experiments, from simulation, through reconstruction to physics analysis"
-    date: 2019-05-29
-    meeting: Physics in Machine Learning Workshop
-    meetingurl: https://www.ml4science.org/agenda-physics-in-ml
-    url: https://www.ml4science.org/agenda-physics-in-ml
-    focus-area: ia
-    project:
-  - title: "IRIS-HEP Innovative Algorithms"
-    date: 2019-02-06
-    url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271529/attachments/1791453/2919650/Innovative_Algorithms_3.pdf
-    meeting: IRIS-HEP Steering Board Meeting #1
-    meetingurl: https://indico.cern.ch/event/790759/
-    focus-area: ia
-    project: acts
-  - title: "Selected recent ideas in computing and their impact on high-energy physics"
-    date: 2019-02-17
-    url: http://www.icepp.s.u-tokyo.ac.jp/symposium/25/download/sympo25-special_gray.pdf
-    meeting: 25th ICEPP Symposium
-    meetingurl: http://www.icepp.s.u-tokyo.ac.jp/symposium/25/timetable.html
-    focus-area: ia
-    project:
-  - title: "Ambiguity Resolution Studies with ACTS"
-    date: 2019-01-13
-    url: https://indico.physics.lbl.gov/indico/event/712/contributions/3021/attachments/1761/2138/go
-    meeting: Berkeley Tracking Workshop
-    meetingurl: https://indico.physics.lbl.gov/indico/event/712/contributions/3021/
-    focus-area: ia
-    project: acts
-  - title: "Workshop introduction"
-    date: 2019-01-13
-    url: https://indico.physics.lbl.gov/indico/event/712/contributions/3017/attachments/1753/2124/TrackingWorkshopIntro.pdf
-    meeting: Berkeley Tracking Workshop
-    meetingurl: https://indico.physics.lbl.gov/indico/event/712/timetable/#20190114
-    focus-area: ia
-    project: acts
+- title: HEP Software over the next decade
+  date: 2021-05-17
+  meeting: vCHEP
+  meetingurl: https://indico.cern.ch/event/948465/
+  url: https://indico.cern.ch/event/948465/
+  focus-area: ia
+  project: acts
+- title: 'IRIS-HEP Report: Innovative Algorithms'
+  date: 2020-08-11
+  meeting: Snowmass Computational Frontier Workshop
+  meetingurl: https://indico.fnal.gov/event/43829/overview
+  url: https://indico.fnal.gov/event/43829/contributions/193723/
+  focus-area: ia
+  project:
+- title: Machine learning in high-energy particle physics experiments, from simulation,
+    through reconstruction to physics analysis
+  date: 2019-05-29
+  meeting: Physics in Machine Learning Workshop
+  meetingurl: https://www.ml4science.org/agenda-physics-in-ml
+  url: https://www.ml4science.org/agenda-physics-in-ml
+  focus-area: ia
+  project:
+- title: IRIS-HEP Innovative Algorithms
+  date: 2019-02-06
+  url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271529/attachments/1791453/2919650/Innovative_Algorithms_3.pdf
+  meeting: IRIS-HEP Steering Board Meeting
+  meetingurl: https://indico.cern.ch/event/790759/
+  focus-area: ia
+  project: acts
+- title: Selected recent ideas in computing and their impact on high-energy physics
+  date: 2019-02-17
+  url: http://www.icepp.s.u-tokyo.ac.jp/symposium/25/download/sympo25-special_gray.pdf
+  meeting: 25th ICEPP Symposium
+  meetingurl: http://www.icepp.s.u-tokyo.ac.jp/symposium/25/timetable.html
+  focus-area: ia
+  project:
+- title: Ambiguity Resolution Studies with ACTS
+  date: 2019-01-13
+  url: https://indico.physics.lbl.gov/indico/event/712/contributions/3021/attachments/1761/2138/go
+  meeting: Berkeley Tracking Workshop
+  meetingurl: https://indico.physics.lbl.gov/indico/event/712/contributions/3021/
+  focus-area: ia
+  project: acts
+- title: Workshop introduction
+  date: 2019-01-13
+  url: https://indico.physics.lbl.gov/indico/event/712/contributions/3017/attachments/1753/2124/TrackingWorkshopIntro.pdf
+  meeting: Berkeley Tracking Workshop
+  meetingurl: https://indico.physics.lbl.gov/indico/event/712/timetable/#20190114
+  focus-area: ia
+  project: acts

--- a/_data/people/heather-gray.yml
+++ b/_data/people/heather-gray.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ia
+institution: University of California, Berkeley
 name: Heather Gray
+photo: "/assets/images/team/Heather-Gray.png"
 shortname: heather-gray
 title: Innovative Algorithms Area <nobr>co-Lead</nobr>
-active: true
-institution: University of California, Berkeley
 website: https://atlas.cern/authors/heather-gray
-photo: "/assets/images/team/Heather-Gray.png"
 presentations:
 - title: HEP Software over the next decade
   date: 2021-05-17
@@ -57,5 +58,3 @@ presentations:
   meetingurl: https://indico.physics.lbl.gov/indico/event/712/timetable/#20190114
   focus-area: ia
   project: acts
-focus-area:
-- ia

--- a/_data/people/heikomuller.yml
+++ b/_data/people/heikomuller.yml
@@ -1,29 +1,34 @@
+---
 name: Heiko Mueller
 shortname: heikomuller
 title: Research Software Engineer (SCAILFIN)
 active: true
 institution: New York University
 website: https://cims.nyu.edu/~hmueller/
-photo: /assets/images/team/Heiko-Mueller.jpg
+photo: "/assets/images/team/Heiko-Mueller.jpg"
 presentations:
-  - title: "SCAILFIN: Reproducible Open Benchmarks"
-    date: 2019-06-19
-    url: https://indico.cern.ch/event/822074/contributions/3471463/
-    meeting: Analysis Systems Topical Meeting
-    meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
-    location: NYU
-    focus-area: [as, ia]
-  - title: "Benchmarks for ML4Jets research"
-    date: 2019-09-25
-    url: https://indico.cern.ch/event/841905/
-    meeting: IRIS-HEP Topical Meeting
-    meetingurl: https://indico.cern.ch/event/841905/
-    location: Vidyo
-    focus-area: ia
-  - title: "ROB: Reproducible Open Benchmarks for Data Analysis Platform"
-    date: 2020-01-17
-    url: https://indico.cern.ch/event/809820/contributions/3632640/attachments/1971191/3279096/ROB-ML4Jets.pdf
-    meeting: ML4Jets 2020
-    meetingurl: https://indico.cern.ch/event/809820/
-    location: New York University
-    focus-area: [ia, core]
+- title: 'SCAILFIN: Reproducible Open Benchmarks'
+  date: 2019-06-19
+  url: https://indico.cern.ch/event/822074/contributions/3471463/
+  meeting: Analysis Systems Topical Meeting
+  meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
+  location: NYU
+  focus-area:
+  - as
+  - ia
+- title: Benchmarks for ML4Jets research
+  date: 2019-09-25
+  url: https://indico.cern.ch/event/841905/
+  meeting: IRIS-HEP Topical Meeting
+  meetingurl: https://indico.cern.ch/event/841905/
+  location: Vidyo
+  focus-area: ia
+- title: 'ROB: Reproducible Open Benchmarks for Data Analysis Platform'
+  date: 2020-01-17
+  url: https://indico.cern.ch/event/809820/contributions/3632640/attachments/1971191/3279096/ROB-ML4Jets.pdf
+  meeting: ML4Jets 2020
+  meetingurl: https://indico.cern.ch/event/809820/
+  location: New York University
+  focus-area:
+  - ia
+  - core

--- a/_data/people/heikomuller.yml
+++ b/_data/people/heikomuller.yml
@@ -1,11 +1,13 @@
----
+active: true
+focus-area:
+- as
+- ia
+institution: New York University
 name: Heiko Mueller
+photo: "/assets/images/team/Heiko-Mueller.jpg"
 shortname: heikomuller
 title: Research Software Engineer (SCAILFIN)
-active: true
-institution: New York University
 website: https://cims.nyu.edu/~hmueller/
-photo: "/assets/images/team/Heiko-Mueller.jpg"
 presentations:
 - title: 'SCAILFIN: Reproducible Open Benchmarks'
   date: 2019-06-19
@@ -32,6 +34,3 @@ presentations:
   focus-area:
   - ia
   - core
-focus-area:
-- as
-- ia

--- a/_data/people/heikomuller.yml
+++ b/_data/people/heikomuller.yml
@@ -32,3 +32,6 @@ presentations:
   focus-area:
   - ia
   - core
+focus-area:
+- as
+- ia

--- a/_data/people/henryiii.yml
+++ b/_data/people/henryiii.yml
@@ -247,3 +247,7 @@ presentations:
   focus-area: ssc
   project:
   location: Virtual
+focus-area:
+- ia
+- as
+- ssc

--- a/_data/people/henryiii.yml
+++ b/_data/people/henryiii.yml
@@ -1,13 +1,16 @@
----
-name: Henry Schreiner
-shortname: henryiii
-title:
-inspire-id: Henry.F.Schreiner.1
 active: true
 e-mail: henryfs@princeton.edu
+focus-area:
+- ia
+- as
+- ssc
+inspire-id: Henry.F.Schreiner.1
 institution: Princeton University
-website: https://iscinumpy.gitlab.io
+name: Henry Schreiner
 photo: "/assets/images/team/Henry-Schreiner.jpg"
+shortname: henryiii
+title:
+website: https://iscinumpy.gitlab.io
 presentations:
 - title: A hybrid deep learning approach to vertexing
   date: 2019-04-17
@@ -247,7 +250,3 @@ presentations:
   focus-area: ssc
   project:
   location: Virtual
-focus-area:
-- ia
-- as
-- ssc

--- a/_data/people/henryiii.yml
+++ b/_data/people/henryiii.yml
@@ -1,3 +1,4 @@
+---
 name: Henry Schreiner
 shortname: henryiii
 title:
@@ -6,236 +7,243 @@ active: true
 e-mail: henryfs@princeton.edu
 institution: Princeton University
 website: https://iscinumpy.gitlab.io
-photo: /assets/images/team/Henry-Schreiner.jpg
+photo: "/assets/images/team/Henry-Schreiner.jpg"
 presentations:
-  - title: "A hybrid deep learning approach to vertexing"
-    date: 2019-04-17
-    url: https://indico.cern.ch/event/766872/contributions/3358003/
-    meeting: 3rd IML Machine Learning Workshop
-    meetingurl: https://indico.cern.ch/event/766872/
-    location: CERN
-    focus-area: ia
-    project: pv-finder
-  - title: "boost-histogram and hist"
-    date: 2019-04-15
-    url: https://indico.cern.ch/event/803122/
-    meeting: IRIS-HEP Topical Meeting
-    meetingurl: https://indico.cern.ch/event/803122/
-    focus-area: as
-    project: histogram
-    location: Virtual
-  - title: "A hybrid deep learning approach to vertexing"
-    date: 2019-04-03
-    url: https://indico.cern.ch/event/742793/contributions/3298730/
-    meeting: Connecting The Dots and Workshop on Intelligent Trackers 2019
-    meetingurl: https://indico.cern.ch/event/742793/
-    location: Valencia, Spain
-    focus-area: ia
-    project: pv-finder
-  - title: "Conda: a complete reproducible ROOT environment in under 5 minutes"
-    date: 2019-03-21
-    url: https://indico.cern.ch/event/759388/contributions/3306849/
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop
-    meetingurl: https://indico.cern.ch/event/759388
-    location: Jefferson Lab
-    focus-area: as
-    project: rootconda
-  - title: "Machine Learning for the Primary Vertex reconstruction"
-    date: 2019-03-20
-    url: https://indico.cern.ch/event/759388/contributions/3303404/
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop
-    meetingurl: https://indico.cern.ch/event/759388
-    location: Jefferson Lab
-    focus-area: ia
-    project: pv-finder
-  - title: "A hybrid deep learning approach to vertexing"
-    date: 2019-03-11
-    url: https://indico.cern.ch/event/708041/contributions/3269692/attachments/1809272/2954230/PvFinder_ACAT2019.pdf
-    meeting: 19th International Workshop on Advanced Computing and Analysis Techniques in Physics Research
-    meetingurl: https://indico.cern.ch/event/708041/overview
-    location: Saas Fee, Switzerland
-    focus-area: ia
-    project: pv-finder
-  - title: "Histograms"
-    date: 2019-06-19
-    url: https://indico.cern.ch/event/822074/contributions/3471456/
-    meeting: IRIS-HEP Analysis Systems Topical Workshop
-    meetingurl: https://indico.cern.ch/event/822074/
-    focus-area: as
-    project: histogram
-    location: NYU, New York, NY
-  - title: "AmpGen & Particle/DecayLanguage"
-    date: 2019-06-19
-    url: https://indico.cern.ch/event/822074/contributions/3471460/
-    meeting: IRIS-HEP Analysis Systems Topical Workshop
-    meetingurl: https://indico.cern.ch/event/822074/
-    focus-area: as
-    project: [ampgen, particle, decaylanguage]
-    location: NYU, New York, NY
-  - title: Modern CMake
-    date: 2019-08-14
-    url: https://gitlab.com/CLIUtils/modern-cmake-interactive-talk
-    meeting: PICSciE Lunch Seminar
-    meetingurl: https://researchcomputing.princeton.edu/about
-    location: Princeton
-    focus-area: ssc
-    project:
-  - title: Modern CMake Workshop
-    date: 2019-08-20
-    url: https://henryiii.github.io/cmake_workshop/
-    meeting: USATLAS/FIRST-HEP Computing Bootcamp
-    meetingurl: https://indico.cern.ch/event/816946/
-    location: Lawrence Berkeley National Laboratory
-    focus-area: ssc
-    project:
-  - title: "Boost Histogram Roadmap"
-    date: 2019-09-12
-    url: https://indico.cern.ch/event/840472/contributions/3564389/
-    meeting: 2019 IRIS-HEP Institute Retreat
-    meetingurl: https://indico.cern.ch/event/840472/
-    location: Fermi National Accelerator Laboratory
-    project: histogram
-    focus-area: as
-  - title: "Histogramming and more"
-    date: 2019-09-13
-    url: https://indico.cern.ch/event/840472/contributions/3561801/
-    meeting: 2019 IRIS-HEP Institute Retreat
-    meetingurl: https://indico.cern.ch/event/840472/
-    location: Fermi National Accelerator Laboratory
-    project: histogram
-    focus-area: [as, ssc, ia]
-  - title: "Python 3.8: What's new"
-    date: 2019-10-17
-    url: https://indico.cern.ch/event/833895/contributions/3606920/
-    meeting: PyHEP 2019
-    meetingurl: https://indico.cern.ch/event/833895/
-    location: Abingdon, UK
-    focus-area: ssc
-    project:
-  - title: "Python Histogramming Packages"
-    date: 2019-10-17
-    url: https://indico.cern.ch/event/833895/contributions/3577833/
-    meeting: PyHEP 2019
-    meetingurl: https://indico.cern.ch/event/833895/
-    location: Abingdon, UK
-    focus-area: as
-    project: histogram
-  - title: "Boost-Histogram: Hands-on"
-    date: 2019-10-17
-    url: https://indico.cern.ch/event/833895/contributions/3577835/
-    meeting: PyHEP 2019
-    meetingurl: https://indico.cern.ch/event/833895/
-    location: Abingdon, UK
-    focus-area: as
-    project: histogram
-  - title: "Recent developments in histogram libraries"
-    date: 2019-11-07
-    url: https://indico.cern.ch/event/773049/contributions/3473265/
-    meeting: CHEP 2019
-    meetingurl: https://indico.cern.ch/event/773049/
-    location: Adelaide, South Australia
-    focus-area: as
-    project: histogram
-  - title: "High-Performance Python: CPUs"
-    date: 2019-11-20
-    url: https://github.com/henryiii/python-performance-minicourse
-    meeting: Princeton Research Computing Fall Mini-courses and Workshops
-    meetingurl: https://researchcomputing.princeton.edu/education/training/fall-2019-workshop-materials
-    location: Princeton University
-    focus-area: ssc
-    project:
-  - title: "High-Performance Python: GPUs"
-    date: 2019-12-05
-    url: https://github.com/henryiii/pygpu-minicourse
-    meeting: Princeton Research Computing Fall Mini-courses and Workshops
-    meetingurl: https://researchcomputing.princeton.edu/education/training/fall-2019-workshop-materials
-    location: Princeton University
-    focus-area: ssc
-    project:
-  - title: "Python, Numpy, and Pandas"
-    date: 2020-01-28
-    meeting: "Princeton Research Data Management Workshop 2020"
-    url: https://library.princeton.edu/news/research-data-service/2019-12-05/research-data-management-workshop-graduate-students-jan-27-29
-    meetingurl: https://researchcomputing.princeton.edu/events/research-data-management-workshop
-    location: Princeton University
-    focus-area: ssc
-    project:
-  - title: "International efforts on efficient computing"
-    date: 2020-02-18
-    url: https://indico.ph.ed.ac.uk/event/66/contributions/820/
-    meeting: "Workshop on Efficient Computing for High Energy Physics (ECHEP)"
-    meetingurl: https://indico.ph.ed.ac.uk/event/66
-    location: Edinburgh, UK
-    focus-area: core
-    project:
-  - title: "Boost-Histogram for Analysis Systems (poster)"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331172/5_-_BoostHistogram.pdf
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton, New Jersey, US
-    focus-area: as
-    project: histogram
-  - title: "Boost-histogram: High-Performance Histograms as Objects"
-    date: 2020-07-07
-    url: https://doi.org/10.25080/Majora-342d178e-01b
-    meetingurl: https://conference.scipy.org/proceedings/scipy2020/slides.html
-    meeting: 19th Python in Science Conference (SciPy 2020)
-    focus-area: as
-    project: histogram
-    location: Virtual
-  - title: "The boost-histogram package"
-    date: 2020-07-17
-    url: https://zenodo.org/record/4147611
-    meeting: PyHEP 2020 Workshop
-    meetingurl: https://indico.cern.ch/event/882824/
-    focus-area: as
-    project: histogram
-    location: Virtual
-  - title: "High-performance Python: CPUs"
-    date: 2020-11-04
-    url: https://researchcomputing.princeton.edu/events/high-performance-python-cpus-1
-    meeting: Princeton Research Computing Training Series
-    meetingurl: https://researchcomputing.princeton.edu/education/training
-    focus-area: ssc
-    project:
-    location: Virtual
-  - title: Mixing Python and Compiled Code
-    date: 2020-11-11
-    url: https://researchcomputing.princeton.edu/events/mixing-python-and-compiled-code-0
-    meeting: Princeton Research Computing Training Series
-    meetingurl: https://researchcomputing.princeton.edu/education/training
-    focus-area: ssc
-    project:
-    location: Virtual
-  - title: "High-performance Python: CPUs"
-    date: 2020-11-18
-    url: https://researchcomputing.princeton.edu/events/high-performance-python-gpus-0
-    meeting: Princeton Research Computing Training Series
-    meetingurl: https://researchcomputing.princeton.edu/education/training
-    focus-area: ssc
-    project:
-    location: Virtual
-  - title: Building a Python library
-    date: 2020-11-04
-    url: https://github.com/henryiii/building_a_python_library
-    meeting: Princeton RSE group
-    focus-area: ssc
-    project:
-    location: Virtual
-  - title: Level Up Your Python
-    date: 2021-01-20
-    url: https://princetonuniversity.github.io/PUbootcamp_winter2021/sessions/W1B-level-up-python/
-    meetingurl: https://princetonuniversity.github.io/PUbootcamp_winter2021/agenda/
-    meeting: Princeton Research Computing Bootcamp, Spring 2021
-    focus-area: ssc
-    project:
-    location: Virtual
-  - title: "CMake: Best Practices"
-    date: 2021-02-02
-    url: https://indico.jlab.org/event/420/#10-cmake-best-practices
-    meetingurl: https://indico.jlab.org/event/420/
-    meeting: Software & Computing Round Table
-    focus-area: ssc
-    project:
-    location: Virtual
+- title: A hybrid deep learning approach to vertexing
+  date: 2019-04-17
+  url: https://indico.cern.ch/event/766872/contributions/3358003/
+  meeting: 3rd IML Machine Learning Workshop
+  meetingurl: https://indico.cern.ch/event/766872/
+  location: CERN
+  focus-area: ia
+  project: pv-finder
+- title: boost-histogram and hist
+  date: 2019-04-15
+  url: https://indico.cern.ch/event/803122/
+  meeting: IRIS-HEP Topical Meeting
+  meetingurl: https://indico.cern.ch/event/803122/
+  focus-area: as
+  project: histogram
+  location: Virtual
+- title: A hybrid deep learning approach to vertexing
+  date: 2019-04-03
+  url: https://indico.cern.ch/event/742793/contributions/3298730/
+  meeting: Connecting The Dots and Workshop on Intelligent Trackers 2019
+  meetingurl: https://indico.cern.ch/event/742793/
+  location: Valencia, Spain
+  focus-area: ia
+  project: pv-finder
+- title: 'Conda: a complete reproducible ROOT environment in under 5 minutes'
+  date: 2019-03-21
+  url: https://indico.cern.ch/event/759388/contributions/3306849/
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop
+  meetingurl: https://indico.cern.ch/event/759388
+  location: Jefferson Lab
+  focus-area: as
+  project: rootconda
+- title: Machine Learning for the Primary Vertex reconstruction
+  date: 2019-03-20
+  url: https://indico.cern.ch/event/759388/contributions/3303404/
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop
+  meetingurl: https://indico.cern.ch/event/759388
+  location: Jefferson Lab
+  focus-area: ia
+  project: pv-finder
+- title: A hybrid deep learning approach to vertexing
+  date: 2019-03-11
+  url: https://indico.cern.ch/event/708041/contributions/3269692/attachments/1809272/2954230/PvFinder_ACAT2019.pdf
+  meeting: 19th International Workshop on Advanced Computing and Analysis Techniques
+    in Physics Research
+  meetingurl: https://indico.cern.ch/event/708041/overview
+  location: Saas Fee, Switzerland
+  focus-area: ia
+  project: pv-finder
+- title: Histograms
+  date: 2019-06-19
+  url: https://indico.cern.ch/event/822074/contributions/3471456/
+  meeting: IRIS-HEP Analysis Systems Topical Workshop
+  meetingurl: https://indico.cern.ch/event/822074/
+  focus-area: as
+  project: histogram
+  location: NYU, New York, NY
+- title: AmpGen & Particle/DecayLanguage
+  date: 2019-06-19
+  url: https://indico.cern.ch/event/822074/contributions/3471460/
+  meeting: IRIS-HEP Analysis Systems Topical Workshop
+  meetingurl: https://indico.cern.ch/event/822074/
+  focus-area: as
+  project:
+  - ampgen
+  - particle
+  - decaylanguage
+  location: NYU, New York, NY
+- title: Modern CMake
+  date: 2019-08-14
+  url: https://gitlab.com/CLIUtils/modern-cmake-interactive-talk
+  meeting: PICSciE Lunch Seminar
+  meetingurl: https://researchcomputing.princeton.edu/about
+  location: Princeton
+  focus-area: ssc
+  project:
+- title: Modern CMake Workshop
+  date: 2019-08-20
+  url: https://henryiii.github.io/cmake_workshop/
+  meeting: USATLAS/FIRST-HEP Computing Bootcamp
+  meetingurl: https://indico.cern.ch/event/816946/
+  location: Lawrence Berkeley National Laboratory
+  focus-area: ssc
+  project:
+- title: Boost Histogram Roadmap
+  date: 2019-09-12
+  url: https://indico.cern.ch/event/840472/contributions/3564389/
+  meeting: 2019 IRIS-HEP Institute Retreat
+  meetingurl: https://indico.cern.ch/event/840472/
+  location: Fermi National Accelerator Laboratory
+  project: histogram
+  focus-area: as
+- title: Histogramming and more
+  date: 2019-09-13
+  url: https://indico.cern.ch/event/840472/contributions/3561801/
+  meeting: 2019 IRIS-HEP Institute Retreat
+  meetingurl: https://indico.cern.ch/event/840472/
+  location: Fermi National Accelerator Laboratory
+  project: histogram
+  focus-area:
+  - as
+  - ssc
+  - ia
+- title: 'Python 3.8: What''s new'
+  date: 2019-10-17
+  url: https://indico.cern.ch/event/833895/contributions/3606920/
+  meeting: PyHEP 2019
+  meetingurl: https://indico.cern.ch/event/833895/
+  location: Abingdon, UK
+  focus-area: ssc
+  project:
+- title: Python Histogramming Packages
+  date: 2019-10-17
+  url: https://indico.cern.ch/event/833895/contributions/3577833/
+  meeting: PyHEP 2019
+  meetingurl: https://indico.cern.ch/event/833895/
+  location: Abingdon, UK
+  focus-area: as
+  project: histogram
+- title: 'Boost-Histogram: Hands-on'
+  date: 2019-10-17
+  url: https://indico.cern.ch/event/833895/contributions/3577835/
+  meeting: PyHEP 2019
+  meetingurl: https://indico.cern.ch/event/833895/
+  location: Abingdon, UK
+  focus-area: as
+  project: histogram
+- title: Recent developments in histogram libraries
+  date: 2019-11-07
+  url: https://indico.cern.ch/event/773049/contributions/3473265/
+  meeting: CHEP 2019
+  meetingurl: https://indico.cern.ch/event/773049/
+  location: Adelaide, South Australia
+  focus-area: as
+  project: histogram
+- title: 'High-Performance Python: CPUs'
+  date: 2019-11-20
+  url: https://github.com/henryiii/python-performance-minicourse
+  meeting: Princeton Research Computing Fall Mini-courses and Workshops
+  meetingurl: https://researchcomputing.princeton.edu/education/training/fall-2019-workshop-materials
+  location: Princeton University
+  focus-area: ssc
+  project:
+- title: 'High-Performance Python: GPUs'
+  date: 2019-12-05
+  url: https://github.com/henryiii/pygpu-minicourse
+  meeting: Princeton Research Computing Fall Mini-courses and Workshops
+  meetingurl: https://researchcomputing.princeton.edu/education/training/fall-2019-workshop-materials
+  location: Princeton University
+  focus-area: ssc
+  project:
+- title: Python, Numpy, and Pandas
+  date: 2020-01-28
+  meeting: Princeton Research Data Management Workshop 2020
+  url: https://library.princeton.edu/news/research-data-service/2019-12-05/research-data-management-workshop-graduate-students-jan-27-29
+  meetingurl: https://researchcomputing.princeton.edu/events/research-data-management-workshop
+  location: Princeton University
+  focus-area: ssc
+  project:
+- title: International efforts on efficient computing
+  date: 2020-02-18
+  url: https://indico.ph.ed.ac.uk/event/66/contributions/820/
+  meeting: Workshop on Efficient Computing for High Energy Physics (ECHEP)
+  meetingurl: https://indico.ph.ed.ac.uk/event/66
+  location: Edinburgh, UK
+  focus-area: core
+  project:
+- title: Boost-Histogram for Analysis Systems (poster)
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331172/5_-_BoostHistogram.pdf
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton, New Jersey, US
+  focus-area: as
+  project: histogram
+- title: 'Boost-histogram: High-Performance Histograms as Objects'
+  date: 2020-07-07
+  url: https://doi.org/10.25080/Majora-342d178e-01b
+  meetingurl: https://conference.scipy.org/proceedings/scipy2020/slides.html
+  meeting: 19th Python in Science Conference (SciPy 2020)
+  focus-area: as
+  project: histogram
+  location: Virtual
+- title: The boost-histogram package
+  date: 2020-07-17
+  url: https://zenodo.org/record/4147611
+  meeting: PyHEP 2020 Workshop
+  meetingurl: https://indico.cern.ch/event/882824/
+  focus-area: as
+  project: histogram
+  location: Virtual
+- title: 'High-performance Python: CPUs'
+  date: 2020-11-04
+  url: https://researchcomputing.princeton.edu/events/high-performance-python-cpus-1
+  meeting: Princeton Research Computing Training Series
+  meetingurl: https://researchcomputing.princeton.edu/education/training
+  focus-area: ssc
+  project:
+  location: Virtual
+- title: Mixing Python and Compiled Code
+  date: 2020-11-11
+  url: https://researchcomputing.princeton.edu/events/mixing-python-and-compiled-code-0
+  meeting: Princeton Research Computing Training Series
+  meetingurl: https://researchcomputing.princeton.edu/education/training
+  focus-area: ssc
+  project:
+  location: Virtual
+- title: 'High-performance Python: CPUs'
+  date: 2020-11-18
+  url: https://researchcomputing.princeton.edu/events/high-performance-python-gpus-0
+  meeting: Princeton Research Computing Training Series
+  meetingurl: https://researchcomputing.princeton.edu/education/training
+  focus-area: ssc
+  project:
+  location: Virtual
+- title: Building a Python library
+  date: 2020-11-04
+  url: https://github.com/henryiii/building_a_python_library
+  meeting: Princeton RSE group
+  focus-area: ssc
+  project:
+  location: Virtual
+- title: Level Up Your Python
+  date: 2021-01-20
+  url: https://princetonuniversity.github.io/PUbootcamp_winter2021/sessions/W1B-level-up-python/
+  meetingurl: https://princetonuniversity.github.io/PUbootcamp_winter2021/agenda/
+  meeting: Princeton Research Computing Bootcamp, Spring 2021
+  focus-area: ssc
+  project:
+  location: Virtual
+- title: 'CMake: Best Practices'
+  date: 2021-02-02
+  url: https://indico.jlab.org/event/420/#10-cmake-best-practices
+  meetingurl: https://indico.jlab.org/event/420/
+  meeting: Software & Computing Round Table
+  focus-area: ssc
+  project:
+  location: Virtual

--- a/_data/people/hzhu16.yml
+++ b/_data/people/hzhu16.yml
@@ -1,12 +1,11 @@
----
-name: Huijun Zhu
-shortname: hzhu16
-title:
 active: true
-institution: University of Nebraska - Lincoln
-website:
-photo: "/assets/images/team/Huijun-Zhu.jpg"
-presentations:
 focus-area:
 - doma
 - osglhc
+institution: University of Nebraska - Lincoln
+name: Huijun Zhu
+photo: "/assets/images/team/Huijun-Zhu.jpg"
+shortname: hzhu16
+title:
+website:
+presentations:

--- a/_data/people/hzhu16.yml
+++ b/_data/people/hzhu16.yml
@@ -7,3 +7,6 @@ institution: University of Nebraska - Lincoln
 website:
 photo: "/assets/images/team/Huijun-Zhu.jpg"
 presentations:
+focus-area:
+- doma
+- osglhc

--- a/_data/people/hzhu16.yml
+++ b/_data/people/hzhu16.yml
@@ -1,8 +1,9 @@
+---
 name: Huijun Zhu
 shortname: hzhu16
 title:
 active: true
 institution: University of Nebraska - Lincoln
 website:
-photo: /assets/images/team/Huijun-Zhu.jpg
+photo: "/assets/images/team/Huijun-Zhu.jpg"
 presentations:

--- a/_data/people/ianna.yml
+++ b/_data/people/ianna.yml
@@ -1,9 +1,10 @@
+---
 name: Ianna Osborne
 shortname: ianna
 title: Research Software Engineer
 active: true
 institution: Princeton University
 website:
-photo: /assets/images/team/Ianna-Osborne.png
+photo: "/assets/images/team/Ianna-Osborne.png"
 e-mail: Ianna.Osborne@cern.ch
 presentations:

--- a/_data/people/ianna.yml
+++ b/_data/people/ianna.yml
@@ -1,10 +1,9 @@
----
+active: true
+e-mail: Ianna.Osborne@cern.ch
+institution: Princeton University
 name: Ianna Osborne
+photo: "/assets/images/team/Ianna-Osborne.png"
 shortname: ianna
 title: Research Software Engineer
-active: true
-institution: Princeton University
 website:
-photo: "/assets/images/team/Ianna-Osborne.png"
-e-mail: Ianna.Osborne@cern.ch
 presentations:

--- a/_data/people/ioifrim.yml
+++ b/_data/people/ioifrim.yml
@@ -1,8 +1,9 @@
+---
 name: Ioana Ifrim
 shortname: ioifrim
 title: Research Software Engineer
 active: true
 institution: Princeton University
 website:
-photo: /assets/images/team/Ioana-Ifrim.jpg
+photo: "/assets/images/team/Ioana-Ifrim.jpg"
 presentations:

--- a/_data/people/ioifrim.yml
+++ b/_data/people/ioifrim.yml
@@ -1,9 +1,8 @@
----
-name: Ioana Ifrim
-shortname: ioifrim
-title: Research Software Engineer
 active: true
 institution: Princeton University
-website:
+name: Ioana Ifrim
 photo: "/assets/images/team/Ioana-Ifrim.jpg"
+shortname: ioifrim
+title: Research Software Engineer
+website:
 presentations:

--- a/_data/people/irinaene.yml
+++ b/_data/people/irinaene.yml
@@ -14,3 +14,5 @@ presentations:
   meetingurl: https://indico.cern.ch/event/945364/
   focus-area: ia
   project: acts
+focus-area:
+- ia

--- a/_data/people/irinaene.yml
+++ b/_data/people/irinaene.yml
@@ -1,11 +1,12 @@
----
+active: false
+focus-area:
+- ia
+institution: University of California, Berkeley
 name: Irina Ene
+photo: "/assets/images/team/Irina-Ene.jpg"
 shortname: irinaene
 title:
-active: false
-institution: University of California, Berkeley
 website:
-photo: "/assets/images/team/Irina-Ene.jpg"
 presentations:
 - title: Ambiguity Resolution in ACTS
   date: 2020-09-02
@@ -14,5 +15,3 @@ presentations:
   meetingurl: https://indico.cern.ch/event/945364/
   focus-area: ia
   project: acts
-focus-area:
-- ia

--- a/_data/people/irinaene.yml
+++ b/_data/people/irinaene.yml
@@ -1,15 +1,16 @@
+---
 name: Irina Ene
 shortname: irinaene
 title:
 active: false
 institution: University of California, Berkeley
 website:
-photo: /assets/images/team/Irina-Ene.jpg
+photo: "/assets/images/team/Irina-Ene.jpg"
 presentations:
-  - title: Ambiguity Resolution in ACTS
-    date: 2020-09-02
-    url: https://indico.cern.ch/event/945364/contributions/3972551/attachments/2095760/3522537/IrinaEne-IRIS-HEP_topical_meeting_090220.pdf
-    meeting: IRIS-HEP topical meeting
-    meetingurl: https://indico.cern.ch/event/945364/
-    focus-area: ia
-    project: acts
+- title: Ambiguity Resolution in ACTS
+  date: 2020-09-02
+  url: https://indico.cern.ch/event/945364/contributions/3972551/attachments/2095760/3522537/IrinaEne-IRIS-HEP_topical_meeting_090220.pdf
+  meeting: IRIS-HEP topical meeting
+  meetingurl: https://indico.cern.ch/event/945364/
+  focus-area: ia
+  project: acts

--- a/_data/people/irinaespejo.yml
+++ b/_data/people/irinaespejo.yml
@@ -1,11 +1,13 @@
----
+active: true
+focus-area:
+- as
+- ia
+institution: New York University
 name: Irina Espejo
+photo: "/assets/images/team/irinaespejo.jpeg"
 shortname: irinaespejo
 title:
-active: true
-institution: New York University
 website:
-photo: "/assets/images/team/irinaespejo.jpeg"
 presentations:
 - title: 'SCAILFIN: Madminer deployment using REANA'
   date: 2019-06-19
@@ -32,6 +34,3 @@ presentations:
   meeting: Frontiers in Machine Learning for the Physical Sciences, UC Southern Hub
   meetingurl: https://sites.research.uci.edu/frontiers-machine-learning/symposium/
   location: Virtual
-focus-area:
-- as
-- ia

--- a/_data/people/irinaespejo.yml
+++ b/_data/people/irinaespejo.yml
@@ -32,3 +32,6 @@ presentations:
   meeting: Frontiers in Machine Learning for the Physical Sciences, UC Southern Hub
   meetingurl: https://sites.research.uci.edu/frontiers-machine-learning/symposium/
   location: Virtual
+focus-area:
+- as
+- ia

--- a/_data/people/irinaespejo.yml
+++ b/_data/people/irinaespejo.yml
@@ -1,33 +1,34 @@
+---
 name: Irina Espejo
 shortname: irinaespejo
 title:
 active: true
 institution: New York University
 website:
-photo: /assets/images/team/irinaespejo.jpeg
+photo: "/assets/images/team/irinaespejo.jpeg"
 presentations:
-  - title: "SCAILFIN: Madminer deployment using REANA"
-    date: 2019-06-19
-    url: https://indico.cern.ch/event/822074/contributions/3471463/
-    meeting: Analysis Systems Topical Meeting
-    meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
-    location: NYU
-    focus-area: as
-  - title: "Scalable cyberinfraestructure applications"
-    date: 2020-02-27
-    url: https://sites.research.uci.edu/frontiers-machine-learning/symposium/
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton
-  - title: "Excursion: Efficient Reinterpretation Campaigns with Active Learning"
-    date: 2020-10-27
-    url: https://indico.cern.ch/event/960587/contributions/4081701/
-    meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
-    meetingurl: https://indico.cern.ch/event/960587/
-    location: Virtual
-  - title: "Excursion - Active Learning and Gaussian Processes for black box inference"
-    date: 2020-10-26
-    url: https://sites.research.uci.edu/frontiers-machine-learning/symposium/
-    meeting: Frontiers in Machine Learning for the Physical Sciences, UC Southern Hub
-    meetingurl: https://sites.research.uci.edu/frontiers-machine-learning/symposium/
-    location: Virtual
+- title: 'SCAILFIN: Madminer deployment using REANA'
+  date: 2019-06-19
+  url: https://indico.cern.ch/event/822074/contributions/3471463/
+  meeting: Analysis Systems Topical Meeting
+  meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
+  location: NYU
+  focus-area: as
+- title: Scalable cyberinfraestructure applications
+  date: 2020-02-27
+  url: https://sites.research.uci.edu/frontiers-machine-learning/symposium/
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton
+- title: 'Excursion: Efficient Reinterpretation Campaigns with Active Learning'
+  date: 2020-10-27
+  url: https://indico.cern.ch/event/960587/contributions/4081701/
+  meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
+  meetingurl: https://indico.cern.ch/event/960587/
+  location: Virtual
+- title: Excursion - Active Learning and Gaussian Processes for black box inference
+  date: 2020-10-26
+  url: https://sites.research.uci.edu/frontiers-machine-learning/symposium/
+  meeting: Frontiers in Machine Learning for the Physical Sciences, UC Southern Hub
+  meetingurl: https://sites.research.uci.edu/frontiers-machine-learning/symposium/
+  location: Virtual

--- a/_data/people/ivotron.yml
+++ b/_data/people/ivotron.yml
@@ -1,21 +1,24 @@
+---
 name: Ivo Jimenez
 shortname: ivotron
 title: Research Scientist
 active: true
 institution: UC Santa Cruz
 website: http://ivotron.me
-photo: /assets/images/team/ivotron.png
+photo: "/assets/images/team/ivotron.png"
 e-mail: ivotron@ucsc.edu
 presentations:
-- title: "Towards Arrow-native and Coffea Analysis Support in SkyhookDM"
+- title: Towards Arrow-native and Coffea Analysis Support in SkyhookDM
   date: 2020-10-27
   url: https://indico.cern.ch/event/960587/contributions/4077725/attachments/2130844/3588510/20201026-arrow-native-support-in-skyhook.pdf
   meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
   meetingurl: https://indico.cern.ch/event/960587/
   location: Virtual
-- title: "Enabling Seamless Execution of Computational and Data Science Workflows on HPC and Cloud with the Popper Container-Native Automation Engine"
+- title: Enabling Seamless Execution of Computational and Data Science Workflows on
+    HPC and Cloud with the Popper Container-Native Automation Engine
   date: 2020-11-12
   url: https://youtu.be/tV5HmKRanvA
-  meeting: "2020 2nd International Workshop on Containers and New Orchestration Paradigms for Isolated Environments in HPC (CANOPIE-HPC)"
+  meeting: 2020 2nd International Workshop on Containers and New Orchestration Paradigms
+    for Isolated Environments in HPC (CANOPIE-HPC)
   meetingurl: https://www.canopie-hpc.org/program/
   location: Virtual

--- a/_data/people/ivotron.yml
+++ b/_data/people/ivotron.yml
@@ -1,12 +1,13 @@
----
+active: true
+e-mail: ivotron@ucsc.edu
+focus-area:
+- doma
+institution: UC Santa Cruz
 name: Ivo Jimenez
+photo: "/assets/images/team/ivotron.png"
 shortname: ivotron
 title: Research Scientist
-active: true
-institution: UC Santa Cruz
 website: http://ivotron.me
-photo: "/assets/images/team/ivotron.png"
-e-mail: ivotron@ucsc.edu
 presentations:
 - title: Towards Arrow-native and Coffea Analysis Support in SkyhookDM
   date: 2020-10-27
@@ -22,5 +23,3 @@ presentations:
     for Isolated Environments in HPC (CANOPIE-HPC)
   meetingurl: https://www.canopie-hpc.org/program/
   location: Virtual
-focus-area:
-- doma

--- a/_data/people/ivotron.yml
+++ b/_data/people/ivotron.yml
@@ -22,3 +22,5 @@ presentations:
     for Isolated Environments in HPC (CANOPIE-HPC)
   meetingurl: https://www.canopie-hpc.org/program/
   location: Virtual
+focus-area:
+- doma

--- a/_data/people/jeyserma.yml
+++ b/_data/people/jeyserma.yml
@@ -1,7 +1,7 @@
----
-name: Jan Eysermans
-shortname: jeyserma
-title:
 active: true
 institution: Massachusetts Institute of Technology
+name: Jan Eysermans
 photo: "/assets/images/team/Jan-Eysermans.jpg"
+shortname: jeyserma
+title:
+presentations:

--- a/_data/people/jeyserma.yml
+++ b/_data/people/jeyserma.yml
@@ -1,6 +1,7 @@
+---
 name: Jan Eysermans
 shortname: jeyserma
 title:
 active: true
 institution: Massachusetts Institute of Technology
-photo: /assets/images/team/Jan-Eysermans.jpg
+photo: "/assets/images/team/Jan-Eysermans.jpg"

--- a/_data/people/jlefevre.yml
+++ b/_data/people/jlefevre.yml
@@ -1,12 +1,13 @@
----
+active: true
+e-mail: jlefevre@ucsc.edu
+focus-area:
+- doma
+institution: University of California, Santa Cruz
 name: Jeff LeFevre
+photo: "/assets/images/team/Jeff-LeFevre.jpg"
 shortname: jlefevre
 title:
-active: true
-institution: University of California, Santa Cruz
 website: https://users.soe.ucsc.edu/~jlefevre/
-photo: "/assets/images/team/Jeff-LeFevre.jpg"
-e-mail: jlefevre@ucsc.edu
 presentations:
 - title: SkyhookDB - Leveraging object storage toward database elasticity in the cloud
   date: 2017-11-16
@@ -51,5 +52,3 @@ presentations:
   meetingurl: https://www.fujitsu.com/jp/group/labs/en/
   focus-area: doma
   project: skyhookdm
-focus-area:
-- doma

--- a/_data/people/jlefevre.yml
+++ b/_data/people/jlefevre.yml
@@ -1,51 +1,53 @@
+---
 name: Jeff LeFevre
 shortname: jlefevre
 title:
 active: true
 institution: University of California, Santa Cruz
 website: https://users.soe.ucsc.edu/~jlefevre/
-photo: /assets/images/team/Jeff-LeFevre.jpg
+photo: "/assets/images/team/Jeff-LeFevre.jpg"
 e-mail: jlefevre@ucsc.edu
 presentations:
-  - title: SkyhookDB - Leveraging object storage toward database elasticity in the cloud
-    date: 2017-11-16
-    url: https://indico.cern.ch/event/669506/contributions/2782611/attachments/1560226/2455903/jlefevre-skyhookdb-20171116-flatiron.pdf
-    meeting: DOMA Workshop 2017 (Flatiron Institute)
-    meetingurl: https://indico.cern.ch/event/669506/
-    focus-area: doma
-    project: skyhookdm
-  - title: "Skyhook: programmable storage for databases"
-    date: 2019-02-26
-    url: https://users.soe.ucsc.edu/~jlefevre/skyhookdb/Skyhook-JeffNoah-Vault19.pdf
-    meeting: Vault'19
-    meetingurl: https://www.usenix.org/conference/vault19
-    focus-area: doma
-    project: skyhookdm
-  - title: "Skyhook: Programmable Object Storage for Analysis"
-    date: 2019-04-24
-    url: https://indico.cern.ch/event/813447/contributions/3392127/attachments/1834797/3005672/skyhook-iris-hep-topical-meeting-20190424.pdf
-    meeting: "IRIS-HEP Topical Meetings"
-    meetingurl: https://indico.cern.ch/event/813447/
-    focus-area: doma
-    project: skyhookdm
-  - title: "Skyhook Data Management: Scaling Databases and Applications with Open Source Extensible Storage"
-    date: 2019-10-03
-    url: https://cross.ucsc.edu/2019-symposium/
-    meeting: "CROSS Research Symposium 2019"
-    meetingurl: https://cross.ucsc.edu/2019-symposium/
-    focus-area: doma
-    project: skyhookdm
-  - title: "Mapping datasets to object storage"
-    date: 2019-11-05
-    url: https://indico.cern.ch/event/773049/contributions/3474413/attachments/1936811/3213825/CHEP2019-Mapping_datasets_to_object_storage.pdf
-    meeting: "CHEP 2019"
-    meetingurl: https://indico.cern.ch/event/773049/contributions/3474413/
-    focus-area: doma
-    project: skyhookdm
-  - title: "Skyhook Data Management: programmable object storage for databases"
-    date: 2020-05-26
-    url: https://drive.google.com/file/d/11uG0dJxxGfyc4RZ60dChU22nzO-dWL78/view?usp=sharing
-    meeting: "Fujitsu Labs"
-    meetingurl: https://www.fujitsu.com/jp/group/labs/en/
-    focus-area: doma
-    project: skyhookdm
+- title: SkyhookDB - Leveraging object storage toward database elasticity in the cloud
+  date: 2017-11-16
+  url: https://indico.cern.ch/event/669506/contributions/2782611/attachments/1560226/2455903/jlefevre-skyhookdb-20171116-flatiron.pdf
+  meeting: DOMA Workshop 2017 (Flatiron Institute)
+  meetingurl: https://indico.cern.ch/event/669506/
+  focus-area: doma
+  project: skyhookdm
+- title: 'Skyhook: programmable storage for databases'
+  date: 2019-02-26
+  url: https://users.soe.ucsc.edu/~jlefevre/skyhookdb/Skyhook-JeffNoah-Vault19.pdf
+  meeting: Vault'19
+  meetingurl: https://www.usenix.org/conference/vault19
+  focus-area: doma
+  project: skyhookdm
+- title: 'Skyhook: Programmable Object Storage for Analysis'
+  date: 2019-04-24
+  url: https://indico.cern.ch/event/813447/contributions/3392127/attachments/1834797/3005672/skyhook-iris-hep-topical-meeting-20190424.pdf
+  meeting: IRIS-HEP Topical Meetings
+  meetingurl: https://indico.cern.ch/event/813447/
+  focus-area: doma
+  project: skyhookdm
+- title: 'Skyhook Data Management: Scaling Databases and Applications with Open Source
+    Extensible Storage'
+  date: 2019-10-03
+  url: https://cross.ucsc.edu/2019-symposium/
+  meeting: CROSS Research Symposium 2019
+  meetingurl: https://cross.ucsc.edu/2019-symposium/
+  focus-area: doma
+  project: skyhookdm
+- title: Mapping datasets to object storage
+  date: 2019-11-05
+  url: https://indico.cern.ch/event/773049/contributions/3474413/attachments/1936811/3213825/CHEP2019-Mapping_datasets_to_object_storage.pdf
+  meeting: CHEP 2019
+  meetingurl: https://indico.cern.ch/event/773049/contributions/3474413/
+  focus-area: doma
+  project: skyhookdm
+- title: 'Skyhook Data Management: programmable object storage for databases'
+  date: 2020-05-26
+  url: https://drive.google.com/file/d/11uG0dJxxGfyc4RZ60dChU22nzO-dWL78/view?usp=sharing
+  meeting: Fujitsu Labs
+  meetingurl: https://www.fujitsu.com/jp/group/labs/en/
+  focus-area: doma
+  project: skyhookdm

--- a/_data/people/jlefevre.yml
+++ b/_data/people/jlefevre.yml
@@ -51,3 +51,5 @@ presentations:
   meetingurl: https://www.fujitsu.com/jp/group/labs/en/
   focus-area: doma
   project: skyhookdm
+focus-area:
+- doma

--- a/_data/people/johannbrehmer.yml
+++ b/_data/people/johannbrehmer.yml
@@ -1,176 +1,184 @@
+---
 name: Johann Brehmer
 shortname: johannbrehmer
 title:
 active: false
 institution: New York University
 website: https://johannbrehmer.github.io
-photo: /assets/images/team/Johann-Brehmer.jpg
+photo: "/assets/images/team/Johann-Brehmer.jpg"
 presentations:
-  - title: "How machine learning can help us get the most out of high-precision particle physics models"
-    date: 2020-11-23
-    url: https://www.jlab.org/sites/default/files/theory/files/simulation_based_inference_jlab_2020.pdf
-    meeting: JLab theory seminar
-    meetingurl: https://www.jlab.org/theory/seminars/theorysem
-    location: Jefferson Lab, USA
-    focus-area: as
-    project: madminer
-  - title: "How machine learning can help us get the most out of high-precision particle physics models"
-    date: 2020-11-12
-    url: https://theorieseminar.desy.de/sites2009/site_theorieseminar/content/e41199/e308614/Brehmer121120.pdf
-    meeting: DESY-HU theory seminar
-    meetingurl: https://theorieseminar.desy.de/zeuthen/
-    location: Berlin, Germany
-    focus-area: as
-    project: madminer
-  - title: "NOTAGAN: Normalizing flows for simultaneous manifold learning and density estimation"
-    date: 2020-07-18
-    url: https://invertibleworkshop.github.io/accepted_papers/index.html
-    meeting: "INNF+: Invertible Neural Networks, Normalizing Flows, and Explicit Likelihood Models"
-    meetingurl: https://invertibleworkshop.github.io/
-    location: remote
-    focus-area: as
-    project:
-  - title: "Flows for simultaneous manifold learning and density estimation"
-    date: 2020-07-15
-    url:
-    meeting: mlclub.net
-    meetingurl:
-    location: remote
-    focus-area: as
-    project:
-  - title: "Mining for Dark Matter substructure:  Learning from lenses without a likelihood"
-    date: 2020-02-17
-    url: https://ithems.riken.jp/ja/events/mining-for-dark-matter-substructure-learning-from-lenses-without-a-likelihood
-    meeting: Dark Matter Working Group seminar
-    meetingurl:
-    location: RIKEN, Tokyo, Japan
-    focus-area: as
-    project: madminer
-  - title: The frontier of simulation-based inference
-    date: 2020-02-05
-    url: https://agenda.hepl.phys.nagoya-u.ac.jp/indico/contributionDisplay.py?sessionId=1&contribId=6&confId=1336
-    meeting: Workshop on Machine Learning at the LHC
-    meetingurl: https://agenda.hepl.phys.nagoya-u.ac.jp/indico/conferenceDisplay.py?confId=1336
-    location: Nagoya University, Japan
-    focus-area: as
-    project: madminer
-  - title: Normalizing flows and the likelihood ratio trick in particle physics
-    date: 2020-01-06
-    url:
-    meeting: Deep learning seminar
-    meetingurl:
-    location: University of Bremen, Germany
-    focus-area: as
-    project: madminer
-  - title: "Mining gold: Improving simulation-based inference with latent information (poster)"
-    date: 2019-12-14
-    url: https://ml4physicalsciences.github.io/files/NeurIPS_ML4PS_2019_16.pdf
-    meeting: NeurIPS 2019 workshop on Machine Learning and the Physical Sciences
-    meetingurl: https://ml4physicalsciences.github.io
-    location: Vancouver, Canada
-    focus-area: as
-    project: madminer
-  - title: MadMiner Update
-    date: 2019-06-19
-    url: https://indico.cern.ch/event/822074/contributions/3471461/
-    meeting: Analysis Systems Topical Meeting
-    meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
-    location: NYU
-    focus-area: as
-    project: madminer
-  - title: "Constraining effective field theories with machine learning"
-    date: 2019-06-06
-    url:
-    meeting: INFN Padova seminar
-    meetingurl:
-    location: Padova, Italy
-    focus-area: as
-    project: madminer
-  - title: "Constraining effective field theories with machine learning"
-    date: 2019-04-18
-    url: https://agenda.irmp.ucl.ac.be/event/3283/contributions/3930/
-    meeting: Higgs and Effective Field Theory 2019
-    meetingurl: https://agenda.irmp.ucl.ac.be/event/3283/
-    location: Louvain-la-Neuve, Belgium
-    focus-area: as
-    project: madminer
-  - title: "'Mining gold' from simulators to improve likelihood-free inference"
-    date: 2019-03-18
-    url: https://lfitaskforce.github.io/FlatironMeeting/
-    meeting: Likelihood-free inference workshop
-    meetingurl: https://lfitaskforce.github.io/FlatironMeeting/
-    location: New York, USA
-    focus-area: as
-    project: madminer
-  - title: "Keynote: Constraining effective field theories with machine learning"
-    date: 2019-03-14
-    url: https://indico.cern.ch/event/708041/contributions/3308812/
-    meeting: International Workshop on Advanced Computing and Analysis Techniques in Physics Research
-    meetingurl: https://indico.cern.ch/event/708041/
-    location: Saas-Fee, Switzerland
-    focus-area: as
-    project: madminer
-  - title: "Bringing together simulations, physics insight, and machine learning to constrain new physics"
-    date: 2019-02-28
-    url: https://www.brandeis.edu/physics/news-events/dark-universe.html
-    meeting: Dark universe seminar
-    meetingurl: https://www.brandeis.edu/physics/news-events/dark-universe.html
-    location: Brandeis University, Boston, USA
-    focus-area: as
-    project: madminer
-  - title: "Meticulous measurements with matrix elements and machine learning"
-    date: 2019-01-14
-    url: https://pages.uoregon.edu/its/seminars/
-    meeting: ITS/CHEP joint seminar
-    meetingurl: https://pages.uoregon.edu/its/seminars/
-    location: U Oregon, Eugene, USA
-    focus-area: as
-    project: madminer
-  - title: Improving inference with matrix elements and machine learning
-    date: 2019-01-11
-    url: http://ias.ust.hk/program/shared_doc/2019/201901hep/program/20190111_4042_pm_Johann_Brehmer.pdf
-    meeting: HK IAS Program on High Energy Physics
-    meetingurl: http://iasprogram.ust.hk/hep/2019/
-    location: Hong Kong
-    focus-area: as
-    project: madminer
-  - title: Learning to constrain new physics
-    date: 2018-09-20
-    url: https://conference.ippp.dur.ac.uk/event/738/
-    meeting: IPPP seminar
-    meetingurl: https://phy.princeton.edu/events
-    location: Durham, UK
-    focus-area: as
-    project: madminer
-  - title: Learning to constrain new physics
-    date: 2018-09-13
-    url: https://phy.princeton.edu/events/pheno-vino-seminar-johann-brehmer-nyu-learning-constrain-new-physics-jadwin-111
-    meeting: Pheno & Vino Seminar
-    meetingurl: https://phy.princeton.edu/events/pheno-vino-seminar-johann-brehmer-nyu-learning-constrain-new-physics-jadwin-111
-    location: Princeton University, USA
-    focus-area: as
-    project: madminer
-  - title: Learning to constrain new physics
-    date: 2018-08-27
-    url: https://mcfp.physics.umd.edu/images/EPTSeminarSlides/Johann_Brehmer_Aug2018.pdf
-    meeting: Elementary particle seminar
-    meetingurl: http://www.physics.umd.edu/ep/seminars/
-    location: University of Maryland, USA
-    focus-area: as
-    project: madminer
-  - title: Machine Learning to Probe a BSM Higgs Sector
-    date: 2018-07-23
-    url: https://indico.lal.in2p3.fr/event/4754/#sc-19-8-machine-learning-to-pr
-    meeting: Higgs Hunting
-    meetingurl: http://wpsist.lal.in2p3.fr/higgshunting2018/
-    location: Paris, France
-    focus-area: as
-    project: madminer
-  - title: Constraining Effective Theories with Machine Learning
-    date: 2018-06-27
-    url:  https://www.bnl.gov/physics/HET/events/
-    meeting: Theory seminar
-    meetingurl: https://www.bnl.gov/physics/HET/events/
-    location: Brookhaven National Lab, USA
-    focus-area: as
-    project: madminer
+- title: How machine learning can help us get the most out of high-precision particle
+    physics models
+  date: 2020-11-23
+  url: https://www.jlab.org/sites/default/files/theory/files/simulation_based_inference_jlab_2020.pdf
+  meeting: JLab theory seminar
+  meetingurl: https://www.jlab.org/theory/seminars/theorysem
+  location: Jefferson Lab, USA
+  focus-area: as
+  project: madminer
+- title: How machine learning can help us get the most out of high-precision particle
+    physics models
+  date: 2020-11-12
+  url: https://theorieseminar.desy.de/sites2009/site_theorieseminar/content/e41199/e308614/Brehmer121120.pdf
+  meeting: DESY-HU theory seminar
+  meetingurl: https://theorieseminar.desy.de/zeuthen/
+  location: Berlin, Germany
+  focus-area: as
+  project: madminer
+- title: 'NOTAGAN: Normalizing flows for simultaneous manifold learning and density
+    estimation'
+  date: 2020-07-18
+  url: https://invertibleworkshop.github.io/accepted_papers/index.html
+  meeting: 'INNF+: Invertible Neural Networks, Normalizing Flows, and Explicit Likelihood
+    Models'
+  meetingurl: https://invertibleworkshop.github.io/
+  location: remote
+  focus-area: as
+  project:
+- title: Flows for simultaneous manifold learning and density estimation
+  date: 2020-07-15
+  url:
+  meeting: mlclub.net
+  meetingurl:
+  location: remote
+  focus-area: as
+  project:
+- title: 'Mining for Dark Matter substructure:     Learning from lenses without a likelihood'
+  date: 2020-02-17
+  url: https://ithems.riken.jp/ja/events/mining-for-dark-matter-substructure-learning-from-lenses-without-a-likelihood
+  meeting: Dark Matter Working Group seminar
+  meetingurl:
+  location: RIKEN, Tokyo, Japan
+  focus-area: as
+  project: madminer
+- title: The frontier of simulation-based inference
+  date: 2020-02-05
+  url: https://agenda.hepl.phys.nagoya-u.ac.jp/indico/contributionDisplay.py?sessionId=1&contribId=6&confId=1336
+  meeting: Workshop on Machine Learning at the LHC
+  meetingurl: https://agenda.hepl.phys.nagoya-u.ac.jp/indico/conferenceDisplay.py?confId=1336
+  location: Nagoya University, Japan
+  focus-area: as
+  project: madminer
+- title: Normalizing flows and the likelihood ratio trick in particle physics
+  date: 2020-01-06
+  url:
+  meeting: Deep learning seminar
+  meetingurl:
+  location: University of Bremen, Germany
+  focus-area: as
+  project: madminer
+- title: 'Mining gold: Improving simulation-based inference with latent information
+    (poster)'
+  date: 2019-12-14
+  url: https://ml4physicalsciences.github.io/files/NeurIPS_ML4PS_2019_16.pdf
+  meeting: NeurIPS 2019 workshop on Machine Learning and the Physical Sciences
+  meetingurl: https://ml4physicalsciences.github.io
+  location: Vancouver, Canada
+  focus-area: as
+  project: madminer
+- title: MadMiner Update
+  date: 2019-06-19
+  url: https://indico.cern.ch/event/822074/contributions/3471461/
+  meeting: Analysis Systems Topical Meeting
+  meetingurl: https://indico.cern.ch/event/822074/timetable/#20190620
+  location: NYU
+  focus-area: as
+  project: madminer
+- title: Constraining effective field theories with machine learning
+  date: 2019-06-06
+  url:
+  meeting: INFN Padova seminar
+  meetingurl:
+  location: Padova, Italy
+  focus-area: as
+  project: madminer
+- title: Constraining effective field theories with machine learning
+  date: 2019-04-18
+  url: https://agenda.irmp.ucl.ac.be/event/3283/contributions/3930/
+  meeting: Higgs and Effective Field Theory 2019
+  meetingurl: https://agenda.irmp.ucl.ac.be/event/3283/
+  location: Louvain-la-Neuve, Belgium
+  focus-area: as
+  project: madminer
+- title: "'Mining gold' from simulators to improve likelihood-free inference"
+  date: 2019-03-18
+  url: https://lfitaskforce.github.io/FlatironMeeting/
+  meeting: Likelihood-free inference workshop
+  meetingurl: https://lfitaskforce.github.io/FlatironMeeting/
+  location: New York, USA
+  focus-area: as
+  project: madminer
+- title: 'Keynote: Constraining effective field theories with machine learning'
+  date: 2019-03-14
+  url: https://indico.cern.ch/event/708041/contributions/3308812/
+  meeting: International Workshop on Advanced Computing and Analysis Techniques in
+    Physics Research
+  meetingurl: https://indico.cern.ch/event/708041/
+  location: Saas-Fee, Switzerland
+  focus-area: as
+  project: madminer
+- title: Bringing together simulations, physics insight, and machine learning to constrain
+    new physics
+  date: 2019-02-28
+  url: https://www.brandeis.edu/physics/news-events/dark-universe.html
+  meeting: Dark universe seminar
+  meetingurl: https://www.brandeis.edu/physics/news-events/dark-universe.html
+  location: Brandeis University, Boston, USA
+  focus-area: as
+  project: madminer
+- title: Meticulous measurements with matrix elements and machine learning
+  date: 2019-01-14
+  url: https://pages.uoregon.edu/its/seminars/
+  meeting: ITS/CHEP joint seminar
+  meetingurl: https://pages.uoregon.edu/its/seminars/
+  location: U Oregon, Eugene, USA
+  focus-area: as
+  project: madminer
+- title: Improving inference with matrix elements and machine learning
+  date: 2019-01-11
+  url: http://ias.ust.hk/program/shared_doc/2019/201901hep/program/20190111_4042_pm_Johann_Brehmer.pdf
+  meeting: HK IAS Program on High Energy Physics
+  meetingurl: http://iasprogram.ust.hk/hep/2019/
+  location: Hong Kong
+  focus-area: as
+  project: madminer
+- title: Learning to constrain new physics
+  date: 2018-09-20
+  url: https://conference.ippp.dur.ac.uk/event/738/
+  meeting: IPPP seminar
+  meetingurl: https://phy.princeton.edu/events
+  location: Durham, UK
+  focus-area: as
+  project: madminer
+- title: Learning to constrain new physics
+  date: 2018-09-13
+  url: https://phy.princeton.edu/events/pheno-vino-seminar-johann-brehmer-nyu-learning-constrain-new-physics-jadwin-111
+  meeting: Pheno & Vino Seminar
+  meetingurl: https://phy.princeton.edu/events/pheno-vino-seminar-johann-brehmer-nyu-learning-constrain-new-physics-jadwin-111
+  location: Princeton University, USA
+  focus-area: as
+  project: madminer
+- title: Learning to constrain new physics
+  date: 2018-08-27
+  url: https://mcfp.physics.umd.edu/images/EPTSeminarSlides/Johann_Brehmer_Aug2018.pdf
+  meeting: Elementary particle seminar
+  meetingurl: http://www.physics.umd.edu/ep/seminars/
+  location: University of Maryland, USA
+  focus-area: as
+  project: madminer
+- title: Machine Learning to Probe a BSM Higgs Sector
+  date: 2018-07-23
+  url: https://indico.lal.in2p3.fr/event/4754/#sc-19-8-machine-learning-to-pr
+  meeting: Higgs Hunting
+  meetingurl: http://wpsist.lal.in2p3.fr/higgshunting2018/
+  location: Paris, France
+  focus-area: as
+  project: madminer
+- title: Constraining Effective Theories with Machine Learning
+  date: 2018-06-27
+  url: https://www.bnl.gov/physics/HET/events/
+  meeting: Theory seminar
+  meetingurl: https://www.bnl.gov/physics/HET/events/
+  location: Brookhaven National Lab, USA
+  focus-area: as
+  project: madminer

--- a/_data/people/johannbrehmer.yml
+++ b/_data/people/johannbrehmer.yml
@@ -1,11 +1,13 @@
----
+active: false
+focus-area:
+- as
+- ia
+institution: New York University
 name: Johann Brehmer
+photo: "/assets/images/team/Johann-Brehmer.jpg"
 shortname: johannbrehmer
 title:
-active: false
-institution: New York University
 website: https://johannbrehmer.github.io
-photo: "/assets/images/team/Johann-Brehmer.jpg"
 presentations:
 - title: How machine learning can help us get the most out of high-precision particle
     physics models
@@ -182,6 +184,3 @@ presentations:
   location: Brookhaven National Lab, USA
   focus-area: as
   project: madminer
-focus-area:
-- as
-- ia

--- a/_data/people/johannbrehmer.yml
+++ b/_data/people/johannbrehmer.yml
@@ -182,3 +182,6 @@ presentations:
   location: Brookhaven National Lab, USA
   focus-area: as
   project: madminer
+focus-area:
+- as
+- ia

--- a/_data/people/jpivarski.yml
+++ b/_data/people/jpivarski.yml
@@ -1,288 +1,328 @@
+---
 name: Jim Pivarski
 shortname: jpivarski
 title:
 active: true
 institution: Princeton University
 website: https://github.com/jpivarski
-photo: /assets/images/team/Jim-Pivarski.jpg
-
+photo: "/assets/images/team/Jim-Pivarski.jpg"
 presentations:
-
-  - title: "Nested data structures in array and SIMD frameworks"
-    date: 2019-03-14
-    url: https://indico.cern.ch/event/708041/contributions/3276200/attachments/1810057/2955674/pivarski-acat2019.pdf
-    meeting: "ACAT 2019"
-    meetingurl: https://indico.cern.ch/event/708041/
-    location: "Saas-Fee, Switzerland"
-    focus-area: [as]
-    project: [awkward]
-
-  - title: "PyROOT, uproot, and awkward-arrays"
-    date: 2019-04-01
-    url: https://github.com/jpivarski/2019-04-01-fermilab-carpentries
-    meeting: "Software Carpentry at Fermilab"
-    meetingurl: https://davidyakobovitch.github.io/2019-04-01_fnal/
-    location: "Fermilab"
-    focus-area: [as, ssc]
-    project: [uproot, awkward]
-
-  - title: "High-Performance Python and Interoperability with Compiled Code"
-    date: 2019-04-08
-    url: https://github.com/jpivarski/2019-04-08-picscie-numpy
-    meeting: "Princeton PICSciE mini-courses"
-    meetingurl: https://researchcomputing.princeton.edu/events/high-performance-python-and-interoperability-compiled-code-48-410
-    location: "Princeton University"
-    focus-area: [as, ssc]
-    project:
-
-  - title: "Aghast"
-    date: 2019-04-15
-    url: https://indico.cern.ch/event/803122/contributions/3339215/attachments/1830076/2996786/pivarski-2019-04-15-irishep-aghast.pdf
-    meeting: "IRIS-HEP Topical Meetings"
-    meetingurl: https://indico.cern.ch/event/803122/
-    location: "online"
-    focus-area: [as]
-    project: [histogram]
-
-  - title: "Awkward Array: Numba"
-    date: 2019-04-17
-    url: https://indico.cern.ch/event/808630/contributions/3367657/attachments/1830385/2997458/pivarski-2019-04-17-irishep-awkwardnumba.pdf
-    meeting: "IRIS-HEP Topical Meetings"
-    meetingurl: https://indico.cern.ch/event/808630/
-    location: "online"
-    focus-area: [as]
-    project: [awkward]
-
-  - title: "Skyhook for query systems"
-    date: 2019-04-24
-    url: https://indico.cern.ch/event/813447/contributions/3396060/attachments/1833398/3003091/pivarski-2019-04-24-irishep-skyhook.pdf
-    meeting: "IRIS-HEP Topical Meetings"
-    meetingurl: https://indico.cern.ch/event/813447/
-    location: "online"
-    focus-area: [as]
-    project: [skyhookdm]
-
-  - title: "How to build your own language (hands-on demo)"
-    date: 2019-05-06
-    url: https://github.com/jpivarski/2019-05-06-adl-language-tools
-    meeting: "Analysis Description Languages Workshop"
-    meetingurl: https://indico.cern.ch/event/769263/timetable/
-    location: "Fermilab"
-    focus-area: [as, ssc]
-    project:
-
-  - title: "Programming languages and particle physics"
-    date: 2019-05-08
-    url: https://indico.cern.ch/event/769263/contributions/3420926/
-    meeting: "Fermilab Colloquium"
-    meetingurl: https://events.fnal.gov/colloquium/events/event/pivarski-colloq-2019/
-    location: "Fermilab"
-    focus-area: [as]
-    project:
-
-  - title: "Summary of the 'Analysis Description Languages for the LHC' workshop"
-    date: 2019-05-09
-    meeting: "LPC Physics Forum"
-    meetingurl: https://indico.cern.ch/event/806811/
-    url: https://indico.cern.ch/event/806811/#1-summary-of-the-analysis-desc
-    location: "Fermilab"
-    focus-area: [as]
-    project:
-
-  - title: "Pattern matching for decay trees"
-    date: 2019-05-22
-    meeting: "IRIS-HEP Topical Meetings"
-    meetingurl: https://indico.cern.ch/event/820598/
-    location: "online"
-    url: https://indico.cern.ch/event/820598/#2-pattern-matching-for-decay-t
-    focus-area: [as]
-    project:
-
-  - title: "Scientific Python and Uproot HATS"
-    date: 2019-05-28
-    meeting: "LPC HATS: Hands-on Training for CMS"
-    meetingurl: https://indico.cern.ch/event/814895/
-    location: "Fermilab"
-    url: https://indico.cern.ch/event/814895/
-    focus-area: [as]
-    project: [uproot]
-
-  - title: "Columnar Analysis Tools HATS"
-    date: 2019-05-29
-    meeting: "LPC HATS: Hands-on Training for CMS"
-    meetingurl: https://indico.cern.ch/event/814100/
-    url: https://indico.cern.ch/event/814100/
-    location: "Fermilab"
-    focus-area: [as]
-    project: [awkward]
-
-  - title: "Numpy, Pandas, PyROOT, and Uproot"
-    date: 2019-06-10
-    meeting: "U.S. ATLAS Software Training at Argonne National Lab"
-    meetingurl: https://indico.cern.ch/event/811577/
-    url: https://indico.cern.ch/event/811577/
-    location: "Argonne"
-    focus-area: [as]
-    project: [uproot]
-
-  - title: "Uproot: accessing ROOT data in the scientific Python ecosystem"
-    date: 2019-06-18
-    meeting: "3rd CMS Machine Learning Workshop"
-    meetingurl: https://indico.cern.ch/event/798721/
-    url: https://indico.cern.ch/event/798721/contributions/3461343/
-    location: "online"
-    focus-area: [as]
-    project: [uproot]
-
-  - title: "Update on awkward-array, uproot, and related projects"
-    date: 2019-06-19
-    meeting: "Analysis Systems Topical Workshop"
-    meetingurl: https://indico.cern.ch/event/822074/overview
-    url: https://indico.cern.ch/event/822074/contributions/3471451/
-    location: "NYU Physics Department"
-    focus-area: [as]
-    project: [uproot, awkward]
-
-  - title: "Motivation and requirements for awkward 1.0"
-    date: 2019-07-10
-    meeting: "Analysis Systems Biweekly Meeting"
-    url: https://indico.cern.ch/event/815512/
-    meetingurl:
-    location: "online"
-    focus-area: [as]
-    project: [awkward]
-
-  - title: "Scientific Python Ecosystem; Columnar Data Analysis; Accelerating Python"
-    date: 2019-07-23
-    meeting: "Third Computational and Data Science for High Energy Physics (CoDaS-HEP) School"
-    meetingurl: http://codas-hep.org/
-    url: https://github.com/jpivarski/2019-07-23-codas-hep#readme
-    location: "Princeton University"
-    focus-area: [as, ssc]
-    project:
-
-  - title: "IRIS-HEP Tutorial: Fast columnar data analysis with data science tools"
-    date: 2019-07-29
-    meeting: "Division of Particles and Fields (DPF) of the American Physical Society (APS)"
-    meetingurl: https://indico.cern.ch/event/782953/overview
-    url: https://indico.cern.ch/event/782953/sessions/302485/#20190729
-    location: "Boston, MA"
-    focus-area: [as, ssc]
-    project: [uproot, awkward]
-
-  - title: "Jagged, ragged, awkward arrays"
-    date: 2019-09-14
-    meeting: "Strange Loop 2019"
-    meetingurl: https://www.thestrangeloop.com/2019/jagged-ragged-awkward-arrays.html
-    url: https://youtu.be/2NxWpU7NArk
-    location: "St. Louis, MO"
-    focus-area: [as]
-    project: [awkward]
-
-  - title: "Awkward 1.0"
-    date: 2019-10-17
-    meeting: "PyHEP Workshop"
-    meetingurl: https://indico.cern.ch/event/833895/
-    url: https://indico.cern.ch/event/833895/contributions/3577882/
-    location: "Abingdon, U.K."
-    focus-area: [as]
-    project: [awkward]
-
-  - title: "Ragged, jagged, nested, indirected, very awkward arrays"
-    date: 2019-11-07
-    meeting: "CHEP 2019"
-    meetingurl: https://indico.cern.ch/event/773049/overview
-    url: https://indico.cern.ch/event/773049/contributions/3473258/
-    location: "Adelaide, Australia"
-    focus-area: [as]
-    project: [awkward]
-
-  - title: "Awkward Arrays for Analysis Systems"
-    date: 2020-02-27
-    meeting: "IRIS-HEP Review"
-    url: https://github.com/jpivarski/2020-02-27-irishep-poster/blob/master/pivarski-irishep-poster.pdf
-    meetingurl:
-    location: "Princeton University"
-    focus-area: [as]
-    project: [awkward]
-
-  - title: "Uproot and Awkward Array tutorials for the Electron Ion Collider"
-    date: 2020-04-08
-    meeting: "Electron Ion Collider User's meeting"
-    url: https://www.youtube.com/watch?v=FoxNS6nlbD0
-    meetingurl:
-    location: "online"
-    focus-area: [as, ssc]
-    project: [awkward]
-
-  - title: "Uproot Awkward columnar HATS"
-    date: 2020-06-08
-    url: https://github.com/jpivarski/2020-06-08-uproot-awkward-columnar-hats#readme
-    meeting: "LPC HATS: Hands-on Training for CMS"
-    meetingurl: https://indico.cern.ch/event/917675/
-    location: "online"
-    focus-area: [as, ssc]
-    project: [uproot, awkward]
-
-  - title: "Awkward Array: Manipulating JSON like Data with NumPy like Idioms"
-    date: 2020-07-05
-    url: https://youtu.be/WlnUF3LRBj4
-    meeting: "SciPy 2020"
-    meetingurl: https://www.scipy2020.scipy.org/
-    location: "online"
-    focus-area: [as]
-    project: [awkward]
-
-  - title: "Uproot and Awkward Array tutorial"
-    date: 2020-07-15
-    url: https://youtu.be/ea-zYLQBS4U
-    meeting: "PyHEP 2020"
-    meetingurl: https://indico.cern.ch/event/882824/
-    location: "online"
-    focus-area: [as, ssc]
-    project: [uproot, awkward]
-
-  - title: "Measuring Python adoption by CMS physicists using GitHub API"
-    date: 2020-08-11
-    url: https://indico.fnal.gov/event/43829/contributions/193602/
-    meeting: "Snowmass Computational Frontier Workshop 2020"
-    meetingurl: https://indico.fnal.gov/event/43829/
-    location: "online"
-    focus-area: [as]
-    project:
-
-  - title: "Future of User Analysis"
-    date: 2020-10-01
-    url: https://indico.cern.ch/event/958432/
-    meeting: "LHCb Computing Workshop"
-    meetingurl: https://indico.cern.ch/event/941919
-    location: "online"
-    focus-area: [as]
-    project: [uproot, awkward]
-
-  - title: "Access & Manipulation of Complex Data Structures: Uproot & Awkward Array"
-    date: 2020-10-26
-    url: https://indico.cern.ch/event/960587/contributions/4070318/
-    meeting: "Future Analysis Systems and Facilities"
-    meetingurl: https://indico.cern.ch/event/960587/
-    location: "online"
-    focus-area: [as]
-    project: [uproot, awkward]
-
-  - title: "Survey and status of Pythonic HEP analysis tools"
-    date: 2020-11-20
-    url: https://indico.cern.ch/event/971994/contributions/4106679/
-    meeting: "CMS Physics Workshop on Analysis Tools and Techniques"
-    meetingurl: https://indico.cern.ch/event/971994/
-    location: "online"
-    focus-area: [as]
-    project:
-
-  - title: "PyHEP Numba tutorial"
-    date: 2021-02-03
-    url: https://github.com/jpivarski-talks/2021-02-03-pyhep-numba-tutorial
-    meeting: "PyHEP module of the month"
-    meetingurl: https://indico.cern.ch/event/985350/
-    location: "online"
-    focus-area: [as, ssc]
-    project:
+- title: Nested data structures in array and SIMD frameworks
+  date: 2019-03-14
+  url: https://indico.cern.ch/event/708041/contributions/3276200/attachments/1810057/2955674/pivarski-acat2019.pdf
+  meeting: ACAT 2019
+  meetingurl: https://indico.cern.ch/event/708041/
+  location: Saas-Fee, Switzerland
+  focus-area:
+  - as
+  project:
+  - awkward
+- title: PyROOT, uproot, and awkward-arrays
+  date: 2019-04-01
+  url: https://github.com/jpivarski/2019-04-01-fermilab-carpentries
+  meeting: Software Carpentry at Fermilab
+  meetingurl: https://davidyakobovitch.github.io/2019-04-01_fnal/
+  location: Fermilab
+  focus-area:
+  - as
+  - ssc
+  project:
+  - uproot
+  - awkward
+- title: High-Performance Python and Interoperability with Compiled Code
+  date: 2019-04-08
+  url: https://github.com/jpivarski/2019-04-08-picscie-numpy
+  meeting: Princeton PICSciE mini-courses
+  meetingurl: https://researchcomputing.princeton.edu/events/high-performance-python-and-interoperability-compiled-code-48-410
+  location: Princeton University
+  focus-area:
+  - as
+  - ssc
+  project:
+- title: Aghast
+  date: 2019-04-15
+  url: https://indico.cern.ch/event/803122/contributions/3339215/attachments/1830076/2996786/pivarski-2019-04-15-irishep-aghast.pdf
+  meeting: IRIS-HEP Topical Meetings
+  meetingurl: https://indico.cern.ch/event/803122/
+  location: online
+  focus-area:
+  - as
+  project:
+  - histogram
+- title: 'Awkward Array: Numba'
+  date: 2019-04-17
+  url: https://indico.cern.ch/event/808630/contributions/3367657/attachments/1830385/2997458/pivarski-2019-04-17-irishep-awkwardnumba.pdf
+  meeting: IRIS-HEP Topical Meetings
+  meetingurl: https://indico.cern.ch/event/808630/
+  location: online
+  focus-area:
+  - as
+  project:
+  - awkward
+- title: Skyhook for query systems
+  date: 2019-04-24
+  url: https://indico.cern.ch/event/813447/contributions/3396060/attachments/1833398/3003091/pivarski-2019-04-24-irishep-skyhook.pdf
+  meeting: IRIS-HEP Topical Meetings
+  meetingurl: https://indico.cern.ch/event/813447/
+  location: online
+  focus-area:
+  - as
+  project:
+  - skyhookdm
+- title: How to build your own language (hands-on demo)
+  date: 2019-05-06
+  url: https://github.com/jpivarski/2019-05-06-adl-language-tools
+  meeting: Analysis Description Languages Workshop
+  meetingurl: https://indico.cern.ch/event/769263/timetable/
+  location: Fermilab
+  focus-area:
+  - as
+  - ssc
+  project:
+- title: Programming languages and particle physics
+  date: 2019-05-08
+  url: https://indico.cern.ch/event/769263/contributions/3420926/
+  meeting: Fermilab Colloquium
+  meetingurl: https://events.fnal.gov/colloquium/events/event/pivarski-colloq-2019/
+  location: Fermilab
+  focus-area:
+  - as
+  project:
+- title: Summary of the 'Analysis Description Languages for the LHC' workshop
+  date: 2019-05-09
+  meeting: LPC Physics Forum
+  meetingurl: https://indico.cern.ch/event/806811/
+  url: https://indico.cern.ch/event/806811/#1-summary-of-the-analysis-desc
+  location: Fermilab
+  focus-area:
+  - as
+  project:
+- title: Pattern matching for decay trees
+  date: 2019-05-22
+  meeting: IRIS-HEP Topical Meetings
+  meetingurl: https://indico.cern.ch/event/820598/
+  location: online
+  url: https://indico.cern.ch/event/820598/#2-pattern-matching-for-decay-t
+  focus-area:
+  - as
+  project:
+- title: Scientific Python and Uproot HATS
+  date: 2019-05-28
+  meeting: 'LPC HATS: Hands-on Training for CMS'
+  meetingurl: https://indico.cern.ch/event/814895/
+  location: Fermilab
+  url: https://indico.cern.ch/event/814895/
+  focus-area:
+  - as
+  project:
+  - uproot
+- title: Columnar Analysis Tools HATS
+  date: 2019-05-29
+  meeting: 'LPC HATS: Hands-on Training for CMS'
+  meetingurl: https://indico.cern.ch/event/814100/
+  url: https://indico.cern.ch/event/814100/
+  location: Fermilab
+  focus-area:
+  - as
+  project:
+  - awkward
+- title: Numpy, Pandas, PyROOT, and Uproot
+  date: 2019-06-10
+  meeting: U.S. ATLAS Software Training at Argonne National Lab
+  meetingurl: https://indico.cern.ch/event/811577/
+  url: https://indico.cern.ch/event/811577/
+  location: Argonne
+  focus-area:
+  - as
+  project:
+  - uproot
+- title: 'Uproot: accessing ROOT data in the scientific Python ecosystem'
+  date: 2019-06-18
+  meeting: 3rd CMS Machine Learning Workshop
+  meetingurl: https://indico.cern.ch/event/798721/
+  url: https://indico.cern.ch/event/798721/contributions/3461343/
+  location: online
+  focus-area:
+  - as
+  project:
+  - uproot
+- title: Update on awkward-array, uproot, and related projects
+  date: 2019-06-19
+  meeting: Analysis Systems Topical Workshop
+  meetingurl: https://indico.cern.ch/event/822074/overview
+  url: https://indico.cern.ch/event/822074/contributions/3471451/
+  location: NYU Physics Department
+  focus-area:
+  - as
+  project:
+  - uproot
+  - awkward
+- title: Motivation and requirements for awkward 1.0
+  date: 2019-07-10
+  meeting: Analysis Systems Biweekly Meeting
+  url: https://indico.cern.ch/event/815512/
+  meetingurl:
+  location: online
+  focus-area:
+  - as
+  project:
+  - awkward
+- title: Scientific Python Ecosystem; Columnar Data Analysis; Accelerating Python
+  date: 2019-07-23
+  meeting: Third Computational and Data Science for High Energy Physics (CoDaS-HEP)
+    School
+  meetingurl: http://codas-hep.org/
+  url: https://github.com/jpivarski/2019-07-23-codas-hep#readme
+  location: Princeton University
+  focus-area:
+  - as
+  - ssc
+  project:
+- title: 'IRIS-HEP Tutorial: Fast columnar data analysis with data science tools'
+  date: 2019-07-29
+  meeting: Division of Particles and Fields (DPF) of the American Physical Society
+    (APS)
+  meetingurl: https://indico.cern.ch/event/782953/overview
+  url: https://indico.cern.ch/event/782953/sessions/302485/#20190729
+  location: Boston, MA
+  focus-area:
+  - as
+  - ssc
+  project:
+  - uproot
+  - awkward
+- title: Jagged, ragged, awkward arrays
+  date: 2019-09-14
+  meeting: Strange Loop 2019
+  meetingurl: https://www.thestrangeloop.com/2019/jagged-ragged-awkward-arrays.html
+  url: https://youtu.be/2NxWpU7NArk
+  location: St. Louis, MO
+  focus-area:
+  - as
+  project:
+  - awkward
+- title: Awkward 1.0
+  date: 2019-10-17
+  meeting: PyHEP Workshop
+  meetingurl: https://indico.cern.ch/event/833895/
+  url: https://indico.cern.ch/event/833895/contributions/3577882/
+  location: Abingdon, U.K.
+  focus-area:
+  - as
+  project:
+  - awkward
+- title: Ragged, jagged, nested, indirected, very awkward arrays
+  date: 2019-11-07
+  meeting: CHEP 2019
+  meetingurl: https://indico.cern.ch/event/773049/overview
+  url: https://indico.cern.ch/event/773049/contributions/3473258/
+  location: Adelaide, Australia
+  focus-area:
+  - as
+  project:
+  - awkward
+- title: Awkward Arrays for Analysis Systems
+  date: 2020-02-27
+  meeting: IRIS-HEP Review
+  url: https://github.com/jpivarski/2020-02-27-irishep-poster/blob/master/pivarski-irishep-poster.pdf
+  meetingurl:
+  location: Princeton University
+  focus-area:
+  - as
+  project:
+  - awkward
+- title: Uproot and Awkward Array tutorials for the Electron Ion Collider
+  date: 2020-04-08
+  meeting: Electron Ion Collider User's meeting
+  url: https://www.youtube.com/watch?v=FoxNS6nlbD0
+  meetingurl:
+  location: online
+  focus-area:
+  - as
+  - ssc
+  project:
+  - awkward
+- title: Uproot Awkward columnar HATS
+  date: 2020-06-08
+  url: https://github.com/jpivarski/2020-06-08-uproot-awkward-columnar-hats#readme
+  meeting: 'LPC HATS: Hands-on Training for CMS'
+  meetingurl: https://indico.cern.ch/event/917675/
+  location: online
+  focus-area:
+  - as
+  - ssc
+  project:
+  - uproot
+  - awkward
+- title: 'Awkward Array: Manipulating JSON like Data with NumPy like Idioms'
+  date: 2020-07-05
+  url: https://youtu.be/WlnUF3LRBj4
+  meeting: SciPy 2020
+  meetingurl: https://www.scipy2020.scipy.org/
+  location: online
+  focus-area:
+  - as
+  project:
+  - awkward
+- title: Uproot and Awkward Array tutorial
+  date: 2020-07-15
+  url: https://youtu.be/ea-zYLQBS4U
+  meeting: PyHEP 2020
+  meetingurl: https://indico.cern.ch/event/882824/
+  location: online
+  focus-area:
+  - as
+  - ssc
+  project:
+  - uproot
+  - awkward
+- title: Measuring Python adoption by CMS physicists using GitHub API
+  date: 2020-08-11
+  url: https://indico.fnal.gov/event/43829/contributions/193602/
+  meeting: Snowmass Computational Frontier Workshop 2020
+  meetingurl: https://indico.fnal.gov/event/43829/
+  location: online
+  focus-area:
+  - as
+  project:
+- title: Future of User Analysis
+  date: 2020-10-01
+  url: https://indico.cern.ch/event/958432/
+  meeting: LHCb Computing Workshop
+  meetingurl: https://indico.cern.ch/event/941919
+  location: online
+  focus-area:
+  - as
+  project:
+  - uproot
+  - awkward
+- title: 'Access & Manipulation of Complex Data Structures: Uproot & Awkward Array'
+  date: 2020-10-26
+  url: https://indico.cern.ch/event/960587/contributions/4070318/
+  meeting: Future Analysis Systems and Facilities
+  meetingurl: https://indico.cern.ch/event/960587/
+  location: online
+  focus-area:
+  - as
+  project:
+  - uproot
+  - awkward
+- title: Survey and status of Pythonic HEP analysis tools
+  date: 2020-11-20
+  url: https://indico.cern.ch/event/971994/contributions/4106679/
+  meeting: CMS Physics Workshop on Analysis Tools and Techniques
+  meetingurl: https://indico.cern.ch/event/971994/
+  location: online
+  focus-area:
+  - as
+  project:
+- title: PyHEP Numba tutorial
+  date: 2021-02-03
+  url: https://github.com/jpivarski-talks/2021-02-03-pyhep-numba-tutorial
+  meeting: PyHEP module of the month
+  meetingurl: https://indico.cern.ch/event/985350/
+  location: online
+  focus-area:
+  - as
+  - ssc
+  project:

--- a/_data/people/jpivarski.yml
+++ b/_data/people/jpivarski.yml
@@ -326,3 +326,7 @@ presentations:
   - as
   - ssc
   project:
+focus-area:
+- as
+- ssc
+- doma

--- a/_data/people/jpivarski.yml
+++ b/_data/people/jpivarski.yml
@@ -1,11 +1,14 @@
----
+active: true
+focus-area:
+- as
+- ssc
+- doma
+institution: Princeton University
 name: Jim Pivarski
+photo: "/assets/images/team/Jim-Pivarski.jpg"
 shortname: jpivarski
 title:
-active: true
-institution: Princeton University
 website: https://github.com/jpivarski
-photo: "/assets/images/team/Jim-Pivarski.jpg"
 presentations:
 - title: Nested data structures in array and SIMD frameworks
   date: 2019-03-14
@@ -326,7 +329,3 @@ presentations:
   - as
   - ssc
   project:
-focus-area:
-- as
-- ssc
-- doma

--- a/_data/people/k_kvdam.yml
+++ b/_data/people/k_kvdam.yml
@@ -1,13 +1,13 @@
+---
 name: Kerstin Kleese van Dam
 shortname: k_kvdam
 title:
 active: true
 institution: Brookhaven National Laboratory
 website:
-photo: /assets/images/team/Kerstin-Kleese-van-Dam.jpg
+photo: "/assets/images/team/Kerstin-Kleese-van-Dam.jpg"
 presentations:
 about: Additional DOE lab representative.
-role: Provide a view point from
-   an additional DOE lab doing significant HEP R&D. This improves the
-   connection to the DOE lab ecosystem, including HPC expertise.
+role: Provide a view point from an additional DOE lab doing significant HEP R&D. This
+  improves the connection to the DOE lab ecosystem, including HPC expertise.
 hidden: true

--- a/_data/people/k_kvdam.yml
+++ b/_data/people/k_kvdam.yml
@@ -1,13 +1,12 @@
----
-name: Kerstin Kleese van Dam
-shortname: k_kvdam
-title:
-active: true
-institution: Brookhaven National Laboratory
-website:
-photo: "/assets/images/team/Kerstin-Kleese-van-Dam.jpg"
-presentations:
 about: Additional DOE lab representative.
+active: true
+hidden: true
+institution: Brookhaven National Laboratory
+name: Kerstin Kleese van Dam
+photo: "/assets/images/team/Kerstin-Kleese-van-Dam.jpg"
 role: Provide a view point from an additional DOE lab doing significant HEP R&D. This
   improves the connection to the DOE lab ecosystem, including HPC expertise.
-hidden: true
+shortname: k_kvdam
+title:
+website:
+presentations:

--- a/_data/people/kenbloom.yml
+++ b/_data/people/kenbloom.yml
@@ -1,8 +1,9 @@
+---
 name: Ken Bloom
 shortname: kenbloom
 title:
 active: true
 institution: University of Nebraska - Lincoln
 website: https://www.unl.edu/physics/ken-bloom-bio
-photo: /assets/images/team/Ken-Bloom.jpg
+photo: "/assets/images/team/Ken-Bloom.jpg"
 presentations:

--- a/_data/people/kenbloom.yml
+++ b/_data/people/kenbloom.yml
@@ -1,12 +1,11 @@
----
-name: Ken Bloom
-shortname: kenbloom
-title:
 active: true
-institution: University of Nebraska - Lincoln
-website: https://www.unl.edu/physics/ken-bloom-bio
-photo: "/assets/images/team/Ken-Bloom.jpg"
-presentations:
 focus-area:
 - doma
 - as
+institution: University of Nebraska - Lincoln
+name: Ken Bloom
+photo: "/assets/images/team/Ken-Bloom.jpg"
+shortname: kenbloom
+title:
+website: https://www.unl.edu/physics/ken-bloom-bio
+presentations:

--- a/_data/people/kenbloom.yml
+++ b/_data/people/kenbloom.yml
@@ -7,3 +7,6 @@ institution: University of Nebraska - Lincoln
 website: https://www.unl.edu/physics/ken-bloom-bio
 photo: "/assets/images/team/Ken-Bloom.jpg"
 presentations:
+focus-area:
+- doma
+- as

--- a/_data/people/kherner.yml
+++ b/_data/people/kherner.yml
@@ -1,10 +1,9 @@
----
+active: true
+hidden: true
+institution: FNAL
 name: Kenneth Herner
+photo: "/assets/images/team/KH_cropped.jpg"
 shortname: kherner
 title: OSG Council, DUNE Collaboration
-active: true
-institution: FNAL
 website:
-photo: "/assets/images/team/KH_cropped.jpg"
-hidden: true
 presentations:

--- a/_data/people/kherner.yml
+++ b/_data/people/kherner.yml
@@ -1,9 +1,10 @@
+---
 name: Kenneth Herner
 shortname: kherner
 title: OSG Council, DUNE Collaboration
 active: true
 institution: FNAL
 website:
-photo: /assets/images/team/KH_cropped.jpg
+photo: "/assets/images/team/KH_cropped.jpg"
 hidden: true
 presentations:

--- a/_data/people/klute.yml
+++ b/_data/people/klute.yml
@@ -1,9 +1,8 @@
----
-name: Markus Klute
-shortname: klute
-title:
 active: true
 institution: Massachusetts Institute of Technology
-website: https://web.mit.edu/physics/people/faculty/klute_markus.html
+name: Markus Klute
 photo: "/assets/images/team/Markus-Klute.jpg"
+shortname: klute
+title:
+website: https://web.mit.edu/physics/people/faculty/klute_markus.html
 presentations:

--- a/_data/people/klute.yml
+++ b/_data/people/klute.yml
@@ -1,8 +1,9 @@
+---
 name: Markus Klute
 shortname: klute
 title:
 active: true
 institution: Massachusetts Institute of Technology
 website: https://web.mit.edu/physics/people/faculty/klute_markus.html
-photo: /assets/images/team/Markus-Klute.jpg
+photo: "/assets/images/team/Markus-Klute.jpg"
 presentations:

--- a/_data/people/latompkins.yml
+++ b/_data/people/latompkins.yml
@@ -1,12 +1,11 @@
----
-name: Lauren Tompkins
-shortname: latompkins
-title:
 active: true
-institution: Stanford University
-website: https://profiles.stanford.edu/lauren-tompkins
-photo: "/assets/images/team/Lauren-Tompkins.jpg"
-presentations:
 focus-area:
 - as
 - ia
+institution: Stanford University
+name: Lauren Tompkins
+photo: "/assets/images/team/Lauren-Tompkins.jpg"
+shortname: latompkins
+title:
+website: https://profiles.stanford.edu/lauren-tompkins
+presentations:

--- a/_data/people/latompkins.yml
+++ b/_data/people/latompkins.yml
@@ -7,3 +7,6 @@ institution: Stanford University
 website: https://profiles.stanford.edu/lauren-tompkins
 photo: "/assets/images/team/Lauren-Tompkins.jpg"
 presentations:
+focus-area:
+- as
+- ia

--- a/_data/people/latompkins.yml
+++ b/_data/people/latompkins.yml
@@ -1,8 +1,9 @@
+---
 name: Lauren Tompkins
 shortname: latompkins
 title:
 active: true
 institution: Stanford University
 website: https://profiles.stanford.edu/lauren-tompkins
-photo: /assets/images/team/Lauren-Tompkins.jpg
+photo: "/assets/images/team/Lauren-Tompkins.jpg"
 presentations:

--- a/_data/people/likt1.yml
+++ b/_data/people/likt1.yml
@@ -7,3 +7,5 @@ institution: University of Cincinnati
 website:
 photo: "/assets/images/team/Kendrick-Li.jpg"
 presentations:
+focus-area:
+- ia

--- a/_data/people/likt1.yml
+++ b/_data/people/likt1.yml
@@ -1,11 +1,10 @@
----
-name: Kendrick Li
-shortname: likt1
-title:
 active: false
-institution: University of Cincinnati
-website:
-photo: "/assets/images/team/Kendrick-Li.jpg"
-presentations:
 focus-area:
 - ia
+institution: University of Cincinnati
+name: Kendrick Li
+photo: "/assets/images/team/Kendrick-Li.jpg"
+shortname: likt1
+title:
+website:
+presentations:

--- a/_data/people/likt1.yml
+++ b/_data/people/likt1.yml
@@ -1,8 +1,9 @@
+---
 name: Kendrick Li
 shortname: likt1
 title:
 active: false
 institution: University of Cincinnati
 website:
-photo: /assets/images/team/Kendrick-Li.jpg
+photo: "/assets/images/team/Kendrick-Li.jpg"
 presentations:

--- a/_data/people/m-carothers.yml
+++ b/_data/people/m-carothers.yml
@@ -1,9 +1,10 @@
+---
 name: Maureen Carothers
 shortname: m-carothers
 title: Project Office
 active: true
 institution: Princeton University
 website:
-photo: /assets/images/team/Maureen-Carothers.JPG
+photo: "/assets/images/team/Maureen-Carothers.JPG"
 e-mail:
 presentations:

--- a/_data/people/m-carothers.yml
+++ b/_data/people/m-carothers.yml
@@ -1,10 +1,9 @@
----
+active: true
+e-mail:
+institution: Princeton University
 name: Maureen Carothers
+photo: "/assets/images/team/Maureen-Carothers.JPG"
 shortname: m-carothers
 title: Project Office
-active: true
-institution: Princeton University
 website:
-photo: "/assets/images/team/Maureen-Carothers.JPG"
-e-mail:
 presentations:

--- a/_data/people/m_norman.yml
+++ b/_data/people/m_norman.yml
@@ -1,12 +1,13 @@
+---
 name: Mike Norman
 shortname: m_norman
 title:
 active: true
 institution: San Diego Supercomputer Center & University of California, San Diego
 website:
-photo: /assets/images/team/Mike_Norman.jpg
+photo: "/assets/images/team/Mike_Norman.jpg"
 presentations:
 about: OAC / CI representative.
-role: Provide expertise and input from a member
-   of the NSF/OAC community that leads significant CI projects.
+role: Provide expertise and input from a member of the NSF/OAC community that leads
+  significant CI projects.
 hidden: true

--- a/_data/people/m_norman.yml
+++ b/_data/people/m_norman.yml
@@ -1,13 +1,12 @@
----
-name: Mike Norman
-shortname: m_norman
-title:
-active: true
-institution: San Diego Supercomputer Center & University of California, San Diego
-website:
-photo: "/assets/images/team/Mike_Norman.jpg"
-presentations:
 about: OAC / CI representative.
+active: true
+hidden: true
+institution: San Diego Supercomputer Center & University of California, San Diego
+name: Mike Norman
+photo: "/assets/images/team/Mike_Norman.jpg"
 role: Provide expertise and input from a member of the NSF/OAC community that leads
   significant CI projects.
-hidden: true
+shortname: m_norman
+title:
+website:
+presentations:

--- a/_data/people/marianstahl.yml
+++ b/_data/people/marianstahl.yml
@@ -23,3 +23,5 @@ presentations:
   date: 2020-04-20
   focus-area: ia
   project: pv-finder
+focus-area:
+- ia

--- a/_data/people/marianstahl.yml
+++ b/_data/people/marianstahl.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ia
+institution: University of Cincinnati
 name: Marian Stahl
+photo: "/assets/images/team/Marian_Stahl.jpg"
 shortname: marianstahl
 title:
-active: true
-institution: University of Cincinnati
 website:
-photo: "/assets/images/team/Marian_Stahl.jpg"
 presentations:
 - title: LHCb HLT performance- and regression-tests A hybrid deep learning approach
     to vertexing
@@ -23,5 +24,3 @@ presentations:
   date: 2020-04-20
   focus-area: ia
   project: pv-finder
-focus-area:
-- ia

--- a/_data/people/marianstahl.yml
+++ b/_data/people/marianstahl.yml
@@ -1,22 +1,25 @@
+---
 name: Marian Stahl
 shortname: marianstahl
 title:
 active: true
 institution: University of Cincinnati
 website:
-photo: /assets/images/team/Marian_Stahl.jpg
+photo: "/assets/images/team/Marian_Stahl.jpg"
 presentations:
-  - title: LHCb HLT performance- and regression-tests A hybrid deep learning approach to vertexing
-    meeting: IRIS-HEP Topical Meeting
-    meetingurl: https://indico.cern.ch/event/870237/
-    url: https://indico.cern.ch/event/870237/contributions/3669956/attachments/1977777/3292316/iris_hep_report_20200129_mstahl.pdf
-    date: 2020-01-29
-    focus-area: ia
-    project: pv-finder
-  - title: An updated hybrid deep learning algorithm for identifying and locating primary vertices
-    meeting: Connecting The Dots 2020
-    meetingurl: https://indico.cern.ch/event/831165/
-    url: https://indico.cern.ch/event/831165/contributions/3717153/attachments/2022590/3382558/pvfinder_ctd_20200420_mstahl.pdf
-    date: 2020-04-20
-    focus-area: ia
-    project: pv-finder
+- title: LHCb HLT performance- and regression-tests A hybrid deep learning approach
+    to vertexing
+  meeting: IRIS-HEP Topical Meeting
+  meetingurl: https://indico.cern.ch/event/870237/
+  url: https://indico.cern.ch/event/870237/contributions/3669956/attachments/1977777/3292316/iris_hep_report_20200129_mstahl.pdf
+  date: 2020-01-29
+  focus-area: ia
+  project: pv-finder
+- title: An updated hybrid deep learning algorithm for identifying and locating primary
+    vertices
+  meeting: Connecting The Dots 2020
+  meetingurl: https://indico.cern.ch/event/831165/
+  url: https://indico.cern.ch/event/831165/contributions/3717153/attachments/2022590/3382558/pvfinder_ctd_20200420_mstahl.pdf
+  date: 2020-04-20
+  focus-area: ia
+  project: pv-finder

--- a/_data/people/masonproffitt.yml
+++ b/_data/people/masonproffitt.yml
@@ -1,48 +1,50 @@
+---
 name: Mason Proffitt
 shortname: masonproffitt
 title: PhD student
 active: true
 institution: University of Washington
 website: https://github.com/masonproffitt
-photo: /assets/images/team/Mason-Proffitt.jpg
+photo: "/assets/images/team/Mason-Proffitt.jpg"
 presentations:
-  - title: "IRIS-HEP: A new software institute to prepare for the data from the High Luminosity Large Hadron Collider in the exabyte era"
-    date: 2019-05-08
-    url: https://indico.cern.ch/event/821258/contributions/3433444/attachments/1844402/3025513/Northwest_Data_Science_Summit_Poster_Final.pdf
-    meeting: Northwest Data Science Summit
-    meetingurl: https://www.eventbrite.com/e/northwest-data-science-summit-tickets-55037447487
-    location: University of Washington
-    focus-area: as
-    project: func-adl
-  - title: "Prototype declarative analysis interface using uproot and awkward-array"
-    date: 2019-09-12
-    url: https://indico.cern.ch/event/840472/contributions/3563332/attachments/1907329/3150287/lightning-talk_2019-09-12.pdf
-    meeting: IRIS-HEP Institute Retreat
-    meetingurl: https://indico.cern.ch/event/840472/
-    location: Fermilab
-    focus-area: as
-    project: func-adl
-  - title: "HEP Data Query Challenges"
-    date: 2019-11-07
-    url: https://indico.cern.ch/event/773049/contributions/3476178/attachments/1936838/3210025/chep_2019_poster.pdf
-    meeting: CHEP 2019
-    meetingurl: http://chep2019.org/
-    location: Adelaide, Australia
-    focus-area: as
-    project: adl-benchmarks-index
-  - title: uproot Tutorial
-    date: 2019-11-29
-    url: https://masonproffitt.github.io/uproot-tutorial/
-    meeting: Software Carpentry at CERN
-    meetingurl: https://indico.cern.ch/event/834411/
-    location: CERN
-    focus-area: as
-    project: uproot
-  - title: "Functional Analysis Description Language (FuncADL)"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331177/11_-_Functional_Analysis_Description_Language_FuncADL.pdf
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/overview
-    location: Princeton University
-    focus-area: as
-    project: func-adl
+- title: 'IRIS-HEP: A new software institute to prepare for the data from the High
+    Luminosity Large Hadron Collider in the exabyte era'
+  date: 2019-05-08
+  url: https://indico.cern.ch/event/821258/contributions/3433444/attachments/1844402/3025513/Northwest_Data_Science_Summit_Poster_Final.pdf
+  meeting: Northwest Data Science Summit
+  meetingurl: https://www.eventbrite.com/e/northwest-data-science-summit-tickets-55037447487
+  location: University of Washington
+  focus-area: as
+  project: func-adl
+- title: Prototype declarative analysis interface using uproot and awkward-array
+  date: 2019-09-12
+  url: https://indico.cern.ch/event/840472/contributions/3563332/attachments/1907329/3150287/lightning-talk_2019-09-12.pdf
+  meeting: IRIS-HEP Institute Retreat
+  meetingurl: https://indico.cern.ch/event/840472/
+  location: Fermilab
+  focus-area: as
+  project: func-adl
+- title: HEP Data Query Challenges
+  date: 2019-11-07
+  url: https://indico.cern.ch/event/773049/contributions/3476178/attachments/1936838/3210025/chep_2019_poster.pdf
+  meeting: CHEP 2019
+  meetingurl: http://chep2019.org/
+  location: Adelaide, Australia
+  focus-area: as
+  project: adl-benchmarks-index
+- title: uproot Tutorial
+  date: 2019-11-29
+  url: https://masonproffitt.github.io/uproot-tutorial/
+  meeting: Software Carpentry at CERN
+  meetingurl: https://indico.cern.ch/event/834411/
+  location: CERN
+  focus-area: as
+  project: uproot
+- title: Functional Analysis Description Language (FuncADL)
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331177/11_-_Functional_Analysis_Description_Language_FuncADL.pdf
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/overview
+  location: Princeton University
+  focus-area: as
+  project: func-adl

--- a/_data/people/masonproffitt.yml
+++ b/_data/people/masonproffitt.yml
@@ -48,3 +48,5 @@ presentations:
   location: Princeton University
   focus-area: as
   project: func-adl
+focus-area:
+- as

--- a/_data/people/masonproffitt.yml
+++ b/_data/people/masonproffitt.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- as
+institution: University of Washington
 name: Mason Proffitt
+photo: "/assets/images/team/Mason-Proffitt.jpg"
 shortname: masonproffitt
 title: PhD student
-active: true
-institution: University of Washington
 website: https://github.com/masonproffitt
-photo: "/assets/images/team/Mason-Proffitt.jpg"
 presentations:
 - title: 'IRIS-HEP: A new software institute to prepare for the data from the High
     Luminosity Large Hadron Collider in the exabyte era'
@@ -48,5 +49,3 @@ presentations:
   location: Princeton University
   focus-area: as
   project: func-adl
-focus-area:
-- as

--- a/_data/people/matkinso.yml
+++ b/_data/people/matkinso.yml
@@ -63,3 +63,5 @@ presentations:
   meetingurl: https://exatrkx.github.io
   location: Virtual
   focus-area: ia
+focus-area:
+- ia

--- a/_data/people/matkinso.yml
+++ b/_data/people/matkinso.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ia
+institution: University of Illinois at Urbana-Champaign
 name: Markus Atkinson
+photo: "/assets/images/team/Markus-Atkinson.png"
 shortname: matkinso
 title:
-active: true
-institution: University of Illinois at Urbana-Champaign
 website:
-photo: "/assets/images/team/Markus-Atkinson.png"
 presentations:
 - title: Introduction and Plans
   date: 2019-09-12
@@ -63,5 +64,3 @@ presentations:
   meetingurl: https://exatrkx.github.io
   location: Virtual
   focus-area: ia
-focus-area:
-- ia

--- a/_data/people/matkinso.yml
+++ b/_data/people/matkinso.yml
@@ -1,64 +1,65 @@
+---
 name: Markus Atkinson
 shortname: matkinso
 title:
 active: true
 institution: University of Illinois at Urbana-Champaign
 website:
-photo: /assets/images/team/Markus-Atkinson.png
+photo: "/assets/images/team/Markus-Atkinson.png"
 presentations:
-  - title: "Introduction and Plans"
-    date: 2019-09-12
-    url: https://indico.cern.ch/event/840472/contributions/3563439/attachments/1907817/3151491/Introduction_and_Plan.pdf
-    meeting: IRIS-HEP Institute Retreat
-    meetingurl: https://indico.cern.ch/event/840472/overview
-    location: FNAL
-    focus-area: ia
-  - title: "FPGA ML inference as a service on AWS"
-    date: 2019-10-19
-    url: https://indico.cern.ch/event/858899/contributions/3619146/attachments/1933518/3203232/AWS_talk.pdf
-    meeting: FastML Co-processors Meeting
-    meetingurl: https://indico.cern.ch/event/858899/
-    location: Vidyo
-    focus-area: ia
-  - title: "GNN Tracking and FPGA Acceleration (poster)"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331186/16%20-%20IRIS-HEP-poster-GNNTrackingFPGA.pdf
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton, USA
-    focus-area: ia
-  - title: "Pixel Detector Tracklet Finding"
-    date: 2020-05-04
-    url: https://exatrkx.github.io
-    meeting: Exa.Trkx Weekly Meeting
-    meetingurl: https://exatrkx.github.io
-    location: Virtual
-    focus-area: ia
-  - title: "Graph Neural Network Tracking using the Endcaps"
-    date: 2020-05-18
-    url: https://exatrkx.github.io
-    meeting: Exa.Trkx Weekly Meeting
-    meetingurl: https://exatrkx.github.io
-    location: Virtual
-    focus-area: ia
-  - title: "Graph Neural Networks Architectures"
-    date: 2020-10-21
-    url: https://indico.cern.ch/event/955026/contributions/4012924/attachments/2127589/3582355/IRIS-Topical_GNN_Tracking.pdf
-    meeting: IRIS-HEP Topical Meeting
-    meetingurl: https://indico.cern.ch/event/955026/
-    location: Virtual
-    focus-area: ia
-  - title: "Graph Neural Networks Architectures"
-    date: 2020-10-23
-    url: https://indico.cern.ch/event/968452/contributions/4078571/attachments/2129154/3585214/IRIS-Topical%20GNN%20Tracking.pdf
-    meeting: FastML Co-processors Meeting
-    meetingurl: https://indico.cern.ch/event/968452/
-    location: Virtual
-    focus-area: ia
-  - title: "Hough Transforms and GNN"
-    date: 2020-11-30
-    url: https://indico.cern.ch/event/977132/contributions/4115380/attachments/2146099/3631008/GNN%20Hough.pdf
-    meeting: Exa.Trkx Weekly Meeting
-    meetingurl: https://exatrkx.github.io
-    location: Virtual
-    focus-area: ia
+- title: Introduction and Plans
+  date: 2019-09-12
+  url: https://indico.cern.ch/event/840472/contributions/3563439/attachments/1907817/3151491/Introduction_and_Plan.pdf
+  meeting: IRIS-HEP Institute Retreat
+  meetingurl: https://indico.cern.ch/event/840472/overview
+  location: FNAL
+  focus-area: ia
+- title: FPGA ML inference as a service on AWS
+  date: 2019-10-19
+  url: https://indico.cern.ch/event/858899/contributions/3619146/attachments/1933518/3203232/AWS_talk.pdf
+  meeting: FastML Co-processors Meeting
+  meetingurl: https://indico.cern.ch/event/858899/
+  location: Vidyo
+  focus-area: ia
+- title: GNN Tracking and FPGA Acceleration (poster)
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331186/16%20-%20IRIS-HEP-poster-GNNTrackingFPGA.pdf
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton, USA
+  focus-area: ia
+- title: Pixel Detector Tracklet Finding
+  date: 2020-05-04
+  url: https://exatrkx.github.io
+  meeting: Exa.Trkx Weekly Meeting
+  meetingurl: https://exatrkx.github.io
+  location: Virtual
+  focus-area: ia
+- title: Graph Neural Network Tracking using the Endcaps
+  date: 2020-05-18
+  url: https://exatrkx.github.io
+  meeting: Exa.Trkx Weekly Meeting
+  meetingurl: https://exatrkx.github.io
+  location: Virtual
+  focus-area: ia
+- title: Graph Neural Networks Architectures
+  date: 2020-10-21
+  url: https://indico.cern.ch/event/955026/contributions/4012924/attachments/2127589/3582355/IRIS-Topical_GNN_Tracking.pdf
+  meeting: IRIS-HEP Topical Meeting
+  meetingurl: https://indico.cern.ch/event/955026/
+  location: Virtual
+  focus-area: ia
+- title: Graph Neural Networks Architectures
+  date: 2020-10-23
+  url: https://indico.cern.ch/event/968452/contributions/4078571/attachments/2129154/3585214/IRIS-Topical%20GNN%20Tracking.pdf
+  meeting: FastML Co-processors Meeting
+  meetingurl: https://indico.cern.ch/event/968452/
+  location: Virtual
+  focus-area: ia
+- title: Hough Transforms and GNN
+  date: 2020-11-30
+  url: https://indico.cern.ch/event/977132/contributions/4115380/attachments/2146099/3631008/GNN%20Hough.pdf
+  meeting: Exa.Trkx Weekly Meeting
+  meetingurl: https://exatrkx.github.io
+  location: Virtual
+  focus-area: ia

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -165,3 +165,6 @@ presentations:
   location: Virtual
   focus-area: as
   project: pyhf
+focus-area:
+- as
+- ssc

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -1,162 +1,167 @@
+---
 name: Matthew Feickert
 shortname: matthewfeickert
 title: Postdoctoral researcher
 active: true
 institution: University of Illinois at Urbana-Champaign
 website: https://www.matthewfeickert.com
-photo: /assets/images/team/matthewfeickert.jpeg
+photo: "/assets/images/team/matthewfeickert.jpeg"
 e-mail: matthew.feickert@cern.ch
 presentations:
-  - title: "pyhf: a pure Python implementation of HistFactory with tensors and autograd"
-    date: 2018-10-29
-    url: https://indico.cern.ch/event/759480/contributions/3149836/
-    meeting: DIANA/HEP Meeting
-    meetingurl: https://indico.cern.ch/event/759480/
-    location: Virtual
-    focus-area: as
-    project: pyhf
-  - title: "pyhf: a pure Python statistical fitting library for High Energy Physics with tensors and autograd"
-    date: 2019-07-09
-    url: https://doi.org/10.25080/Majora-7ddc1dd1-019
-    meeting: 18th annual Scientific Computing with Python conference (SciPy 2019)
-    meetingurl: http://conference.scipy.org/proceedings/scipy2019/
-    location: University of Texas at Austin
-    focus-area: as
-    project: pyhf
-  - title: "Introduction to Docker"
-    date: 2019-08-22
-    url: https://matthewfeickert.github.io/intro-to-docker/
-    meeting: 2019 USATLAS/FIRST-HEP Computing Bootcamp
-    meetingurl: https://indico.cern.ch/event/816946/
-    location: Lawrence Berkeley National Laboratory
-    focus-area: ssc
-    project:
-  - title: "pyhf Roadmap: 2019 into 2020"
-    date: 2019-09-12
-    url: https://indico.cern.ch/event/840472/contributions/3564386/
-    meeting: 2019 IRIS-HEP Institute Retreat
-    meetingurl: https://indico.cern.ch/event/840472/
-    location: Fermi National Accelerator Laboratory
-    focus-area: as
-    project: pyhf
-  - title: "pyhf: pure-Python implementation of HistFactory"
-    date: 2019-10-18
-    url: https://indico.cern.ch/event/833895/contributions/3577824/
-    meeting: PyHEP 2019 Workshop
-    meetingurl: https://indico.cern.ch/event/833895/
-    location: Abingdon, U.K.
-    focus-area: as
-    project: pyhf
-  - title: "pyhf: a pure Python implementation of HistFactory with tensors and autograd (poster)"
-    date: 2019-11-05
-    url: https://indico.cern.ch/event/773049/contributions/3476180/
-    meeting: CHEP 2019 Conference
-    meetingurl: https://indico.cern.ch/event/773049/
-    location: Adelaide, South Australia
-    focus-area: as
-    project: pyhf
-  - title: "Likelihood preservation and statistical reproduction of searches for new physics"
-    date: 2019-11-07
-    url: https://indico.cern.ch/event/773049/contributions/3476143/
-    meeting: CHEP 2019 Conference
-    meetingurl: https://indico.cern.ch/event/773049/
-    location: Adelaide, South Australia
-    focus-area: as
-    project: pyhf
-  - title: "An introduction to pyhf and HistFactory likelihoods"
-    date: 2019-11-25
-    url: https://matthewfeickert.github.io/talk-LHCb-Stats-Forum/index.html
-    meeting: LHCb Statistics Working Group
-    meetingurl: https://indico.cern.ch/event/863729/
-    location: Vidyo
-    focus-area: as
-    project: pyhf
-  - title: "pyhf: Pure Python Implementation of HistFactory"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3334540/10_-_IRIS-HEP-2020-poster-session-pyhf.pdf
-    meeting: IRIS-HEP Poster Session 2020
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton, U.S.A.
-    focus-area: as
-    project: pyhf
-  - title: "pyhf: A Pure Python Statistical Fitting Library with Tensors and Autograd"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/897086/attachments/2001484/3341223/Feickert_pyhf-NSF-Review-IRIS-HEP_2020-02-27.pdf
-    meeting: IRIS-HEP Postdoc Presentations
-    meetingurl: https://indico.cern.ch/event/897086/
-    location: Princeton, U.S.A.
-    focus-area: as
-    project: pyhf
-  - title: "pyhf Roadmap for IRIS-HEP Execution Phase"
-    date: 2020-05-27
-    url: https://indico.cern.ch/event/896167/contributions/3880229/
-    meeting: 2020 IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167/
-    location: Virtual
-    focus-area: as
-    project: pyhf
-  - title: "pyhf: a pure Python statistical fitting library with tensors and autograd"
-    date: 2020-07-07
-    url: https://doi.org/10.25080/Majora-342d178e-023
-    meeting: 19th Python in Science Conference (SciPy 2020)
-    meetingurl: https://conference.scipy.org/proceedings/scipy2020/slides.html
-    location: Virtual
-    focus-area: as
-    project: pyhf
-  - title: "pyhf Tutorial: Accelerating analyses and preserving likelihoods"
-    date: 2020-07-16
-    url: https://indico.cern.ch/event/882824/contributions/3931292/
-    meeting: PyHEP 2020 Workshop
-    meetingurl: https://indico.cern.ch/event/882824/
-    location: Virtual
-    focus-area: as
-    project: pyhf
-    comment: "DOI: 10.5281/zenodo.4152916"
-  - title: "Likelihood Publication and Preservation"
-    date: 2020-08-10
-    url: https://indico.fnal.gov/event/43829/contributions/193820/
-    meeting: Snowmass 2021 Computational Frontier Workshop
-    meetingurl: https://indico.fnal.gov/event/43829/
-    location: Virtual
-    focus-area: as
-    project: pyhf
-  - title: "Toward Fitting as a Service with pyhf"
-    date: 2020-10-26
-    url: https://indico.cern.ch/event/960587/contributions/4070323/
-    meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
-    meetingurl: https://indico.cern.ch/event/960587/
-    location: Virtual
-    focus-area: as
-    project: pyhf
-  - title: "pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation"
-    date: 2020-11-03
-    url: https://indico.cern.ch/event/955391/contributions/4075505/
-    meeting: Tools for High Energy Physics and Cosmology 2020 Workshop
-    meetingurl: https://indico.cern.ch/event/955391/
-    location: Virtual
-    focus-area: as
-    project: pyhf
-  - title: "Modern Tools for Reusable Publications and Data Products"
-    date: 2020-11-26
-    url: https://lpsc-indico.in2p3.fr/event/2585/
-    meeting: LPSC Grenoble Colloquium
-    meetingurl: https://lpsc-indico.in2p3.fr/event/2585/
-    location: Virtual
-    focus-area: as
-    project:
-  - title: "Fitting and Statistical Inference as a Service"
-    date: 2020-12-04
-    url: https://indico.cern.ch/event/972791/contributions/4121109/
-    meeting: Mini-Workshop on Portable Inference
-    meetingurl: https://indico.cern.ch/event/972791
-    location: Virtual
-    focus-area: as
-    project: pyhf
-  - title: "Steps Towards Differentiable and Scalable Physics Analyses at the LHC"
-    date: 2020-12-08
-    url: https://indico.fnal.gov/event/46057/
-    meeting: Argonne Lunch Seminar
-    meetingurl: https://indico.fnal.gov/event/46057/
-    location: Virtual
-    focus-area: as
-    project: pyhf
+- title: 'pyhf: a pure Python implementation of HistFactory with tensors and autograd'
+  date: 2018-10-29
+  url: https://indico.cern.ch/event/759480/contributions/3149836/
+  meeting: DIANA/HEP Meeting
+  meetingurl: https://indico.cern.ch/event/759480/
+  location: Virtual
+  focus-area: as
+  project: pyhf
+- title: 'pyhf: a pure Python statistical fitting library for High Energy Physics
+    with tensors and autograd'
+  date: 2019-07-09
+  url: https://doi.org/10.25080/Majora-7ddc1dd1-019
+  meeting: 18th annual Scientific Computing with Python conference (SciPy 2019)
+  meetingurl: http://conference.scipy.org/proceedings/scipy2019/
+  location: University of Texas at Austin
+  focus-area: as
+  project: pyhf
+- title: Introduction to Docker
+  date: 2019-08-22
+  url: https://matthewfeickert.github.io/intro-to-docker/
+  meeting: 2019 USATLAS/FIRST-HEP Computing Bootcamp
+  meetingurl: https://indico.cern.ch/event/816946/
+  location: Lawrence Berkeley National Laboratory
+  focus-area: ssc
+  project:
+- title: 'pyhf Roadmap: 2019 into 2020'
+  date: 2019-09-12
+  url: https://indico.cern.ch/event/840472/contributions/3564386/
+  meeting: 2019 IRIS-HEP Institute Retreat
+  meetingurl: https://indico.cern.ch/event/840472/
+  location: Fermi National Accelerator Laboratory
+  focus-area: as
+  project: pyhf
+- title: 'pyhf: pure-Python implementation of HistFactory'
+  date: 2019-10-18
+  url: https://indico.cern.ch/event/833895/contributions/3577824/
+  meeting: PyHEP 2019 Workshop
+  meetingurl: https://indico.cern.ch/event/833895/
+  location: Abingdon, U.K.
+  focus-area: as
+  project: pyhf
+- title: 'pyhf: a pure Python implementation of HistFactory with tensors and autograd
+    (poster)'
+  date: 2019-11-05
+  url: https://indico.cern.ch/event/773049/contributions/3476180/
+  meeting: CHEP 2019 Conference
+  meetingurl: https://indico.cern.ch/event/773049/
+  location: Adelaide, South Australia
+  focus-area: as
+  project: pyhf
+- title: Likelihood preservation and statistical reproduction of searches for new
+    physics
+  date: 2019-11-07
+  url: https://indico.cern.ch/event/773049/contributions/3476143/
+  meeting: CHEP 2019 Conference
+  meetingurl: https://indico.cern.ch/event/773049/
+  location: Adelaide, South Australia
+  focus-area: as
+  project: pyhf
+- title: An introduction to pyhf and HistFactory likelihoods
+  date: 2019-11-25
+  url: https://matthewfeickert.github.io/talk-LHCb-Stats-Forum/index.html
+  meeting: LHCb Statistics Working Group
+  meetingurl: https://indico.cern.ch/event/863729/
+  location: Vidyo
+  focus-area: as
+  project: pyhf
+- title: 'pyhf: Pure Python Implementation of HistFactory'
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3334540/10_-_IRIS-HEP-2020-poster-session-pyhf.pdf
+  meeting: IRIS-HEP Poster Session 2020
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton, U.S.A.
+  focus-area: as
+  project: pyhf
+- title: 'pyhf: A Pure Python Statistical Fitting Library with Tensors and Autograd'
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/897086/attachments/2001484/3341223/Feickert_pyhf-NSF-Review-IRIS-HEP_2020-02-27.pdf
+  meeting: IRIS-HEP Postdoc Presentations
+  meetingurl: https://indico.cern.ch/event/897086/
+  location: Princeton, U.S.A.
+  focus-area: as
+  project: pyhf
+- title: pyhf Roadmap for IRIS-HEP Execution Phase
+  date: 2020-05-27
+  url: https://indico.cern.ch/event/896167/contributions/3880229/
+  meeting: 2020 IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167/
+  location: Virtual
+  focus-area: as
+  project: pyhf
+- title: 'pyhf: a pure Python statistical fitting library with tensors and autograd'
+  date: 2020-07-07
+  url: https://doi.org/10.25080/Majora-342d178e-023
+  meeting: 19th Python in Science Conference (SciPy 2020)
+  meetingurl: https://conference.scipy.org/proceedings/scipy2020/slides.html
+  location: Virtual
+  focus-area: as
+  project: pyhf
+- title: 'pyhf Tutorial: Accelerating analyses and preserving likelihoods'
+  date: 2020-07-16
+  url: https://indico.cern.ch/event/882824/contributions/3931292/
+  meeting: PyHEP 2020 Workshop
+  meetingurl: https://indico.cern.ch/event/882824/
+  location: Virtual
+  focus-area: as
+  project: pyhf
+  comment: 'DOI: 10.5281/zenodo.4152916'
+- title: Likelihood Publication and Preservation
+  date: 2020-08-10
+  url: https://indico.fnal.gov/event/43829/contributions/193820/
+  meeting: Snowmass 2021 Computational Frontier Workshop
+  meetingurl: https://indico.fnal.gov/event/43829/
+  location: Virtual
+  focus-area: as
+  project: pyhf
+- title: Toward Fitting as a Service with pyhf
+  date: 2020-10-26
+  url: https://indico.cern.ch/event/960587/contributions/4070323/
+  meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
+  meetingurl: https://indico.cern.ch/event/960587/
+  location: Virtual
+  focus-area: as
+  project: pyhf
+- title: 'pyhf: pure-Python implementation of HistFactory with tensors and automatic
+    differentiation'
+  date: 2020-11-03
+  url: https://indico.cern.ch/event/955391/contributions/4075505/
+  meeting: Tools for High Energy Physics and Cosmology 2020 Workshop
+  meetingurl: https://indico.cern.ch/event/955391/
+  location: Virtual
+  focus-area: as
+  project: pyhf
+- title: Modern Tools for Reusable Publications and Data Products
+  date: 2020-11-26
+  url: https://lpsc-indico.in2p3.fr/event/2585/
+  meeting: LPSC Grenoble Colloquium
+  meetingurl: https://lpsc-indico.in2p3.fr/event/2585/
+  location: Virtual
+  focus-area: as
+  project:
+- title: Fitting and Statistical Inference as a Service
+  date: 2020-12-04
+  url: https://indico.cern.ch/event/972791/contributions/4121109/
+  meeting: Mini-Workshop on Portable Inference
+  meetingurl: https://indico.cern.ch/event/972791
+  location: Virtual
+  focus-area: as
+  project: pyhf
+- title: Steps Towards Differentiable and Scalable Physics Analyses at the LHC
+  date: 2020-12-08
+  url: https://indico.fnal.gov/event/46057/
+  meeting: Argonne Lunch Seminar
+  meetingurl: https://indico.fnal.gov/event/46057/
+  location: Virtual
+  focus-area: as
+  project: pyhf

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -1,12 +1,14 @@
----
+active: true
+e-mail: matthew.feickert@cern.ch
+focus-area:
+- as
+- ssc
+institution: University of Illinois at Urbana-Champaign
 name: Matthew Feickert
+photo: "/assets/images/team/matthewfeickert.jpeg"
 shortname: matthewfeickert
 title: Postdoctoral researcher
-active: true
-institution: University of Illinois at Urbana-Champaign
 website: https://www.matthewfeickert.com
-photo: "/assets/images/team/matthewfeickert.jpeg"
-e-mail: matthew.feickert@cern.ch
 presentations:
 - title: 'pyhf: a pure Python implementation of HistFactory with tensors and autograd'
   date: 2018-10-29
@@ -165,6 +167,3 @@ presentations:
   location: Virtual
   focus-area: as
   project: pyhf
-focus-area:
-- as
-- ssc

--- a/_data/people/matyasselmeci.yml
+++ b/_data/people/matyasselmeci.yml
@@ -7,3 +7,5 @@ institution: University of Wisconsin–Madison
 website:
 photo: "/assets/images/team/Mat-Selmeci.png"
 presentations:
+focus-area:
+- osglhc

--- a/_data/people/matyasselmeci.yml
+++ b/_data/people/matyasselmeci.yml
@@ -1,8 +1,9 @@
+---
 name: Mátyás (Mat) Selmeci
 shortname: matyasselmeci
 title: Software Integration Developer
 active: true
 institution: University of Wisconsin–Madison
 website:
-photo: /assets/images/team/Mat-Selmeci.png
+photo: "/assets/images/team/Mat-Selmeci.png"
 presentations:

--- a/_data/people/matyasselmeci.yml
+++ b/_data/people/matyasselmeci.yml
@@ -1,11 +1,10 @@
----
-name: Mátyás (Mat) Selmeci
-shortname: matyasselmeci
-title: Software Integration Developer
 active: true
-institution: University of Wisconsin–Madison
-website:
-photo: "/assets/images/team/Mat-Selmeci.png"
-presentations:
 focus-area:
 - osglhc
+institution: University of Wisconsin–Madison
+name: Mátyás (Mat) Selmeci
+photo: "/assets/images/team/Mat-Selmeci.png"
+shortname: matyasselmeci
+title: Software Integration Developer
+website:
+presentations:

--- a/_data/people/mdhildreth.yml
+++ b/_data/people/mdhildreth.yml
@@ -1,9 +1,8 @@
----
-name: Mike Hildreth
-shortname: mdhildreth
-title:
 active: true
 institution: University of Notre Dame
-website: https://physics.nd.edu/people/faculty/michael-hildreth/
+name: Mike Hildreth
 photo: "/assets/images/team/Mike-Hildreth.jpg"
+shortname: mdhildreth
+title:
+website: https://physics.nd.edu/people/faculty/michael-hildreth/
 presentations:

--- a/_data/people/mdhildreth.yml
+++ b/_data/people/mdhildreth.yml
@@ -1,9 +1,9 @@
+---
 name: Mike Hildreth
 shortname: mdhildreth
 title:
 active: true
 institution: University of Notre Dame
 website: https://physics.nd.edu/people/faculty/michael-hildreth/
-photo: /assets/images/team/Mike-Hildreth.jpg
+photo: "/assets/images/team/Mike-Hildreth.jpg"
 presentations:
-

--- a/_data/people/mdsokoloff.yml
+++ b/_data/people/mdsokoloff.yml
@@ -1,8 +1,9 @@
+---
 name: Mike Sokoloff
 shortname: mdsokoloff
 title:
 active: true
 institution: University of Cincinnati
 website: https://www.artsci.uc.edu/departments/physics/fac_staff.html?eid=sokoloff&thecomp=uceprof
-photo: /assets/images/team/Mike-Sokoloff.jpg
+photo: "/assets/images/team/Mike-Sokoloff.jpg"
 presentations:

--- a/_data/people/mdsokoloff.yml
+++ b/_data/people/mdsokoloff.yml
@@ -1,12 +1,11 @@
----
-name: Mike Sokoloff
-shortname: mdsokoloff
-title:
 active: true
-institution: University of Cincinnati
-website: https://www.artsci.uc.edu/departments/physics/fac_staff.html?eid=sokoloff&thecomp=uceprof
-photo: "/assets/images/team/Mike-Sokoloff.jpg"
-presentations:
 focus-area:
 - ia
 - as
+institution: University of Cincinnati
+name: Mike Sokoloff
+photo: "/assets/images/team/Mike-Sokoloff.jpg"
+shortname: mdsokoloff
+title:
+website: https://www.artsci.uc.edu/departments/physics/fac_staff.html?eid=sokoloff&thecomp=uceprof
+presentations:

--- a/_data/people/mdsokoloff.yml
+++ b/_data/people/mdsokoloff.yml
@@ -7,3 +7,6 @@ institution: University of Cincinnati
 website: https://www.artsci.uc.edu/departments/physics/fac_staff.html?eid=sokoloff&thecomp=uceprof
 photo: "/assets/images/team/Mike-Sokoloff.jpg"
 presentations:
+focus-area:
+- ia
+- as

--- a/_data/people/meevans1.yml
+++ b/_data/people/meevans1.yml
@@ -1,69 +1,72 @@
+---
 name: Meirin Oan Evans
 shortname: meevans1
 title: HSF Training Coordinator
 active: true
 institution: University of Sussex
 website: https://meirinoanevans.wixsite.com/portfolio
-photo: /assets/images/team/Meirin-Evans.jpg
-hidden: True
+photo: "/assets/images/team/Meirin-Evans.jpg"
+hidden: true
 presentations:
-  - title: Introduction to Machine Learning
-    date: 2020-11-02
-    url: https://indico.cern.ch/event/958112/sessions/370197/#20201103
-    meeting: ML + GPU Training
-    meetingurl: https://indico.cern.ch/event/958112/
-    location: Online
-  - title: Teaching Machine Learning with ATLAS Open Data
-    date: 2020-10-23
-    url: https://indico.cern.ch/event/852553/contributions/4057691/attachments/2128826/3584684/TeachingMachineLearning.pdf
-    meeting: 4th Inter-experiment Machine Learning Workshop
-    meetingurl: https://indico.cern.ch/event/852553/
-    location: Online
-  - title: Introduction to Machine Learning
-    date: 2020-10-12
-    url: https://indico.ph.liv.ac.uk/event/103/contributions/1221/
-    meeting: STFC School on Data Intensive Science 2020
-    meetingurl: https://indico.ph.liv.ac.uk/event/103
-    location: Online
-  - title: "Connecting teaching to research: ATLAS Open Data in Sussex courses"
-    date: 2020-10-01
-    url: https://epp.phys.sussex.ac.uk/Seminars_2020_21
-    meeting: University of Sussex Experimental Particle Physics seminars
-    meetingurl: https://epp.phys.sussex.ac.uk/Seminars_2020_21
-    location: Online
-  - title: The ATLAS public website - Evolution to Drupal 8
-    date: 2020-07-28
-    url: https://indico.cern.ch/event/868940/contributions/3814042/
-    meeting: ICHEP 2020
-    meetingurl: https://indico.cern.ch/event/868940
-    location: Online
-  - title: LHC Open Data for the world to see
-    date: 2020-05-29
-    url: https://indico.cern.ch/event/856696/contributions/3855377/
-    meeting: LHCP 2020
-    meetingurl: https://indico.cern.ch/event/856696
-    location: Online
-  - title: "ATLAS Open Data: Data visualisation and educational physics analysis to re-discover the Higgs"
-    date: 2020-05-28
-    url: https://indico.cern.ch/event/856696/contributions/3856041/
-    meeting: LHCP 2020
-    meetingurl: https://indico.cern.ch/event/856696
-    location: Online
-  - title: Optimising for signal to background ratio using statistical techniques
-    date: 2018-07-06
-    url: https://github.com/meevans1/How-to-rediscover-the-Higgs
-    meeting: STFC Data Intensive, Artificial Intelligence and Machine Learning Summer School 2019
-    meetingurl: https://www.sussex.ac.uk/discus/contact/stfcsummerschool2019
-    location: Sussex
-  - title: ATLAS Open Data for Run 2
-    date: 2019-05-29
-    url: http://indico.ictp.it/event/8679/session/74/contribution/241/material/poster/0.pdf
-    meeting: Interpreting the LHC Run 2 Data and Beyond
-    meetingurl: http://indico.ictp.it/event/8679/overview
-    location: ICTP Trieste
-  - title: ATLAS Open Data project
-    date: 2018-07-06
-    url: https://indico.cern.ch/event/686555/contributions/2971025/
-    meeting: ICHEP 2018
-    meetingurl: https://indico.cern.ch/event/686555
-    location: Seoul
+- title: Introduction to Machine Learning
+  date: 2020-11-02
+  url: https://indico.cern.ch/event/958112/sessions/370197/#20201103
+  meeting: ML + GPU Training
+  meetingurl: https://indico.cern.ch/event/958112/
+  location: Online
+- title: Teaching Machine Learning with ATLAS Open Data
+  date: 2020-10-23
+  url: https://indico.cern.ch/event/852553/contributions/4057691/attachments/2128826/3584684/TeachingMachineLearning.pdf
+  meeting: 4th Inter-experiment Machine Learning Workshop
+  meetingurl: https://indico.cern.ch/event/852553/
+  location: Online
+- title: Introduction to Machine Learning
+  date: 2020-10-12
+  url: https://indico.ph.liv.ac.uk/event/103/contributions/1221/
+  meeting: STFC School on Data Intensive Science 2020
+  meetingurl: https://indico.ph.liv.ac.uk/event/103
+  location: Online
+- title: 'Connecting teaching to research: ATLAS Open Data in Sussex courses'
+  date: 2020-10-01
+  url: https://epp.phys.sussex.ac.uk/Seminars_2020_21
+  meeting: University of Sussex Experimental Particle Physics seminars
+  meetingurl: https://epp.phys.sussex.ac.uk/Seminars_2020_21
+  location: Online
+- title: The ATLAS public website - Evolution to Drupal 8
+  date: 2020-07-28
+  url: https://indico.cern.ch/event/868940/contributions/3814042/
+  meeting: ICHEP 2020
+  meetingurl: https://indico.cern.ch/event/868940
+  location: Online
+- title: LHC Open Data for the world to see
+  date: 2020-05-29
+  url: https://indico.cern.ch/event/856696/contributions/3855377/
+  meeting: LHCP 2020
+  meetingurl: https://indico.cern.ch/event/856696
+  location: Online
+- title: 'ATLAS Open Data: Data visualisation and educational physics analysis to
+    re-discover the Higgs'
+  date: 2020-05-28
+  url: https://indico.cern.ch/event/856696/contributions/3856041/
+  meeting: LHCP 2020
+  meetingurl: https://indico.cern.ch/event/856696
+  location: Online
+- title: Optimising for signal to background ratio using statistical techniques
+  date: 2018-07-06
+  url: https://github.com/meevans1/How-to-rediscover-the-Higgs
+  meeting: STFC Data Intensive, Artificial Intelligence and Machine Learning Summer
+    School 2019
+  meetingurl: https://www.sussex.ac.uk/discus/contact/stfcsummerschool2019
+  location: Sussex
+- title: ATLAS Open Data for Run 2
+  date: 2019-05-29
+  url: http://indico.ictp.it/event/8679/session/74/contribution/241/material/poster/0.pdf
+  meeting: Interpreting the LHC Run 2 Data and Beyond
+  meetingurl: http://indico.ictp.it/event/8679/overview
+  location: ICTP Trieste
+- title: ATLAS Open Data project
+  date: 2018-07-06
+  url: https://indico.cern.ch/event/686555/contributions/2971025/
+  meeting: ICHEP 2018
+  meetingurl: https://indico.cern.ch/event/686555
+  location: Seoul

--- a/_data/people/meevans1.yml
+++ b/_data/people/meevans1.yml
@@ -1,12 +1,11 @@
----
+active: true
+hidden: true
+institution: University of Sussex
 name: Meirin Oan Evans
+photo: "/assets/images/team/Meirin-Evans.jpg"
 shortname: meevans1
 title: HSF Training Coordinator
-active: true
-institution: University of Sussex
 website: https://meirinoanevans.wixsite.com/portfolio
-photo: "/assets/images/team/Meirin-Evans.jpg"
-hidden: true
 presentations:
 - title: Introduction to Machine Learning
   date: 2020-11-02

--- a/_data/people/mityinzer.yml
+++ b/_data/people/mityinzer.yml
@@ -1,12 +1,11 @@
----
-name: Mike Williams
-shortname: mityinzer
-title:
 active: true
-institution: Massachusetts Institute of Technology
-website: http://web.mit.edu/physics/people/faculty/williams_mike.html
-photo: "/assets/images/team/Mike-Williams.jpg"
-presentations:
 focus-area:
 - ia
 - as
+institution: Massachusetts Institute of Technology
+name: Mike Williams
+photo: "/assets/images/team/Mike-Williams.jpg"
+shortname: mityinzer
+title:
+website: http://web.mit.edu/physics/people/faculty/williams_mike.html
+presentations:

--- a/_data/people/mityinzer.yml
+++ b/_data/people/mityinzer.yml
@@ -1,8 +1,9 @@
+---
 name: Mike Williams
 shortname: mityinzer
 title:
 active: true
 institution: Massachusetts Institute of Technology
 website: http://web.mit.edu/physics/people/faculty/williams_mike.html
-photo: /assets/images/team/Mike-Williams.jpg
+photo: "/assets/images/team/Mike-Williams.jpg"
 presentations:

--- a/_data/people/mityinzer.yml
+++ b/_data/people/mityinzer.yml
@@ -7,3 +7,6 @@ institution: Massachusetts Institute of Technology
 website: http://web.mit.edu/physics/people/faculty/williams_mike.html
 photo: "/assets/images/team/Mike-Williams.jpg"
 presentations:
+focus-area:
+- ia
+- as

--- a/_data/people/mmasciov.yml
+++ b/_data/people/mmasciov.yml
@@ -1,22 +1,24 @@
+---
 name: Mario Masciovecchio
 shortname: mmasciov
 title:
 active: true
 institution: University of California, San Diego
 website: https://github.com/mmasciov
-photo: /assets/images/team/Mario-Masciovecchio.jpg
+photo: "/assets/images/team/Mario-Masciovecchio.jpg"
 presentations:
-  - title: mkfit and HL-LHC tracking in CMS
-    meeting: Joint HSF event reconstruction/trigger working group and IRIS-HEP Topical Meeting
-    meetingurl: https://indico.cern.ch/event/882106/
-    url: https://indico.cern.ch/event/882106/contributions/3741028/attachments/1986653/3310542/MkFit_Mario-Masciovecchio_IrisHEP.pdf
-    date: 2020-02-12
-    focus-area: ia
-    project: mkfit
-  - title: Accelerated Full Tracking at (CMS) HLT
-    meeting: CMS scouting kick-off workshop
-    meetingurl: https://indico.cern.ch/event/880405/
-    url: https://indico.cern.ch/event/880405/contributions/3709436/attachments/1985482/3308174/MkFit_Mario-Masciovecchio_ScoutingWorkshop.pdf
-    date: 2020-02-11
-    focus-area: ia
-    project: mkfit
+- title: mkfit and HL-LHC tracking in CMS
+  meeting: Joint HSF event reconstruction/trigger working group and IRIS-HEP Topical
+    Meeting
+  meetingurl: https://indico.cern.ch/event/882106/
+  url: https://indico.cern.ch/event/882106/contributions/3741028/attachments/1986653/3310542/MkFit_Mario-Masciovecchio_IrisHEP.pdf
+  date: 2020-02-12
+  focus-area: ia
+  project: mkfit
+- title: Accelerated Full Tracking at (CMS) HLT
+  meeting: CMS scouting kick-off workshop
+  meetingurl: https://indico.cern.ch/event/880405/
+  url: https://indico.cern.ch/event/880405/contributions/3709436/attachments/1985482/3308174/MkFit_Mario-Masciovecchio_ScoutingWorkshop.pdf
+  date: 2020-02-11
+  focus-area: ia
+  project: mkfit

--- a/_data/people/mmasciov.yml
+++ b/_data/people/mmasciov.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ia
+institution: University of California, San Diego
 name: Mario Masciovecchio
+photo: "/assets/images/team/Mario-Masciovecchio.jpg"
 shortname: mmasciov
 title:
-active: true
-institution: University of California, San Diego
 website: https://github.com/mmasciov
-photo: "/assets/images/team/Mario-Masciovecchio.jpg"
 presentations:
 - title: mkfit and HL-LHC tracking in CMS
   meeting: Joint HSF event reconstruction/trigger working group and IRIS-HEP Topical
@@ -22,5 +23,3 @@ presentations:
   date: 2020-02-11
   focus-area: ia
   project: mkfit
-focus-area:
-- ia

--- a/_data/people/mmasciov.yml
+++ b/_data/people/mmasciov.yml
@@ -22,3 +22,5 @@ presentations:
   date: 2020-02-11
   focus-area: ia
   project: mkfit
+focus-area:
+- ia

--- a/_data/people/msneubauer.yml
+++ b/_data/people/msneubauer.yml
@@ -1,93 +1,117 @@
+---
 name: Mark Neubauer
 shortname: msneubauer
 title: Blueprint Coordinator
 active: true
 institution: University of Illinois at Urbana-Champaign
 website: http://msneubauer.github.io
-photo: /assets/images/team/Mark-Neubauer.png
+photo: "/assets/images/team/Mark-Neubauer.png"
 e-mail: msn@illinois.edu
 presentations:
-  - title: Design Roadmap for Future Collaborations
-    date: 2018-10-19
-    url: http://www.ncsa.illinois.edu/Conferences/DeepLearningLSST/agenda.html
-    meeting: Deep Learning for Multimessenger Astrophysics Real-time Discovery at Scale
-    meetingurl: http://www.ncsa.illinois.edu/Conferences/DeepLearningLSST
-    location: NCSA
-    focus-area: [as, ia]
-  - title: Scalable Cyberinfrastructure for Artificial Intelligence and Likelihood-Free Inference
-    date: 2019-04-05
-    url: http://www.largefacilitiesworkshop.com/agenda-3/
-    meeting: NSF Large Facilities Workshop
-    meetingurl: https://www.largefacilitiesworkshop.com/19workshop/
-    location: TACC
-    focus-area: [as, ia]
-  - title: Deep Learning for Higgs Boson Identification and Searches for New Physics at the Large Hadron Collider
-    date: 2019-06-04
-    url: http://bluewaterssymposium2019.sched.com/event/NRlw/physics-mark-neubauer-university-of-illinois-at-urbana-champaign-deep-learning-for-higgs-boson-identification-and-searches-for-new-physics-at-the-large-hadron-collider
-    meeting: Blue Waters Symposium for Petascale Science and Beyond
-    meetingurl: https://bluewaters.ncsa.illinois.edu/blue-waters-symposium-2019
-    location: Sunriver, OR
-    focus-area: [as, ia]
-  - title: IRIS-HEP Blueprint Concepts and Process
-    date: 2019-06-21
-    url: https://indico.cern.ch/event/820946/contributions/3461588/attachments/1866577/3069573/IRIS-HEP_BluePrint_AS_SSL.pdf
-    meeting: Blueprint Meeting on Analysis Systems on Scalable Platforms
-    meetingurl: https://indico.cern.ch/event/820946/
-    location: NYU
-    focus-area: [as, ssl]
-  - title: The IRIS-HEP Blueprint Concepts and Process
-    date: 2019-09-10
-    url: https://indico.cern.ch/event/822126/contributions/3500165/attachments/1905471/3146855/IRIS-HEP_BluePrint_FML.pdf
-    meeting: Blueprint Meeting on Fast Machine Learning and Inference
-    meetingurl: https://indico.cern.ch/event/822126/
-    location: FNAL
-    focus-area: as
-  - title: Artifical Intelligence for High-Energy Physics
-    date: 2020-03-05
-    url: https://www.jlab.org/indico/event/357/contribution/21/material/slides/0.pdf
-    meeting: Artificial Intelligence for Nuclear Physics Workshop
-    meetingurl: https://www.jlab.org/indico/event/357/
-    location: Jefferson Laboratory
-    focus-area: [as, ia]
-  - title: "Future Blueprint Topics: Year 3 Plans, 4 and 5 Year Thoughts"
-    date: 2020-05-29
-    url: https://indico.cern.ch/event/896167/contributions/3876784/attachments/2047955/3431686/IRIS-HEP_Retreat_Blueprint.pdf
-    meeting: IRIS-HEP Team Retreat
-    meetingurl: https://indico.cern.ch/event/896167/
-    location: Virtual
-    focus-area: [as, ia, doma]
-  - title: The IRIS-HEP Blueprint Process
-    date: 2020-07-22
-    url: https://indico.cern.ch/event/930127/contributions/3914364/attachments/2077932/3489689/Blueprint_Intro_SustainableSoftware.pdf
-    meeting: Sustainable Software in HEP Blueprint Workshop
-    meetingurl: https://indico.cern.ch/event/930127/
-    location: Virtual
-    focus-area: ssc
-  - title: Particle Physics and Machine Learning in Education
-    date: 2020-08-11
-    url: https://indico.fnal.gov/event/43829/contributions/193606/attachments/132815/163444/Snomass_Comp_msn.pdf
-    meeting: Snowmass Computational Frontier Workshop
-    meetingurl: https://indico.fnal.gov/event/43829/
-    location: Virtual
-    focus-area: [ia, ssc]
-  - title: Welcome, IRIS-HEP Blueprint Activity and Workshop Overview
-    date: 2020-10-26
-    url: https://indico.cern.ch/event/960587/contributions/4070316/attachments/2129580/3586070/Blueprint_Intro_ASAF.pdf
-    meeting: Future Analysis Systems and Facilities Blueprint Workshop
-    meetingurl: https://indico.cern.ch/event/960587/
-    location: Virtual
-    focus-area: [as, doma]
-  - title: Workshop Overview and Goals
-    date: 2020-12-04
-    url: https://indico.cern.ch/event/972791/contributions/4121084
-    meeting: Mini-Workshop on Portable Inference
-    meetingurl: https://indico.cern.ch/event/972791
-    location: Virtual
-    focus-area: [as, ia]
-  - title: Summary of Future Analysis Systems and Facilities Workshop
-    date: 2020-12-15
-    url: https://indico.cern.ch/event/972791/contributions/4121084
-    meeting: Workflow Management System Software Technical Interchange Meeting
-    meetingurl: https://indico.cern.ch/event/975046
-    location: Virtual
-    focus-area: [as, doma]
+- title: Design Roadmap for Future Collaborations
+  date: 2018-10-19
+  url: http://www.ncsa.illinois.edu/Conferences/DeepLearningLSST/agenda.html
+  meeting: Deep Learning for Multimessenger Astrophysics Real-time Discovery at Scale
+  meetingurl: http://www.ncsa.illinois.edu/Conferences/DeepLearningLSST
+  location: NCSA
+  focus-area:
+  - as
+  - ia
+- title: Scalable Cyberinfrastructure for Artificial Intelligence and Likelihood-Free
+    Inference
+  date: 2019-04-05
+  url: http://www.largefacilitiesworkshop.com/agenda-3/
+  meeting: NSF Large Facilities Workshop
+  meetingurl: https://www.largefacilitiesworkshop.com/19workshop/
+  location: TACC
+  focus-area:
+  - as
+  - ia
+- title: Deep Learning for Higgs Boson Identification and Searches for New Physics
+    at the Large Hadron Collider
+  date: 2019-06-04
+  url: http://bluewaterssymposium2019.sched.com/event/NRlw/physics-mark-neubauer-university-of-illinois-at-urbana-champaign-deep-learning-for-higgs-boson-identification-and-searches-for-new-physics-at-the-large-hadron-collider
+  meeting: Blue Waters Symposium for Petascale Science and Beyond
+  meetingurl: https://bluewaters.ncsa.illinois.edu/blue-waters-symposium-2019
+  location: Sunriver, OR
+  focus-area:
+  - as
+  - ia
+- title: IRIS-HEP Blueprint Concepts and Process
+  date: 2019-06-21
+  url: https://indico.cern.ch/event/820946/contributions/3461588/attachments/1866577/3069573/IRIS-HEP_BluePrint_AS_SSL.pdf
+  meeting: Blueprint Meeting on Analysis Systems on Scalable Platforms
+  meetingurl: https://indico.cern.ch/event/820946/
+  location: NYU
+  focus-area:
+  - as
+  - ssl
+- title: The IRIS-HEP Blueprint Concepts and Process
+  date: 2019-09-10
+  url: https://indico.cern.ch/event/822126/contributions/3500165/attachments/1905471/3146855/IRIS-HEP_BluePrint_FML.pdf
+  meeting: Blueprint Meeting on Fast Machine Learning and Inference
+  meetingurl: https://indico.cern.ch/event/822126/
+  location: FNAL
+  focus-area: as
+- title: Artifical Intelligence for High-Energy Physics
+  date: 2020-03-05
+  url: https://www.jlab.org/indico/event/357/contribution/21/material/slides/0.pdf
+  meeting: Artificial Intelligence for Nuclear Physics Workshop
+  meetingurl: https://www.jlab.org/indico/event/357/
+  location: Jefferson Laboratory
+  focus-area:
+  - as
+  - ia
+- title: 'Future Blueprint Topics: Year 3 Plans, 4 and 5 Year Thoughts'
+  date: 2020-05-29
+  url: https://indico.cern.ch/event/896167/contributions/3876784/attachments/2047955/3431686/IRIS-HEP_Retreat_Blueprint.pdf
+  meeting: IRIS-HEP Team Retreat
+  meetingurl: https://indico.cern.ch/event/896167/
+  location: Virtual
+  focus-area:
+  - as
+  - ia
+  - doma
+- title: The IRIS-HEP Blueprint Process
+  date: 2020-07-22
+  url: https://indico.cern.ch/event/930127/contributions/3914364/attachments/2077932/3489689/Blueprint_Intro_SustainableSoftware.pdf
+  meeting: Sustainable Software in HEP Blueprint Workshop
+  meetingurl: https://indico.cern.ch/event/930127/
+  location: Virtual
+  focus-area: ssc
+- title: Particle Physics and Machine Learning in Education
+  date: 2020-08-11
+  url: https://indico.fnal.gov/event/43829/contributions/193606/attachments/132815/163444/Snomass_Comp_msn.pdf
+  meeting: Snowmass Computational Frontier Workshop
+  meetingurl: https://indico.fnal.gov/event/43829/
+  location: Virtual
+  focus-area:
+  - ia
+  - ssc
+- title: Welcome, IRIS-HEP Blueprint Activity and Workshop Overview
+  date: 2020-10-26
+  url: https://indico.cern.ch/event/960587/contributions/4070316/attachments/2129580/3586070/Blueprint_Intro_ASAF.pdf
+  meeting: Future Analysis Systems and Facilities Blueprint Workshop
+  meetingurl: https://indico.cern.ch/event/960587/
+  location: Virtual
+  focus-area:
+  - as
+  - doma
+- title: Workshop Overview and Goals
+  date: 2020-12-04
+  url: https://indico.cern.ch/event/972791/contributions/4121084
+  meeting: Mini-Workshop on Portable Inference
+  meetingurl: https://indico.cern.ch/event/972791
+  location: Virtual
+  focus-area:
+  - as
+  - ia
+- title: Summary of Future Analysis Systems and Facilities Workshop
+  date: 2020-12-15
+  url: https://indico.cern.ch/event/972791/contributions/4121084
+  meeting: Workflow Management System Software Technical Interchange Meeting
+  meetingurl: https://indico.cern.ch/event/975046
+  location: Virtual
+  focus-area:
+  - as
+  - doma

--- a/_data/people/msneubauer.yml
+++ b/_data/people/msneubauer.yml
@@ -1,12 +1,17 @@
----
+active: true
+e-mail: msn@illinois.edu
+focus-area:
+- as
+- ia
+- ssl
+- doma
+- ssc
+institution: University of Illinois at Urbana-Champaign
 name: Mark Neubauer
+photo: "/assets/images/team/Mark-Neubauer.png"
 shortname: msneubauer
 title: Blueprint Coordinator
-active: true
-institution: University of Illinois at Urbana-Champaign
 website: http://msneubauer.github.io
-photo: "/assets/images/team/Mark-Neubauer.png"
-e-mail: msn@illinois.edu
 presentations:
 - title: Design Roadmap for Future Collaborations
   date: 2018-10-19
@@ -115,9 +120,3 @@ presentations:
   focus-area:
   - as
   - doma
-focus-area:
-- as
-- ia
-- ssl
-- doma
-- ssc

--- a/_data/people/msneubauer.yml
+++ b/_data/people/msneubauer.yml
@@ -115,3 +115,9 @@ presentations:
   focus-area:
   - as
   - doma
+focus-area:
+- as
+- ia
+- ssl
+- doma
+- ssc

--- a/_data/people/mtstanfield.yml
+++ b/_data/people/mtstanfield.yml
@@ -1,8 +1,9 @@
+---
 name: Mike Stanfield
 shortname: mtstanfield
 title: Senior Security Analyst
 active: true
 institution: Indiana University
 website: https://cacr.iu.edu/about/people/mike-stanfield.html
-photo: /assets/images/team/mike-standfield.jpg
+photo: "/assets/images/team/mike-standfield.jpg"
 presentations:

--- a/_data/people/mtstanfield.yml
+++ b/_data/people/mtstanfield.yml
@@ -1,11 +1,10 @@
----
-name: Mike Stanfield
-shortname: mtstanfield
-title: Senior Security Analyst
 active: true
-institution: Indiana University
-website: https://cacr.iu.edu/about/people/mike-stanfield.html
-photo: "/assets/images/team/mike-standfield.jpg"
-presentations:
 focus-area:
 - osglhc
+institution: Indiana University
+name: Mike Stanfield
+photo: "/assets/images/team/mike-standfield.jpg"
+shortname: mtstanfield
+title: Senior Security Analyst
+website: https://cacr.iu.edu/about/people/mike-stanfield.html
+presentations:

--- a/_data/people/mtstanfield.yml
+++ b/_data/people/mtstanfield.yml
@@ -7,3 +7,5 @@ institution: Indiana University
 website: https://cacr.iu.edu/about/people/mike-stanfield.html
 photo: "/assets/images/team/mike-standfield.jpg"
 presentations:
+focus-area:
+- osglhc

--- a/_data/people/mweinberg2718.yml
+++ b/_data/people/mweinberg2718.yml
@@ -1,11 +1,14 @@
----
+active: false
+focus-area:
+- doma
+- as
+- ssl
+institution: University of Chicago
 name: Marc Weinberg
+photo: "/assets/images/team/Marc-Weinberg.jpg"
 shortname: mweinberg2718
 title:
-active: false
-institution: University of Chicago
 website:
-photo: "/assets/images/team/Marc-Weinberg.jpg"
 presentations:
 - title: Delivery of columnar data to analysis systems
   date: 2019-06-24
@@ -47,7 +50,3 @@ presentations:
   - doma
   - as
   - ssl
-focus-area:
-- doma
-- as
-- ssl

--- a/_data/people/mweinberg2718.yml
+++ b/_data/people/mweinberg2718.yml
@@ -1,36 +1,49 @@
+---
 name: Marc Weinberg
 shortname: mweinberg2718
 title:
 active: false
 institution: University of Chicago
 website:
-photo: /assets/images/team/Marc-Weinberg.jpg
+photo: "/assets/images/team/Marc-Weinberg.jpg"
 presentations:
-  - title: Delivery of columnar data to analysis systems
-    date: 2019-06-24
-    url: https://indico.cern.ch/event/765245/contributions/3470867/attachments/1869892/3076485/weinbergServiceX190626.pdf
-    meeting: "ATLAS Software & Computing Week #62"
-    meetingurl: https://indico.cern.ch/event/765245/
-    location: New York City, New York
-    focus-area: [doma, as, ssl]
-    project: idds
-  - title: Delivery of columnar data to analysis systems
-    date: 2019-07-17
-    url: https://indico.cern.ch/event/811101/contributions/3498875/attachments/1882426/3102062/weinbergServiceX190717.pdf
-    meeting: Annual US ATLAS Computing, Software and Physics Support Technical Meeting
-    meetingurl: https://indico.cern.ch/event/811101/
-    location: Seattle, Washington
-    focus-area: [doma, as, ssl]
-  - title: ServiceX
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331175/8_-_weinbergGalewsky-serviceX-irisHepReview.pdf
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton, New Jersey
-    focus-area: [doma, as, ssl]
-  - title: "ServiceX: A distributed, caching, columnar data delivery service"
-    date: 2020-03-23
-    url: https://indico.cern.ch/event/890991/contributions/3778330/attachments/2007255/3352709/weinbergServiceX200323.pdf
-    meeting: "HSF DAWG -- DOMA Access joint meeting"
-    meetingurl: https://indico.cern.ch/event/890991/
-    focus-area: [doma, as, ssl]
+- title: Delivery of columnar data to analysis systems
+  date: 2019-06-24
+  url: https://indico.cern.ch/event/765245/contributions/3470867/attachments/1869892/3076485/weinbergServiceX190626.pdf
+  meeting: 'ATLAS Software & Computing Week #62'
+  meetingurl: https://indico.cern.ch/event/765245/
+  location: New York City, New York
+  focus-area:
+  - doma
+  - as
+  - ssl
+  project: idds
+- title: Delivery of columnar data to analysis systems
+  date: 2019-07-17
+  url: https://indico.cern.ch/event/811101/contributions/3498875/attachments/1882426/3102062/weinbergServiceX190717.pdf
+  meeting: Annual US ATLAS Computing, Software and Physics Support Technical Meeting
+  meetingurl: https://indico.cern.ch/event/811101/
+  location: Seattle, Washington
+  focus-area:
+  - doma
+  - as
+  - ssl
+- title: ServiceX
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331175/8_-_weinbergGalewsky-serviceX-irisHepReview.pdf
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton, New Jersey
+  focus-area:
+  - doma
+  - as
+  - ssl
+- title: 'ServiceX: A distributed, caching, columnar data delivery service'
+  date: 2020-03-23
+  url: https://indico.cern.ch/event/890991/contributions/3778330/attachments/2007255/3352709/weinbergServiceX200323.pdf
+  meeting: HSF DAWG -- DOMA Access joint meeting
+  meetingurl: https://indico.cern.ch/event/890991/
+  focus-area:
+  - doma
+  - as
+  - ssl

--- a/_data/people/mweinberg2718.yml
+++ b/_data/people/mweinberg2718.yml
@@ -47,3 +47,7 @@ presentations:
   - doma
   - as
   - ssl
+focus-area:
+- doma
+- as
+- ssl

--- a/_data/people/nickcinko.yml
+++ b/_data/people/nickcinko.yml
@@ -20,3 +20,5 @@ presentations:
   meetingurl: https://indico.physics.lbl.gov/indico/event/712/contributions/3021/
   focus-area: ia
   project: acts
+focus-area:
+- ia

--- a/_data/people/nickcinko.yml
+++ b/_data/people/nickcinko.yml
@@ -1,21 +1,22 @@
+---
 name: Nicholas Cinko
 shortname: nickcinko
 title: Graduate Student
 active: false
-photo: /assets/images/atom.png
+photo: "/assets/images/atom.png"
 institution: University of California, Berkeley
 presentations:
-  - title: "Ambiguity Resolution: Using Machine Learning"
-    date: 2019-07-31
-    url: https://docs.google.com/presentation/d/10KrWxl0Z07Vp2Scx1k7Dow3JUV5Z7uziEQR56L3FPRs/edit#slide=id.p
-    meeting: ACTS Developers Meetings
-    meetingurl: https://indico.cern.ch/event/832703/
-    focus-area: ia
-    project: acts
-  - title: "Ambiguity Resolution Studies with ACTS"
-    date: 2019-01-13
-    url: https://indico.physics.lbl.gov/indico/event/712/contributions/3021/attachments/1761/2138/go
-    meeting: Berkeley Tracking Workshop
-    meetingurl: https://indico.physics.lbl.gov/indico/event/712/contributions/3021/
-    focus-area: ia
-    project: acts
+- title: 'Ambiguity Resolution: Using Machine Learning'
+  date: 2019-07-31
+  url: https://docs.google.com/presentation/d/10KrWxl0Z07Vp2Scx1k7Dow3JUV5Z7uziEQR56L3FPRs/edit#slide=id.p
+  meeting: ACTS Developers Meetings
+  meetingurl: https://indico.cern.ch/event/832703/
+  focus-area: ia
+  project: acts
+- title: Ambiguity Resolution Studies with ACTS
+  date: 2019-01-13
+  url: https://indico.physics.lbl.gov/indico/event/712/contributions/3021/attachments/1761/2138/go
+  meeting: Berkeley Tracking Workshop
+  meetingurl: https://indico.physics.lbl.gov/indico/event/712/contributions/3021/
+  focus-area: ia
+  project: acts

--- a/_data/people/nickcinko.yml
+++ b/_data/people/nickcinko.yml
@@ -1,10 +1,11 @@
----
+active: false
+focus-area:
+- ia
+institution: University of California, Berkeley
 name: Nicholas Cinko
+photo: "/assets/images/atom.png"
 shortname: nickcinko
 title: Graduate Student
-active: false
-photo: "/assets/images/atom.png"
-institution: University of California, Berkeley
 presentations:
 - title: 'Ambiguity Resolution: Using Machine Learning'
   date: 2019-07-31
@@ -20,5 +21,3 @@ presentations:
   meetingurl: https://indico.physics.lbl.gov/indico/event/712/contributions/3021/
   focus-area: ia
   project: acts
-focus-area:
-- ia

--- a/_data/people/o_gutsche.yml
+++ b/_data/people/o_gutsche.yml
@@ -1,9 +1,10 @@
+---
 name: Oliver Gutsche
 shortname: o_gutsche
 title: US CMS Ops Program
 active: true
 institution: FNAL
 website:
-photo: /assets/images/team/Oliver_Gutsche.jpg
+photo: "/assets/images/team/Oliver_Gutsche.jpg"
 hidden: true
 presentations:

--- a/_data/people/o_gutsche.yml
+++ b/_data/people/o_gutsche.yml
@@ -1,10 +1,9 @@
----
+active: true
+hidden: true
+institution: FNAL
 name: Oliver Gutsche
+photo: "/assets/images/team/Oliver_Gutsche.jpg"
 shortname: o_gutsche
 title: US CMS Ops Program
-active: true
-institution: FNAL
 website:
-photo: "/assets/images/team/Oliver_Gutsche.jpg"
-hidden: true
 presentations:

--- a/_data/people/osg-cat.yml
+++ b/_data/people/osg-cat.yml
@@ -1,8 +1,9 @@
+---
 name: Tim Cartwright
 shortname: osg-cat
 title: OSG Deputy Executive Director
 active: true
 institution: University of Wisconsin–Madison
 website: http://pages.cs.wisc.edu/~cat/
-photo: /assets/images/team/Tim-Cartwright.jpg
+photo: "/assets/images/team/Tim-Cartwright.jpg"
 presentations:

--- a/_data/people/osg-cat.yml
+++ b/_data/people/osg-cat.yml
@@ -1,9 +1,8 @@
----
-name: Tim Cartwright
-shortname: osg-cat
-title: OSG Deputy Executive Director
 active: true
 institution: University of Wisconsin–Madison
-website: http://pages.cs.wisc.edu/~cat/
+name: Tim Cartwright
 photo: "/assets/images/team/Tim-Cartwright.jpg"
+shortname: osg-cat
+title: OSG Deputy Executive Director
+website: http://pages.cs.wisc.edu/~cat/
 presentations:

--- a/_data/people/oshadura.yml
+++ b/_data/people/oshadura.yml
@@ -39,3 +39,6 @@ presentations:
   location: Virtual
   focus-area: doma
   project: coffea-casa
+focus-area:
+- doma
+- as

--- a/_data/people/oshadura.yml
+++ b/_data/people/oshadura.yml
@@ -1,11 +1,13 @@
----
+active: true
+focus-area:
+- doma
+- as
+institution: University of Nebraska - Lincoln
 name: Oksana Shadura
+photo: "/assets/images/team/Oksana-Shadura_.jpg"
 shortname: oshadura
 title:
-active: true
-institution: University of Nebraska - Lincoln
 website: https://github.com/oshadura
-photo: "/assets/images/team/Oksana-Shadura_.jpg"
 presentations:
 - title: Future analysis facilities
   date: 2021-02-03
@@ -39,6 +41,3 @@ presentations:
   location: Virtual
   focus-area: doma
   project: coffea-casa
-focus-area:
-- doma
-- as

--- a/_data/people/oshadura.yml
+++ b/_data/people/oshadura.yml
@@ -1,12 +1,13 @@
+---
 name: Oksana Shadura
 shortname: oshadura
 title:
 active: true
 institution: University of Nebraska - Lincoln
 website: https://github.com/oshadura
-photo: /assets/images/team/Oksana-Shadura_.jpg
+photo: "/assets/images/team/Oksana-Shadura_.jpg"
 presentations:
-- title: "Future analysis facilities"
+- title: Future analysis facilities
   date: 2021-02-03
   url: https://indico.cern.ch/event/998431/contributions/4207282/attachments/2183405/3689404/CMS%20Analysis%20Facility%20-%20CMS%20Week.pdf
   meeting: CMS Week
@@ -14,7 +15,7 @@ presentations:
   location: Virtual
   focus-area: doma
   project: coffea-casa
-- title: "U.S. CMS Managed Analysis Facilities"
+- title: U.S. CMS Managed Analysis Facilities
   date: 2020-11-24
   url: https://indico.cern.ch/event/941278/contributions/4104696/attachments/2149035/3623381/U.S.%20CMS%20Managed%20Analysis%20Facilities-1.pdf
   meeting: HSF WLCG Virtual Workshop
@@ -22,7 +23,7 @@ presentations:
   location: Virtual
   focus-area: doma
   project: coffea-casa
-- title: "Analysis on LHC-Managed Facilities: Coffea-Casa"
+- title: 'Analysis on LHC-Managed Facilities: Coffea-Casa'
   date: 2020-10-27
   url: https://indico.cern.ch/event/960587/contributions/4070335/attachments/2130432/3587698/Analysis%20on%20LHC-Managed%20Facilities%20Coffea-Casa.pdf
   meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
@@ -30,10 +31,10 @@ presentations:
   location: Virtual
   focus-area: doma
   project: coffea-casa
-- title: "Analysis facilities"
+- title: Analysis facilities
   date: 2020-09-23
   url: https://indico.cern.ch/event/956958/contributions/4021690/attachments/2108039/3545396/US_CMS_Analysis_Facilities_RD_and_first_prototypes.pdf
-  meeting: "Upgrade R&D/CMP Meeting (Presented on Weekly CMS O&C Meeting slot)"
+  meeting: Upgrade R&D/CMP Meeting (Presented on Weekly CMS O&C Meeting slot)
   meetingurl: https://indico.cern.ch/event/956958/
   location: Virtual
   focus-area: doma

--- a/_data/people/osschar.yml
+++ b/_data/people/osschar.yml
@@ -1,8 +1,9 @@
+---
 name: Matevz Tadel
 shortname: osschar
 title:
 active: true
 institution: University of California, San Diego
 website:
-photo: /assets/images/team/Matevz-Tadel.jpg
+photo: "/assets/images/team/Matevz-Tadel.jpg"
 presentations:

--- a/_data/people/osschar.yml
+++ b/_data/people/osschar.yml
@@ -1,13 +1,12 @@
----
-name: Matevz Tadel
-shortname: osschar
-title:
 active: true
-institution: University of California, San Diego
-website:
-photo: "/assets/images/team/Matevz-Tadel.jpg"
-presentations:
 focus-area:
 - ia
 - doma
 - osglhc
+institution: University of California, San Diego
+name: Matevz Tadel
+photo: "/assets/images/team/Matevz-Tadel.jpg"
+shortname: osschar
+title:
+website:
+presentations:

--- a/_data/people/osschar.yml
+++ b/_data/people/osschar.yml
@@ -7,3 +7,7 @@ institution: University of California, San Diego
 website:
 photo: "/assets/images/team/Matevz-Tadel.jpg"
 presentations:
+focus-area:
+- ia
+- doma
+- osglhc

--- a/_data/people/p_calafiura.yml
+++ b/_data/people/p_calafiura.yml
@@ -1,9 +1,10 @@
+---
 name: Paolo Calafiura
 shortname: p_calafiura
 title: US ATLAS Ops Program
 active: true
 institution: LBNL
 website:
-photo: /assets/images/team/Paolo_Calafiura.jpg
+photo: "/assets/images/team/Paolo_Calafiura.jpg"
 hidden: true
 presentations:

--- a/_data/people/p_calafiura.yml
+++ b/_data/people/p_calafiura.yml
@@ -1,13 +1,12 @@
----
-name: Paolo Calafiura
-shortname: p_calafiura
-title: US ATLAS Ops Program
 active: true
-institution: LBNL
-website:
-photo: "/assets/images/team/Paolo_Calafiura.jpg"
-hidden: true
-presentations:
 focus-area:
 - as
 - ia
+hidden: true
+institution: LBNL
+name: Paolo Calafiura
+photo: "/assets/images/team/Paolo_Calafiura.jpg"
+shortname: p_calafiura
+title: US ATLAS Ops Program
+website:
+presentations:

--- a/_data/people/p_calafiura.yml
+++ b/_data/people/p_calafiura.yml
@@ -8,3 +8,6 @@ website:
 photo: "/assets/images/team/Paolo_Calafiura.jpg"
 hidden: true
 presentations:
+focus-area:
+- as
+- ia

--- a/_data/people/p_couvares.yml
+++ b/_data/people/p_couvares.yml
@@ -1,17 +1,15 @@
+---
 name: Peter Couvares
 shortname: p_couvares
 title:
 active: true
 institution: Caltech
 website:
-photo: /assets/images/team/p_couvares.png
+photo: "/assets/images/team/p_couvares.png"
 presentations:
-about: Couvares is a leader in providing
-   computing for the LIGO Scientific Collaboration, on the LSC’s
-   executive committee, and is the LIGO Data Analysis Computing
-   Manager.
-role: Expertise in tools to manage data and analysis on
-   the scale of the LHC experiments. The familiarity with other tools
-   and the ability to abstract the methods they have used should
-   provide a valuable resource.
+about: Couvares is a leader in providing computing for the LIGO Scientific Collaboration,
+  on the LSC’s executive committee, and is the LIGO Data Analysis Computing Manager.
+role: Expertise in tools to manage data and analysis on the scale of the LHC experiments.
+  The familiarity with other tools and the ability to abstract the methods they have
+  used should provide a valuable resource.
 hidden: true

--- a/_data/people/p_couvares.yml
+++ b/_data/people/p_couvares.yml
@@ -1,15 +1,14 @@
----
-name: Peter Couvares
-shortname: p_couvares
-title:
-active: true
-institution: Caltech
-website:
-photo: "/assets/images/team/p_couvares.png"
-presentations:
 about: Couvares is a leader in providing computing for the LIGO Scientific Collaboration,
   on the LSC’s executive committee, and is the LIGO Data Analysis Computing Manager.
+active: true
+hidden: true
+institution: Caltech
+name: Peter Couvares
+photo: "/assets/images/team/p_couvares.png"
 role: Expertise in tools to manage data and analysis on the scale of the LHC experiments.
   The familiarity with other tools and the ability to abstract the methods they have
   used should provide a valuable resource.
-hidden: true
+shortname: p_couvares
+title:
+website:
+presentations:

--- a/_data/people/p_koppenburg.yml
+++ b/_data/people/p_koppenburg.yml
@@ -1,9 +1,10 @@
+---
 name: Patrick Koppenburg
 shortname: p_koppenburg
 title: LHCb Deputy Project Leader - DPA
 active: true
 institution: Nikhef
 website:
-photo: /assets/images/team/Patrick-Koppenburg.png
+photo: "/assets/images/team/Patrick-Koppenburg.png"
 hidden: true
 presentations:

--- a/_data/people/p_koppenburg.yml
+++ b/_data/people/p_koppenburg.yml
@@ -1,10 +1,9 @@
----
+active: true
+hidden: true
+institution: Nikhef
 name: Patrick Koppenburg
+photo: "/assets/images/team/Patrick-Koppenburg.png"
 shortname: p_koppenburg
 title: LHCb Deputy Project Leader - DPA
-active: true
-institution: Nikhef
 website:
-photo: "/assets/images/team/Patrick-Koppenburg.png"
-hidden: true
 presentations:

--- a/_data/people/pelmer.yml
+++ b/_data/people/pelmer.yml
@@ -1,12 +1,14 @@
----
+active: true
+e-mail: Peter.Elmer@cern.ch
+focus-area:
+- ssc
+- ia
+institution: Princeton University
 name: Peter Elmer
+photo: "/assets/images/team/Peter-Elmer.jpg"
 shortname: pelmer
 title: Institute PI and Executive Director
-active: true
-institution: Princeton University
 website: https://scholar.princeton.edu/elmer/home
-photo: "/assets/images/team/Peter-Elmer.jpg"
-e-mail: Peter.Elmer@cern.ch
 presentations:
 - title: Institute for Research and Innovation in Software for High Energy Physics
     (IRIS-HEP)
@@ -159,6 +161,3 @@ presentations:
   location: Zoom
   focus-area:
   project:
-focus-area:
-- ssc
-- ia

--- a/_data/people/pelmer.yml
+++ b/_data/people/pelmer.yml
@@ -1,151 +1,161 @@
+---
 name: Peter Elmer
 shortname: pelmer
 title: Institute PI and Executive Director
 active: true
 institution: Princeton University
 website: https://scholar.princeton.edu/elmer/home
-photo: /assets/images/team/Peter-Elmer.jpg
+photo: "/assets/images/team/Peter-Elmer.jpg"
 e-mail: Peter.Elmer@cern.ch
 presentations:
-  - title: "Institute for Research and Innovation in Software for High Energy Physics (IRIS-HEP)"
-    date: 2019-08-01
-    url: https://indico.cern.ch/event/782953/contributions/3462566/attachments/1889484/3115717/IRIS-HEP-APS-DPF-2019.pdf
-    meeting: "2019 Meeting of the Division of Particles & Fields of the American Physical Society"
-    meetingurl: https://indico.cern.ch/event/782953/overview
-    location: Northeastern University (Boston)
-    focus-area:
-    project:
-  - title: "Institute for Research and Innovation in Software for High Energy Physics (IRIS-HEP)"
-    date: 2019-03-22
-    url: https://indico.cern.ch/event/759388/contributions/3302394/attachments/1816794/2969628/IRIS-HEP-HOW2019.pdf
-    meeting: 2019 Joint HSF/OSG/WLCG Workshop
-    meetingurl: https://indico.cern.ch/event/759388/overview
-    location: Jefferson Lab
-    focus-area:
-    project:
-  - title: "Institute for Research and Innovation in Software for High Energy Physics (IRIS-HEP)"
-    date: 2019-03-21
-    url: https://indico.cern.ch/event/759388/contributions/3364938/attachments/1816067/2968165/IRIS-HEP-OSG-Council-HOW2019-Elmer.pdf
-    meeting: OSG Council Meeting at HOW2019
-    meetingurl: https://indico.cern.ch/event/759388/overview
-    location: Jefferson Lab
-    focus-area:
-    project:
-  - title: "Institute for Research and Innovation in Software for High Energy Physics (IRIS-HEP)"
-    date: 2018-10-23
-    url: https://indico.cern.ch/event/765782/contributions/3178944/attachments/1739581/2814524/20181023-iris-hep-cms-offline-computing.pdf
-    meeting: CMS ECOM2X WG7
-    meetingurl: https://indico.cern.ch/event/765782/overview
-    focus-area:
-    project:
-  - title:  Institute for Research and Innovation in Software for High Energy Physics (IRIS-HEP)
-    date: 2018-09-20
-    url: https://indico.cern.ch/event/713888/contributions/2933014/attachments/1719328/2775216/20180920-iris-hep-cern-scf.pdf
-    meeting: 5th Scientific Computing Forum
-    meetingurl: https://indico.cern.ch/event/713888/
-    focus-area:
-    project:
-  - title: "The HEP S&C Roadmap & the Institute for Research and Innovation in Software for High Energy Physics (IRIS-HEP)"
-    date: 2018-07-30
-    url: https://indico.cern.ch/event/732285/contributions/3021320/
-    meeting: US ATLAS Workshop 2018
-    meetingurl: https://indico.cern.ch/event/732285/
-    location: Pittsburgh
-    focus-area:
-    project:
-  - title: "Building Research Software Collaborations"
-    date: 2019-05-10
-    url: https://researchcomputing.princeton.edu/events/picscie-conference-cross-disciplinary-collaboration-accelerated-scientific-discovery
-    meeting: "PICSciE Conference: Cross-Disciplinary Collaboration for Accelerated Scientific Discovery"
-    meetingurl: https://researchcomputing.princeton.edu/events/picscie-conference-cross-disciplinary-collaboration-accelerated-scientific-discovery
-    location: Princeton University
-    focus-area:
-    project:
-  - title: "Goals for the Retreat & Institute Overview and Status"
-    date: 2019-09-12
-    url: https://indico.cern.ch/event/840472/contributions/3561603/attachments/1907132/3149892/IRIS-HEP_Retreat_Sep2019.pdf
-    meeting: IRIS-HEP Institute Retreat
-    meetingurl: https://indico.cern.ch/event/840472/overview
-    location: FNAL
-    focus-area:
-    project:
-  - title: "Institute Overview"
-    date: 2019-09-09
-    url: https://indico.cern.ch/event/840467/contributions/3544994/attachments/1904318/3144662/IRIS-HEP-Advisory-Panel-Sep2019-overview.pdf
-    meeting: IRIS-HEP Advisory Panel Meeting
-    meetingurl: https://indico.cern.ch/event/840467/overview
-    location: Big Ten Conference Center
-    focus-area:
-    project:
-  - title: "Workshop Intro"
-    date: 2019-10-23
-    url: https://indico.cern.ch/event/834880/contributions/3609731/attachments/1932064/3200466/A-Coordinated-Ecosystem-for-HL-LHC-Computing-RD-Workshop-Intro.pdf
-    meeting: "A Coordinated Ecosystem for HL-LHC Computing R&D"
-    meetingurl: https://indico.cern.ch/event/834880/
-    location: Catholic University of America
-    focus-area:
-    project:
-  - title: "Enabling HEP software development for the 2020s - a coherent vision for training"
-    date: 2019-11-06
-    url: https://indico.cern.ch/event/773049/contributions/3474846/attachments/1940542/3217448/CHEP2019-training.pdf
-    meeting: "CHEP 2019"
-    meetingurl: http://chep2019.org/index.html
-    location: Adelaide, Australia
-    focus-area: ssc
-    project:
-  - title: "Collider Community Building toward IRIS-HEP"
-    date: 2019-10-28
-    url: https://indico.cern.ch/event/824917/contributions/3571650/attachments/1934373/3205044/DANCE-Workshop-IRIS-HEP-Community-Building.pdf
-    meeting: "DANCE: Dark-matter And Neutrino Computation Explored"
-    meetingurl: https://dance.rice.edu
-    location: Rice University
-    focus-area:
-    project:
-  - title: "Updates on the NSF IRIS-HEP Software Institute"
-    date: 2020-02-13
-    url: https://indico.cern.ch/event/852994/contributions/3723989/attachments/1987060/3311388/IRIS-HEP-CERN-SCF-13-Feb-2020.pdf
-    meeting: "8th Scientific Computing Forum"
-    meetingurl: https://indico.cern.ch/event/852994/
-    location: CERN
-    focus-area:
-    project:
-  - title: "The IRIS-HEP Software Institute: Motivation and Activities"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/855317/contributions/3671702/attachments/1992234/3327748/IRIS-HEP-18-Month-Overview-v2.pdf
-    meeting: "NSF 18-Month Review of IRIS-HEP"
-    meetingurl: https://indico.cern.ch/event/855317/timetable/
-    location: Princeton University
-    focus-area:
-    project:
-  - title: "Institute for Research and Innovation in Software for High Energy Physics (IRIS-HEP)"
-    date: 2020-03-26
-    url: https://docs.google.com/presentation/d/1OXSJDHtzlip9F215YW7AHbUynpr3kWawIQ5zo75Mga0/edit#slide=id.g7f5f2e8030_8_0
-    meeting: "CMS Offline and Computing Week - Discussion of External Projects"
-    meetingurl: https://indico.cern.ch/event/902343/
-    location: Zoom-only
-    focus-area:
-    project:
-  - title: "IRIS-HEP - US-ATLAS"
-    date: 2020-05-07
-    url: https://docs.google.com/presentation/d/1R64LuoEK_1PHwO7cOU6cO8xmU1IASa9QdQqQQNMAGq4/edit#slide=id.g776ba7baaf_2_86
-    meeting: "US ATLAS Operations L2/L3 Managers Meeting"
-    meetingurl: https://indico.cern.ch/e/901076
-    location: Zoom
-    focus-area:
-    project:
-  - title: "IRIS-HEP - Impact Beyond HEP"
-    date: 2020-12-04
-    url: https://indico.cern.ch/event/976594/contributions/4112994/attachments/2157050/3638425/IRIS-HEP-Impact-Beyond-HEP.pdf
-    meeting: "NSF / IRIS-HEP Meeting - Impact Beyond HEP"
-    meetingurl: https://indico.cern.ch/event/976594/
-    location: Zoom
-    focus-area:
-    project:
-  - title: "IRIS-HEP Covid 19 impact on work survey results"
-    date: 2021-02-10
-    url: https://indico.cern.ch/event/876773/contributions/4222233/attachments/2187909/3697123/IRIS-HEP-COVID-Effects-Survey.pdf
-    meeting: "GDB"
-    meetingurl: https://indico.cern.ch/event/876773/
-    location: Zoom
-    focus-area:
-    project:
+- title: Institute for Research and Innovation in Software for High Energy Physics
+    (IRIS-HEP)
+  date: 2019-08-01
+  url: https://indico.cern.ch/event/782953/contributions/3462566/attachments/1889484/3115717/IRIS-HEP-APS-DPF-2019.pdf
+  meeting: 2019 Meeting of the Division of Particles & Fields of the American Physical
+    Society
+  meetingurl: https://indico.cern.ch/event/782953/overview
+  location: Northeastern University (Boston)
+  focus-area:
+  project:
+- title: Institute for Research and Innovation in Software for High Energy Physics
+    (IRIS-HEP)
+  date: 2019-03-22
+  url: https://indico.cern.ch/event/759388/contributions/3302394/attachments/1816794/2969628/IRIS-HEP-HOW2019.pdf
+  meeting: 2019 Joint HSF/OSG/WLCG Workshop
+  meetingurl: https://indico.cern.ch/event/759388/overview
+  location: Jefferson Lab
+  focus-area:
+  project:
+- title: Institute for Research and Innovation in Software for High Energy Physics
+    (IRIS-HEP)
+  date: 2019-03-21
+  url: https://indico.cern.ch/event/759388/contributions/3364938/attachments/1816067/2968165/IRIS-HEP-OSG-Council-HOW2019-Elmer.pdf
+  meeting: OSG Council Meeting at HOW2019
+  meetingurl: https://indico.cern.ch/event/759388/overview
+  location: Jefferson Lab
+  focus-area:
+  project:
+- title: Institute for Research and Innovation in Software for High Energy Physics
+    (IRIS-HEP)
+  date: 2018-10-23
+  url: https://indico.cern.ch/event/765782/contributions/3178944/attachments/1739581/2814524/20181023-iris-hep-cms-offline-computing.pdf
+  meeting: CMS ECOM2X WG7
+  meetingurl: https://indico.cern.ch/event/765782/overview
+  focus-area:
+  project:
+- title: Institute for Research and Innovation in Software for High Energy Physics
+    (IRIS-HEP)
+  date: 2018-09-20
+  url: https://indico.cern.ch/event/713888/contributions/2933014/attachments/1719328/2775216/20180920-iris-hep-cern-scf.pdf
+  meeting: 5th Scientific Computing Forum
+  meetingurl: https://indico.cern.ch/event/713888/
+  focus-area:
+  project:
+- title: The HEP S&C Roadmap & the Institute for Research and Innovation in Software
+    for High Energy Physics (IRIS-HEP)
+  date: 2018-07-30
+  url: https://indico.cern.ch/event/732285/contributions/3021320/
+  meeting: US ATLAS Workshop 2018
+  meetingurl: https://indico.cern.ch/event/732285/
+  location: Pittsburgh
+  focus-area:
+  project:
+- title: Building Research Software Collaborations
+  date: 2019-05-10
+  url: https://researchcomputing.princeton.edu/events/picscie-conference-cross-disciplinary-collaboration-accelerated-scientific-discovery
+  meeting: 'PICSciE Conference: Cross-Disciplinary Collaboration for Accelerated Scientific
+    Discovery'
+  meetingurl: https://researchcomputing.princeton.edu/events/picscie-conference-cross-disciplinary-collaboration-accelerated-scientific-discovery
+  location: Princeton University
+  focus-area:
+  project:
+- title: Goals for the Retreat & Institute Overview and Status
+  date: 2019-09-12
+  url: https://indico.cern.ch/event/840472/contributions/3561603/attachments/1907132/3149892/IRIS-HEP_Retreat_Sep2019.pdf
+  meeting: IRIS-HEP Institute Retreat
+  meetingurl: https://indico.cern.ch/event/840472/overview
+  location: FNAL
+  focus-area:
+  project:
+- title: Institute Overview
+  date: 2019-09-09
+  url: https://indico.cern.ch/event/840467/contributions/3544994/attachments/1904318/3144662/IRIS-HEP-Advisory-Panel-Sep2019-overview.pdf
+  meeting: IRIS-HEP Advisory Panel Meeting
+  meetingurl: https://indico.cern.ch/event/840467/overview
+  location: Big Ten Conference Center
+  focus-area:
+  project:
+- title: Workshop Intro
+  date: 2019-10-23
+  url: https://indico.cern.ch/event/834880/contributions/3609731/attachments/1932064/3200466/A-Coordinated-Ecosystem-for-HL-LHC-Computing-RD-Workshop-Intro.pdf
+  meeting: A Coordinated Ecosystem for HL-LHC Computing R&D
+  meetingurl: https://indico.cern.ch/event/834880/
+  location: Catholic University of America
+  focus-area:
+  project:
+- title: Enabling HEP software development for the 2020s - a coherent vision for training
+  date: 2019-11-06
+  url: https://indico.cern.ch/event/773049/contributions/3474846/attachments/1940542/3217448/CHEP2019-training.pdf
+  meeting: CHEP 2019
+  meetingurl: http://chep2019.org/index.html
+  location: Adelaide, Australia
+  focus-area: ssc
+  project:
+- title: Collider Community Building toward IRIS-HEP
+  date: 2019-10-28
+  url: https://indico.cern.ch/event/824917/contributions/3571650/attachments/1934373/3205044/DANCE-Workshop-IRIS-HEP-Community-Building.pdf
+  meeting: 'DANCE: Dark-matter And Neutrino Computation Explored'
+  meetingurl: https://dance.rice.edu
+  location: Rice University
+  focus-area:
+  project:
+- title: Updates on the NSF IRIS-HEP Software Institute
+  date: 2020-02-13
+  url: https://indico.cern.ch/event/852994/contributions/3723989/attachments/1987060/3311388/IRIS-HEP-CERN-SCF-13-Feb-2020.pdf
+  meeting: 8th Scientific Computing Forum
+  meetingurl: https://indico.cern.ch/event/852994/
+  location: CERN
+  focus-area:
+  project:
+- title: 'The IRIS-HEP Software Institute: Motivation and Activities'
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/855317/contributions/3671702/attachments/1992234/3327748/IRIS-HEP-18-Month-Overview-v2.pdf
+  meeting: NSF 18-Month Review of IRIS-HEP
+  meetingurl: https://indico.cern.ch/event/855317/timetable/
+  location: Princeton University
+  focus-area:
+  project:
+- title: Institute for Research and Innovation in Software for High Energy Physics
+    (IRIS-HEP)
+  date: 2020-03-26
+  url: https://docs.google.com/presentation/d/1OXSJDHtzlip9F215YW7AHbUynpr3kWawIQ5zo75Mga0/edit#slide=id.g7f5f2e8030_8_0
+  meeting: CMS Offline and Computing Week - Discussion of External Projects
+  meetingurl: https://indico.cern.ch/event/902343/
+  location: Zoom-only
+  focus-area:
+  project:
+- title: IRIS-HEP - US-ATLAS
+  date: 2020-05-07
+  url: https://docs.google.com/presentation/d/1R64LuoEK_1PHwO7cOU6cO8xmU1IASa9QdQqQQNMAGq4/edit#slide=id.g776ba7baaf_2_86
+  meeting: US ATLAS Operations L2/L3 Managers Meeting
+  meetingurl: https://indico.cern.ch/e/901076
+  location: Zoom
+  focus-area:
+  project:
+- title: IRIS-HEP - Impact Beyond HEP
+  date: 2020-12-04
+  url: https://indico.cern.ch/event/976594/contributions/4112994/attachments/2157050/3638425/IRIS-HEP-Impact-Beyond-HEP.pdf
+  meeting: NSF / IRIS-HEP Meeting - Impact Beyond HEP
+  meetingurl: https://indico.cern.ch/event/976594/
+  location: Zoom
+  focus-area:
+  project:
+- title: IRIS-HEP Covid 19 impact on work survey results
+  date: 2021-02-10
+  url: https://indico.cern.ch/event/876773/contributions/4222233/attachments/2187909/3697123/IRIS-HEP-COVID-Effects-Survey.pdf
+  meeting: GDB
+  meetingurl: https://indico.cern.ch/event/876773/
+  location: Zoom
+  focus-area:
+  project:

--- a/_data/people/pelmer.yml
+++ b/_data/people/pelmer.yml
@@ -159,3 +159,6 @@ presentations:
   location: Zoom
   focus-area:
   project:
+focus-area:
+- ssc
+- ia

--- a/_data/people/petya-vasileva.yml
+++ b/_data/people/petya-vasileva.yml
@@ -1,8 +1,9 @@
+---
 name: Petya Vasileva
 shortname: petya-vasileva
 title: Ph.D Student (University of Plovdiv)
 active: true
 institution: University of Michigan
 website:
-photo: /assets/images/team/Petya-Vasileva.png
+photo: "/assets/images/team/Petya-Vasileva.png"
 presentations:

--- a/_data/people/petya-vasileva.yml
+++ b/_data/people/petya-vasileva.yml
@@ -1,11 +1,10 @@
----
-name: Petya Vasileva
-shortname: petya-vasileva
-title: Ph.D Student (University of Plovdiv)
 active: true
-institution: University of Michigan
-website:
-photo: "/assets/images/team/Petya-Vasileva.png"
-presentations:
 focus-area:
 - osglhc
+institution: University of Michigan
+name: Petya Vasileva
+photo: "/assets/images/team/Petya-Vasileva.png"
+shortname: petya-vasileva
+title: Ph.D Student (University of Plovdiv)
+website:
+presentations:

--- a/_data/people/petya-vasileva.yml
+++ b/_data/people/petya-vasileva.yml
@@ -7,3 +7,5 @@ institution: University of Michigan
 website:
 photo: "/assets/images/team/Petya-Vasileva.png"
 presentations:
+focus-area:
+- osglhc

--- a/_data/people/pharris.yml
+++ b/_data/people/pharris.yml
@@ -1,8 +1,8 @@
+---
 name: Philip Harris
 shortname: pharris
 title:
 active: true
 institution: Massachusetts Institute of Technology
 website:
-photo: /assets/images/team/Phil_Harris.jpg
-
+photo: "/assets/images/team/Phil_Harris.jpg"

--- a/_data/people/pharris.yml
+++ b/_data/people/pharris.yml
@@ -6,3 +6,6 @@ active: true
 institution: Massachusetts Institute of Technology
 website:
 photo: "/assets/images/team/Phil_Harris.jpg"
+focus-area:
+- ia
+- as

--- a/_data/people/pharris.yml
+++ b/_data/people/pharris.yml
@@ -1,11 +1,11 @@
----
-name: Philip Harris
-shortname: pharris
-title:
 active: true
-institution: Massachusetts Institute of Technology
-website:
-photo: "/assets/images/team/Phil_Harris.jpg"
 focus-area:
 - ia
 - as
+institution: Massachusetts Institute of Technology
+name: Philip Harris
+photo: "/assets/images/team/Phil_Harris.jpg"
+shortname: pharris
+title:
+website:
+presentations:

--- a/_data/people/pwittich.yml
+++ b/_data/people/pwittich.yml
@@ -7,3 +7,5 @@ institution: Cornell University
 website: https://physics.cornell.edu/peter-wittich
 photo: "/assets/images/team/Peter-Wittich.jpg"
 presentations:
+focus-area:
+- ia

--- a/_data/people/pwittich.yml
+++ b/_data/people/pwittich.yml
@@ -1,11 +1,10 @@
----
-name: Peter Wittich
-shortname: pwittich
-title:
 active: true
-institution: Cornell University
-website: https://physics.cornell.edu/peter-wittich
-photo: "/assets/images/team/Peter-Wittich.jpg"
-presentations:
 focus-area:
 - ia
+institution: Cornell University
+name: Peter Wittich
+photo: "/assets/images/team/Peter-Wittich.jpg"
+shortname: pwittich
+title:
+website: https://physics.cornell.edu/peter-wittich
+presentations:

--- a/_data/people/pwittich.yml
+++ b/_data/people/pwittich.yml
@@ -1,8 +1,9 @@
+---
 name: Peter Wittich
 shortname: pwittich
 title:
 active: true
 institution: Cornell University
 website: https://physics.cornell.edu/peter-wittich
-photo: /assets/images/team/Peter-Wittich.jpg
+photo: "/assets/images/team/Peter-Wittich.jpg"
 presentations:

--- a/_data/people/rct225.yml
+++ b/_data/people/rct225.yml
@@ -1,8 +1,9 @@
+---
 name: Robert Tuck
 shortname: rct225
 title: Associate Project Manager
 active: true
 institution: Princeton University
 website:
-photo: /assets/images/team/Robert-Tuck.jpg
+photo: "/assets/images/team/Robert-Tuck.jpg"
 presentations:

--- a/_data/people/rct225.yml
+++ b/_data/people/rct225.yml
@@ -1,9 +1,8 @@
----
-name: Robert Tuck
-shortname: rct225
-title: Associate Project Manager
 active: true
 institution: Princeton University
-website:
+name: Robert Tuck
 photo: "/assets/images/team/Robert-Tuck.jpg"
+shortname: rct225
+title: Associate Project Manager
+website:
 presentations:

--- a/_data/people/robrwg.yml
+++ b/_data/people/robrwg.yml
@@ -39,3 +39,6 @@ presentations:
     (CHEP2019)
   meetingurl: http://chep2019.org/
   focus-area: ssl
+focus-area:
+- ssl
+- doma

--- a/_data/people/robrwg.yml
+++ b/_data/people/robrwg.yml
@@ -1,11 +1,13 @@
----
+active: true
+focus-area:
+- ssl
+- doma
+institution: University of Chicago
 name: Rob Gardner
+photo: "/assets/images/team/Rob-Gardner.png"
 shortname: robrwg
 title: SSL Area Lead
-active: true
-institution: University of Chicago
 website: https://efi.uchicago.edu/people/profile/rob-gardner/
-photo: "/assets/images/team/Rob-Gardner.png"
 presentations:
 - title: IRIS-HEP Scalable Systems Laboratory for Innovation & Integration
   date: 2019-02-06
@@ -39,6 +41,3 @@ presentations:
     (CHEP2019)
   meetingurl: http://chep2019.org/
   focus-area: ssl
-focus-area:
-- ssl
-- doma

--- a/_data/people/robrwg.yml
+++ b/_data/people/robrwg.yml
@@ -1,37 +1,41 @@
+---
 name: Rob Gardner
 shortname: robrwg
 title: SSL Area Lead
 active: true
 institution: University of Chicago
 website: https://efi.uchicago.edu/people/profile/rob-gardner/
-photo: /assets/images/team/Rob-Gardner.png
+photo: "/assets/images/team/Rob-Gardner.png"
 presentations:
-  - title: "IRIS-HEP Scalable Systems Laboratory for Innovation & Integration"
-    date: 2019-02-06
-    url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271530/attachments/1791890/2919772/2019.02.06_SSL_for_IRIS-HEP_SB_2.pdf
-    meeting: IRIS-HEP Steering Board Meeting #1
-    meetingurl: https://indico.cern.ch/event/790759/
-  - title: "Scalable Systems Laboratory (IRIS-HEP) - challenges, opportunities"
-    date: 2019-06-21
-    url: https://indico.cern.ch/event/820946/contributions/3461590/attachments/1866979/3070394/2019.06.21_SSL_Overview_Rob.pdf
-    meeting: "Analysis Systems R&D on Scalable Platforms (AS-SSL Blueprint)"
-    meetingurl: https://indico.cern.ch/event/820946/
-    focus-area: ssl
-  - title: "Lightning talk: ideas on evolution of grid sites in Run 4"
-    date: 2019-10-02
-    url: https://indico.cern.ch/event/823340/#69-lightning-talk-ideas-on-evo
-    meeting: "ATLAS Software & Computing Week No. 63"
-    meetingurl: https://indico.cern.ch/event/823340/
-    focus-area: ssl
-  - title: "DOMA Facilities"
-    date: 2019-11-01
-    url: https://indico.cern.ch/event/805983/contributions/3569723/
-    meeting: "Joint WLCG & HSF Workshop 2019 - Analysis Systems: From Future Facilities to Final Plots"
-    meetingurl: https://indico.cern.ch/event/805983/
-    focus-area: ssl
-  - title: "The Scalable Systems Laboratory: a Platform for Software Innovation for HEP"
-    date: 2019-11-05
-    url: https://indico.cern.ch/event/773049/contributions/3473260/
-    meeting: "24th International Conference on Computing in High Energy and Nuclear Physics (CHEP2019)"
-    meetingurl: http://chep2019.org/
-    focus-area: ssl
+- title: IRIS-HEP Scalable Systems Laboratory for Innovation & Integration
+  date: 2019-02-06
+  url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271530/attachments/1791890/2919772/2019.02.06_SSL_for_IRIS-HEP_SB_2.pdf
+  meeting: IRIS-HEP Steering Board Meeting
+  meetingurl: https://indico.cern.ch/event/790759/
+- title: Scalable Systems Laboratory (IRIS-HEP) - challenges, opportunities
+  date: 2019-06-21
+  url: https://indico.cern.ch/event/820946/contributions/3461590/attachments/1866979/3070394/2019.06.21_SSL_Overview_Rob.pdf
+  meeting: Analysis Systems R&D on Scalable Platforms (AS-SSL Blueprint)
+  meetingurl: https://indico.cern.ch/event/820946/
+  focus-area: ssl
+- title: 'Lightning talk: ideas on evolution of grid sites in Run 4'
+  date: 2019-10-02
+  url: https://indico.cern.ch/event/823340/#69-lightning-talk-ideas-on-evo
+  meeting: ATLAS Software & Computing Week No. 63
+  meetingurl: https://indico.cern.ch/event/823340/
+  focus-area: ssl
+- title: DOMA Facilities
+  date: 2019-11-01
+  url: https://indico.cern.ch/event/805983/contributions/3569723/
+  meeting: 'Joint WLCG & HSF Workshop 2019 - Analysis Systems: From Future Facilities
+    to Final Plots'
+  meetingurl: https://indico.cern.ch/event/805983/
+  focus-area: ssl
+- title: 'The Scalable Systems Laboratory: a Platform for Software Innovation for
+    HEP'
+  date: 2019-11-05
+  url: https://indico.cern.ch/event/773049/contributions/3473260/
+  meeting: 24th International Conference on Computing in High Energy and Nuclear Physics
+    (CHEP2019)
+  meetingurl: http://chep2019.org/
+  focus-area: ssl

--- a/_data/people/rockybala.yml
+++ b/_data/people/rockybala.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ia
+institution: Stanford University
 name: Rocky Bala Garg
+photo: "/assets/images/team/Rocky-Garg.jpg"
 shortname: rockybala
 title:
-active: true
-institution: Stanford University
 website: https://github.com/rockybala
-photo: "/assets/images/team/Rocky-Garg.jpg"
 presentations:
 - title: Acts Integration into Athena
   date: 2020-05-15
@@ -31,5 +32,3 @@ presentations:
   location: CERN
   project: acts
   focus-area: ia
-focus-area:
-- ia

--- a/_data/people/rockybala.yml
+++ b/_data/people/rockybala.yml
@@ -31,3 +31,5 @@ presentations:
   location: CERN
   project: acts
   focus-area: ia
+focus-area:
+- ia

--- a/_data/people/rockybala.yml
+++ b/_data/people/rockybala.yml
@@ -1,32 +1,33 @@
+---
 name: Rocky Bala Garg
 shortname: rockybala
 title:
 active: true
 institution: Stanford University
 website: https://github.com/rockybala
-photo: /assets/images/team/Rocky-Garg.jpg
+photo: "/assets/images/team/Rocky-Garg.jpg"
 presentations:
-  - title: "Acts Integration into Athena"
-    date: 2020-05-15
-    url:
-    meeting: "SLAC ATLAS meeting"
-    meetingurl:
-    location: SLAC
-    project: acts
-    focus-area: ia
-  - title: "Athena-ACTS Wrapper: Iterative Vertex Finder with Full Billoir Fitter"
-    date: 2021-02-12
-    url:
-    meeting: "SLAC ATLAS meeting"
-    meetingurl:
-    location: SLAC
-    project: acts
-    focus-area: ia
-  - title: "Parameter Optimization and Layer Linking in ACTS track Seeding"
-    date: 2021-02-26
-    url: https://indico.cern.ch/event/1010520/contributions/4249433/attachments/2197746/3716120/ACTS_ML_Meeting_Feb26.pdf
-    meeting: "ACTS Machine Learning Meeting"
-    meetingurl: https://indico.cern.ch/event/1010520/
-    location: CERN
-    project: acts
-    focus-area: ia
+- title: Acts Integration into Athena
+  date: 2020-05-15
+  url:
+  meeting: SLAC ATLAS meeting
+  meetingurl:
+  location: SLAC
+  project: acts
+  focus-area: ia
+- title: 'Athena-ACTS Wrapper: Iterative Vertex Finder with Full Billoir Fitter'
+  date: 2021-02-12
+  url:
+  meeting: SLAC ATLAS meeting
+  meetingurl:
+  location: SLAC
+  project: acts
+  focus-area: ia
+- title: Parameter Optimization and Layer Linking in ACTS track Seeding
+  date: 2021-02-26
+  url: https://indico.cern.ch/event/1010520/contributions/4249433/attachments/2197746/3716120/ACTS_ML_Meeting_Feb26.pdf
+  meeting: ACTS Machine Learning Meeting
+  meetingurl: https://indico.cern.ch/event/1010520/
+  location: CERN
+  project: acts
+  focus-area: ia

--- a/_data/people/s_campana.yml
+++ b/_data/people/s_campana.yml
@@ -1,10 +1,9 @@
----
+active: true
+hidden: true
+institution: CERN
 name: Simone Campana
+photo: "/assets/images/team/Simone-Campana.png"
 shortname: s_campana
 title: Worldwide LHC Computing Grid (WLCG)
-active: true
-institution: CERN
 website:
-photo: "/assets/images/team/Simone-Campana.png"
-hidden: true
 presentations:

--- a/_data/people/s_campana.yml
+++ b/_data/people/s_campana.yml
@@ -1,9 +1,10 @@
+---
 name: Simone Campana
 shortname: s_campana
 title: Worldwide LHC Computing Grid (WLCG)
 active: true
 institution: CERN
 website:
-photo: /assets/images/team/Simone-Campana.png
+photo: "/assets/images/team/Simone-Campana.png"
 hidden: true
 presentations:

--- a/_data/people/savvy379.yml
+++ b/_data/people/savvy379.yml
@@ -63,3 +63,6 @@ presentations:
   meetingurl: https://indico.cern.ch/event/963422
   focus-area: ia
   project: accel-gnn-tracking
+focus-area:
+- ia
+- ssc

--- a/_data/people/savvy379.yml
+++ b/_data/people/savvy379.yml
@@ -1,64 +1,65 @@
+---
 name: Savannah Thais
 shortname: savvy379
 title: Post-doctoral researcher
 active: true
 institution: Princeton University
 website:
-photo: /assets/images/team/Savannah-Thais.jpg
+photo: "/assets/images/team/Savannah-Thais.jpg"
 e-mail: sthais@princeton.edu
 presentations:
-  - title: "Introduction and Plans"
-    date: 2019-09-12
-    url: https://indico.cern.ch/event/840472/contributions/3563440/attachments/1907910/3151492/iris_intro.pdf
-    meeting: IRIS-HEP Institute Retreat
-    location: Fermilab, Chicago IL
-    focus-area: ia
-    project: accel-gnn-tracking
-  - title: "Semantic Segmentation for CMS Pixel Clustering"
-    date: 2019-10-16
-    url: https://indico.cern.ch/event/844493/contributions/3601262/attachments/1928404/3193177/uslua_2019.pdf
-    meeting: "US LHC Users' Association Meeting"
-    location: Rice University, Houston TX
-    focus-area: ia
-    project: accel-gnn-tracking
-  - title: "Education and Engagement of ML Skills"
-    date : 2020-08-11
-    url: https://indico.fnal.gov/event/43829/contributions/192878/
-    meeting: Snowmass Computing Frontier Kickoff Meeting
-    location: Virtual
-    focus-area: ssc
-  - title: "Accelerated Pixed Detector Tracklet Finding with GNNs on FPGAS"
-    date: 2020-10-21
-    url: https://indico.cern.ch/event/852553/contributions/4058173/
-    meeting: 4th Annual Inter-Experiment Machine Learning Workshop
-    focus-area: ia
-    project: accel-gnn-tracking
-  - title: "New Algorithms and Computing Architectures for Tracking"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/855317/contributions/3671721/attachments/1992247/3328035/iris_18mo_review.pdf
-    meeting: IRIS-HEP 18 Month Review
-    focus-area: ia
-    project: accel-gnn-tracking
-  - title: "GNNs for Tracking"
-    date: 2020-09-30
-    url: https://indico.cern.ch/event/952419/contributions/4041556/attachments/2112096/3553019/tracking_gnns_cmsml_09302020.pdf
-    meeting: CMS Machine Learning Forum
-    focus-area: ia
-    project: accel-gnn-tracking
-  - title: "Big Data and Open Science to Fight COVID-19"
-    date: 2020-04-20
-    url: https://meetings.aps.org/Meeting/APR20/Session/Q08.3
-    meeting: APS April Meeting
-    focus-area: ssc
-  - title: "Machine Learning and Your Research"
-    date: 2020-10-20
-    url: https://researchcomputing.princeton.edu/events/machine-learning-your-research
-    meeting: Princeton Research Computing Training Series
-    focus-area: ssc
-  - title: Tracking with GNN
-    date: 2020-11-02
-    url: https://indico.cern.ch/event/963422/contributions/4074299/attachments/2134891/3595882/tracking_gnns_cmstrackingpog_10192020_NOONESHOT.pdf
-    meeting: CMS Tracking POG meeting (CMS internal)
-    meetingurl: https://indico.cern.ch/event/963422
-    focus-area: ia
-    project: accel-gnn-tracking
+- title: Introduction and Plans
+  date: 2019-09-12
+  url: https://indico.cern.ch/event/840472/contributions/3563440/attachments/1907910/3151492/iris_intro.pdf
+  meeting: IRIS-HEP Institute Retreat
+  location: Fermilab, Chicago IL
+  focus-area: ia
+  project: accel-gnn-tracking
+- title: Semantic Segmentation for CMS Pixel Clustering
+  date: 2019-10-16
+  url: https://indico.cern.ch/event/844493/contributions/3601262/attachments/1928404/3193177/uslua_2019.pdf
+  meeting: US LHC Users' Association Meeting
+  location: Rice University, Houston TX
+  focus-area: ia
+  project: accel-gnn-tracking
+- title: Education and Engagement of ML Skills
+  date: 2020-08-11
+  url: https://indico.fnal.gov/event/43829/contributions/192878/
+  meeting: Snowmass Computing Frontier Kickoff Meeting
+  location: Virtual
+  focus-area: ssc
+- title: Accelerated Pixed Detector Tracklet Finding with GNNs on FPGAS
+  date: 2020-10-21
+  url: https://indico.cern.ch/event/852553/contributions/4058173/
+  meeting: 4th Annual Inter-Experiment Machine Learning Workshop
+  focus-area: ia
+  project: accel-gnn-tracking
+- title: New Algorithms and Computing Architectures for Tracking
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/855317/contributions/3671721/attachments/1992247/3328035/iris_18mo_review.pdf
+  meeting: IRIS-HEP 18 Month Review
+  focus-area: ia
+  project: accel-gnn-tracking
+- title: GNNs for Tracking
+  date: 2020-09-30
+  url: https://indico.cern.ch/event/952419/contributions/4041556/attachments/2112096/3553019/tracking_gnns_cmsml_09302020.pdf
+  meeting: CMS Machine Learning Forum
+  focus-area: ia
+  project: accel-gnn-tracking
+- title: Big Data and Open Science to Fight COVID-19
+  date: 2020-04-20
+  url: https://meetings.aps.org/Meeting/APR20/Session/Q08.3
+  meeting: APS April Meeting
+  focus-area: ssc
+- title: Machine Learning and Your Research
+  date: 2020-10-20
+  url: https://researchcomputing.princeton.edu/events/machine-learning-your-research
+  meeting: Princeton Research Computing Training Series
+  focus-area: ssc
+- title: Tracking with GNN
+  date: 2020-11-02
+  url: https://indico.cern.ch/event/963422/contributions/4074299/attachments/2134891/3595882/tracking_gnns_cmstrackingpog_10192020_NOONESHOT.pdf
+  meeting: CMS Tracking POG meeting (CMS internal)
+  meetingurl: https://indico.cern.ch/event/963422
+  focus-area: ia
+  project: accel-gnn-tracking

--- a/_data/people/savvy379.yml
+++ b/_data/people/savvy379.yml
@@ -1,12 +1,14 @@
----
+active: true
+e-mail: sthais@princeton.edu
+focus-area:
+- ia
+- ssc
+institution: Princeton University
 name: Savannah Thais
+photo: "/assets/images/team/Savannah-Thais.jpg"
 shortname: savvy379
 title: Post-doctoral researcher
-active: true
-institution: Princeton University
 website:
-photo: "/assets/images/team/Savannah-Thais.jpg"
-e-mail: sthais@princeton.edu
 presentations:
 - title: Introduction and Plans
   date: 2019-09-12
@@ -63,6 +65,3 @@ presentations:
   meetingurl: https://indico.cern.ch/event/963422
   focus-area: ia
   project: accel-gnn-tracking
-focus-area:
-- ia
-- ssc

--- a/_data/people/sfiligoi.yml
+++ b/_data/people/sfiligoi.yml
@@ -1,140 +1,145 @@
+---
 name: Igor Sfiligoi
 shortname: sfiligoi
 title: Lead Scientific Software Developer and Researcher
 active: true
 institution: University of California, San Diego
 website:
-photo: /assets/images/team/Igor-Sfiligoi.jpg
+photo: "/assets/images/team/Igor-Sfiligoi.jpg"
 presentations:
-  - title: "Data-intensive IceCube Cloud Burst"
-    date: 2020-11-12
-    url: https://www2.slideshare.net/igor_sfiligoi/dataintensive-icecube-cloud-burst
-    meeting: NRP Pilot weekly meeting
-    location: Virtual, USA
-    focus-area: osglhc
-  - title: "Unified Cyber Infrastructure with Kubernetes"
-    date: 2020-11-09
-    url: https://gitlab.com/ucsd-prp/tutorials/sc20
-    meeting: SC 20 Tutorial
-    meetingurl: https://sc20.supercomputing.org/presentation/?id=tut136&sess=sess256
-    location: Virtual, USA
-    focus-area: osglhc
-  - title: "Scheduling a Kubernetes Federation with Admiralty"
-    date: 2020-09-04
-    url: https://indico.fnal.gov/event/22127/contributions/194933/attachments/133961/165464/osg20_lhc_admiralty_rc3.pdf
-    meeting: OSG All-Hands Meeting 2020
-    meetingurl: https://indico.fnal.gov/event/22127
-    location: Virtual, US
-    focus-area: osglhc
-  - title: "Demonstrating a Pre-Exascale, Cost-Effective Multi-Cloud Environment for Scientific Computing"
-    date: 2020-07-29
-    url: https://www.slideshare.net/igor_sfiligoi/demonstrating-a-preexascale-costeffective-multicloud-environment-for-scientific-computing
-    meeting: PEARC20
-    meetingurl: https://pearc.acm.org/pearc20/
-    location: Virtual, US
-    focus-area: osglhc
-  - title: "Demonstrating 100 Gbps in and out of the public Clouds"
-    date: 2020-07-28
-    url: https://doi.org/10.1145/3311790.3399612
-    meeting: PEARC20
-    meetingurl: https://pearc.acm.org/pearc20/
-    location: Virtual, US
-    focus-area: doma
-  - title: "High Throughput Science Workshop"
-    date: 2020-07-31
-    meeting: PEARC20
-    url: https://pearc20.sched.com/event/cnY6/high-throughput-science
-    meetingurl: https://pearc.acm.org/pearc20/
-    location: Virtual, US
-    focus-area: osglhc
-  - title: "Running a Pre-exascale, Geographically Distributed, Multi-cloud Scientific Simulation"
-    date: 2020-06-28
-    url: https://doi.org/10.1007/978-3-030-50743-5_2
-    meeting: ISC20
-    meetingurl: https://www.isc-hpc.com
-    location: Virtual
-    focus-area: osglhc
-  - title: "TransAtlantic networking using Cloud links"
-    date: 2020-05-27
-    url: https://indico.cern.ch/event/923131/contributions/3878486/attachments/2045504/3426871/CMS20_05_CloudNetwork_rc2.pdf
-    meeting: S&C Blueprint Meeting
-    meetingurl: https://indico.cern.ch/event/923131/
-    focus-area: osglhc
-  - title: "Hybrid, multi-Cloud HPC for Multi-Messenger Astrophysics with IceCube"
-    date: 2020-01-28
-    url: https://docs.google.com/presentation/d/1NT5DiCudME7OoU_zxOsw_nkZoNNNKIm3DEfD3miKd0A/edit?usp=sharing
-    meeting: Google Cloud HPC Day San Diego
-    meetingurl: https://events.withgoogle.com/google-cloud-hpc-day-san-diego/
-    location: San Diego, CA ,USA
-    focus-area: osglhc
-  - title: "Running a 380PFLOP32s GPU burst for Multi-Messenger Astrophysics with IceCube across all available GPUs in the Cloud"
-    date: 2020-01-27
-    url: https://www.slideshare.net/igor_sfiligoi/nrp-engagement-webinar-running-a-51k-gpu-multicloud-burstfor-mma-with-icecube
-    meeting: NRP Engagement webinar
-    meetingurl: https://spaces.at.internet2.edu/display/NRPWG/National+Research+Platform+%28NRP%29+Space
-    location: WebEx, US
-    focus-area: osglhc
-  - title: "OSG use of PRP Kubernetes cluster"
-    date: 2019-12-10
-    url: https://indico.cern.ch/event/739899/contributions/3662270/attachments/1959449/3256032/cern19_prp_osg_191210.pdf
-    meeting: pre-GDB meeting
-    meetingurl: https://indico.cern.ch/event/739899/
-    location: CERN
-    focus-area: osglhc
-  - title: "Serving HTC Users in Kubernetes by Leveraging HTCondor"
-    date: 2019-11-21
-    url: https://kccncna19.sched.com/event/77ed0cf42f37809c9640ee8fe1dc5415
-    meeting: KubeCon North America 2019
-    meetingurl: https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/
-    location: San Diego, CA, USA
-    focus-area: osglhc
-  - title: "Burst data retrieval after 50k GPU Cloud run"
-    date: 2019-11-19
-    url: https://www.slideshare.net/igor_sfiligoi/burst-data-retrieval-after-50k-gpu-cloud-run
-    meeting: SC 19 Internet2 Booth
-    meetingurl: https://sc19.supercomputing.org
-    location: Denver, CO, USA
-    focus-area: osglhc
-  - title: "Unified Cyber Infrastructure with Kubernetes"
-    date: 2019-11-18
-    url: https://gitlab.com/ucsd-prp/tutorials/sc19
-    meeting: SC 19 Tutorial
-    meetingurl: https://sc19.supercomputing.org/presentation/?id=tut130&sess=sess190
-    location: Denver, CO, USA
-    focus-area: osglhc
-  - title: "Characterizing network paths in and out of the Clouds"
-    date: 2019-11-04
-    url: https://indico.cern.ch/event/773049/contributions/3473824/attachments/1935023/3206398/CHEP19_Networks.pptx
-    meeting: CHEP 2019
-    meetingurl: http://chep2019.org
-    location: Adelaide, Australia
-    focus-area: doma
-  - title: "Creating a content delivery network for general science on the backbone of the Internet using xcaches."
-    date: 2019-11-05
-    url: https://indico.cern.ch/event/773049/contributions/3474435/attachments/1937430/3211155/Stashcache_CHEP_2019.pdf
-    meeting: CHEP 2019
-    meetingurl: http://chep2019.org
-    location: Adelaide, Australia
-    focus-area: doma
-    project: caching
-  - title: "A Lightweight Door into Non-grid Sites"
-    date: 2019-11-05
-    url: https://indico.cern.ch/event/773049/contributions/3473860/attachments/1935962/3208177/chep2019-hosted-ce.pdf
-    meeting: CHEP 2019
-    meetingurl: http://chep2019.org
-    location: Adelaide, Australia
-    focus-area: osglhc
-  - title: " Nautilus & IceCUBE/LIGO"
-    date: 2019-09-17
-    url: http://grp-workshop-2019.ucsd.edu/presentations/1_SFILIGOI-GRP-2019-IceCubeLigo.pdf
-    meeting: Global Research Platform Workshop 2019
-    meetingurl: http://grp-workshop-2019.ucsd.edu
-    location: San Diego, CA, US
-    focus-area: osglhc
-  - title: "The Open Science Grid"
-    date: 2019-09-13
-    url: https://github.com/pragmagrid/pragma-meetings/raw/master/pragma37/13/invited-talk2-osg.pdf
-    meeting: PRAGMA 37
-    meetingurl: http://www.pragma-grid.net/pragma37-program/
-    location: San Diego, CA, US
-    focus-area: osglhc
+- title: Data-intensive IceCube Cloud Burst
+  date: 2020-11-12
+  url: https://www2.slideshare.net/igor_sfiligoi/dataintensive-icecube-cloud-burst
+  meeting: NRP Pilot weekly meeting
+  location: Virtual, USA
+  focus-area: osglhc
+- title: Unified Cyber Infrastructure with Kubernetes
+  date: 2020-11-09
+  url: https://gitlab.com/ucsd-prp/tutorials/sc20
+  meeting: SC 20 Tutorial
+  meetingurl: https://sc20.supercomputing.org/presentation/?id=tut136&sess=sess256
+  location: Virtual, USA
+  focus-area: osglhc
+- title: Scheduling a Kubernetes Federation with Admiralty
+  date: 2020-09-04
+  url: https://indico.fnal.gov/event/22127/contributions/194933/attachments/133961/165464/osg20_lhc_admiralty_rc3.pdf
+  meeting: OSG All-Hands Meeting 2020
+  meetingurl: https://indico.fnal.gov/event/22127
+  location: Virtual, US
+  focus-area: osglhc
+- title: Demonstrating a Pre-Exascale, Cost-Effective Multi-Cloud Environment for
+    Scientific Computing
+  date: 2020-07-29
+  url: https://www.slideshare.net/igor_sfiligoi/demonstrating-a-preexascale-costeffective-multicloud-environment-for-scientific-computing
+  meeting: PEARC20
+  meetingurl: https://pearc.acm.org/pearc20/
+  location: Virtual, US
+  focus-area: osglhc
+- title: Demonstrating 100 Gbps in and out of the public Clouds
+  date: 2020-07-28
+  url: https://doi.org/10.1145/3311790.3399612
+  meeting: PEARC20
+  meetingurl: https://pearc.acm.org/pearc20/
+  location: Virtual, US
+  focus-area: doma
+- title: High Throughput Science Workshop
+  date: 2020-07-31
+  meeting: PEARC20
+  url: https://pearc20.sched.com/event/cnY6/high-throughput-science
+  meetingurl: https://pearc.acm.org/pearc20/
+  location: Virtual, US
+  focus-area: osglhc
+- title: Running a Pre-exascale, Geographically Distributed, Multi-cloud Scientific
+    Simulation
+  date: 2020-06-28
+  url: https://doi.org/10.1007/978-3-030-50743-5_2
+  meeting: ISC20
+  meetingurl: https://www.isc-hpc.com
+  location: Virtual
+  focus-area: osglhc
+- title: TransAtlantic networking using Cloud links
+  date: 2020-05-27
+  url: https://indico.cern.ch/event/923131/contributions/3878486/attachments/2045504/3426871/CMS20_05_CloudNetwork_rc2.pdf
+  meeting: S&C Blueprint Meeting
+  meetingurl: https://indico.cern.ch/event/923131/
+  focus-area: osglhc
+- title: Hybrid, multi-Cloud HPC for Multi-Messenger Astrophysics with IceCube
+  date: 2020-01-28
+  url: https://docs.google.com/presentation/d/1NT5DiCudME7OoU_zxOsw_nkZoNNNKIm3DEfD3miKd0A/edit?usp=sharing
+  meeting: Google Cloud HPC Day San Diego
+  meetingurl: https://events.withgoogle.com/google-cloud-hpc-day-san-diego/
+  location: San Diego, CA ,USA
+  focus-area: osglhc
+- title: Running a 380PFLOP32s GPU burst for Multi-Messenger Astrophysics with IceCube
+    across all available GPUs in the Cloud
+  date: 2020-01-27
+  url: https://www.slideshare.net/igor_sfiligoi/nrp-engagement-webinar-running-a-51k-gpu-multicloud-burstfor-mma-with-icecube
+  meeting: NRP Engagement webinar
+  meetingurl: https://spaces.at.internet2.edu/display/NRPWG/National+Research+Platform+%28NRP%29+Space
+  location: WebEx, US
+  focus-area: osglhc
+- title: OSG use of PRP Kubernetes cluster
+  date: 2019-12-10
+  url: https://indico.cern.ch/event/739899/contributions/3662270/attachments/1959449/3256032/cern19_prp_osg_191210.pdf
+  meeting: pre-GDB meeting
+  meetingurl: https://indico.cern.ch/event/739899/
+  location: CERN
+  focus-area: osglhc
+- title: Serving HTC Users in Kubernetes by Leveraging HTCondor
+  date: 2019-11-21
+  url: https://kccncna19.sched.com/event/77ed0cf42f37809c9640ee8fe1dc5415
+  meeting: KubeCon North America 2019
+  meetingurl: https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/
+  location: San Diego, CA, USA
+  focus-area: osglhc
+- title: Burst data retrieval after 50k GPU Cloud run
+  date: 2019-11-19
+  url: https://www.slideshare.net/igor_sfiligoi/burst-data-retrieval-after-50k-gpu-cloud-run
+  meeting: SC 19 Internet2 Booth
+  meetingurl: https://sc19.supercomputing.org
+  location: Denver, CO, USA
+  focus-area: osglhc
+- title: Unified Cyber Infrastructure with Kubernetes
+  date: 2019-11-18
+  url: https://gitlab.com/ucsd-prp/tutorials/sc19
+  meeting: SC 19 Tutorial
+  meetingurl: https://sc19.supercomputing.org/presentation/?id=tut130&sess=sess190
+  location: Denver, CO, USA
+  focus-area: osglhc
+- title: Characterizing network paths in and out of the Clouds
+  date: 2019-11-04
+  url: https://indico.cern.ch/event/773049/contributions/3473824/attachments/1935023/3206398/CHEP19_Networks.pptx
+  meeting: CHEP 2019
+  meetingurl: http://chep2019.org
+  location: Adelaide, Australia
+  focus-area: doma
+- title: Creating a content delivery network for general science on the backbone of
+    the Internet using xcaches.
+  date: 2019-11-05
+  url: https://indico.cern.ch/event/773049/contributions/3474435/attachments/1937430/3211155/Stashcache_CHEP_2019.pdf
+  meeting: CHEP 2019
+  meetingurl: http://chep2019.org
+  location: Adelaide, Australia
+  focus-area: doma
+  project: caching
+- title: A Lightweight Door into Non-grid Sites
+  date: 2019-11-05
+  url: https://indico.cern.ch/event/773049/contributions/3473860/attachments/1935962/3208177/chep2019-hosted-ce.pdf
+  meeting: CHEP 2019
+  meetingurl: http://chep2019.org
+  location: Adelaide, Australia
+  focus-area: osglhc
+- title: " Nautilus & IceCUBE/LIGO"
+  date: 2019-09-17
+  url: http://grp-workshop-2019.ucsd.edu/presentations/1_SFILIGOI-GRP-2019-IceCubeLigo.pdf
+  meeting: Global Research Platform Workshop 2019
+  meetingurl: http://grp-workshop-2019.ucsd.edu
+  location: San Diego, CA, US
+  focus-area: osglhc
+- title: The Open Science Grid
+  date: 2019-09-13
+  url: https://github.com/pragmagrid/pragma-meetings/raw/master/pragma37/13/invited-talk2-osg.pdf
+  meeting: PRAGMA 37
+  meetingurl: http://www.pragma-grid.net/pragma37-program/
+  location: San Diego, CA, US
+  focus-area: osglhc

--- a/_data/people/sfiligoi.yml
+++ b/_data/people/sfiligoi.yml
@@ -1,11 +1,13 @@
----
+active: true
+focus-area:
+- osglhc
+- doma
+institution: University of California, San Diego
 name: Igor Sfiligoi
+photo: "/assets/images/team/Igor-Sfiligoi.jpg"
 shortname: sfiligoi
 title: Lead Scientific Software Developer and Researcher
-active: true
-institution: University of California, San Diego
 website:
-photo: "/assets/images/team/Igor-Sfiligoi.jpg"
 presentations:
 - title: Data-intensive IceCube Cloud Burst
   date: 2020-11-12
@@ -143,6 +145,3 @@ presentations:
   meetingurl: http://www.pragma-grid.net/pragma37-program/
   location: San Diego, CA, US
   focus-area: osglhc
-focus-area:
-- osglhc
-- doma

--- a/_data/people/sfiligoi.yml
+++ b/_data/people/sfiligoi.yml
@@ -143,3 +143,6 @@ presentations:
   meetingurl: http://www.pragma-grid.net/pragma37-program/
   location: San Diego, CA, US
   focus-area: osglhc
+focus-area:
+- osglhc
+- doma

--- a/_data/people/sinclert.yml
+++ b/_data/people/sinclert.yml
@@ -1,32 +1,33 @@
+---
 name: Sinclert Pérez
 shortname: sinclert
 title: Research Software Engineer
 active: true
 institution: New York University
 website: https://sinclert.github.io/
-photo: /assets/images/team/Sinclert-Perez.jpg
+photo: "/assets/images/team/Sinclert-Perez.jpg"
 presentations:
-  - title: REANA, To reusability... and beyond!
-    date: 2018-08-16
-    url: https://indico.cern.ch/event/727275/contributions/3100506/attachments/1701324/2740014/REANA_slides_4x3.pptx
-    meeting: CERN Openlab presentations
-    meetingurl: https://indico.cern.ch/event/727275/
-    location: Geneva, Switzerland
-    focus-area: as
-    project:
-  - title: Integrating Cyberinfrastructure components
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331187/17_-_Sinclert-Cyberinfrastructure_components.pdf
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton, US
-    focus-area: as
-    project:
-  - title: Madminer on REANA
-    date: 2020-10-26
-    url: https://indico.cern.ch/event/960587/attachments/2129226/3585364/IRIS-HEP%20Madminer-on-reana.pdf
-    meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
-    meetingurl: https://indico.cern.ch/event/960587/
-    location: Virtual
-    focus-area: as
-    project: madminer
+- title: REANA, To reusability... and beyond!
+  date: 2018-08-16
+  url: https://indico.cern.ch/event/727275/contributions/3100506/attachments/1701324/2740014/REANA_slides_4x3.pptx
+  meeting: CERN Openlab presentations
+  meetingurl: https://indico.cern.ch/event/727275/
+  location: Geneva, Switzerland
+  focus-area: as
+  project:
+- title: Integrating Cyberinfrastructure components
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331187/17_-_Sinclert-Cyberinfrastructure_components.pdf
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton, US
+  focus-area: as
+  project:
+- title: Madminer on REANA
+  date: 2020-10-26
+  url: https://indico.cern.ch/event/960587/attachments/2129226/3585364/IRIS-HEP%20Madminer-on-reana.pdf
+  meeting: IRIS-HEP Future Analysis Systems and Facilities Blueprint Workshop
+  meetingurl: https://indico.cern.ch/event/960587/
+  location: Virtual
+  focus-area: as
+  project: madminer

--- a/_data/people/sinclert.yml
+++ b/_data/people/sinclert.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- as
+institution: New York University
 name: Sinclert Pérez
+photo: "/assets/images/team/Sinclert-Perez.jpg"
 shortname: sinclert
 title: Research Software Engineer
-active: true
-institution: New York University
 website: https://sinclert.github.io/
-photo: "/assets/images/team/Sinclert-Perez.jpg"
 presentations:
 - title: REANA, To reusability... and beyond!
   date: 2018-08-16
@@ -31,5 +32,3 @@ presentations:
   location: Virtual
   focus-area: as
   project: madminer
-focus-area:
-- as

--- a/_data/people/sinclert.yml
+++ b/_data/people/sinclert.yml
@@ -31,3 +31,5 @@ presentations:
   location: Virtual
   focus-area: as
   project: madminer
+focus-area:
+- as

--- a/_data/people/slava77.yml
+++ b/_data/people/slava77.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ia
+institution: University of California, San Diego
 name: Slava Krutelyov
+photo: "/assets/images/team/Slava-Krutelyov.jpg"
 shortname: slava77
 title:
-active: true
-institution: University of California, San Diego
 website:
-photo: "/assets/images/team/Slava-Krutelyov.jpg"
 presentations:
 - title: Charged Particle Tracking Reconstruction (Guest Lecture)
   date: 2019-07-25
@@ -47,5 +48,3 @@ presentations:
   location: CERN
   focus-area: ia
   project: mkfit
-focus-area:
-- ia

--- a/_data/people/slava77.yml
+++ b/_data/people/slava77.yml
@@ -47,3 +47,5 @@ presentations:
   location: CERN
   focus-area: ia
   project: mkfit
+focus-area:
+- ia

--- a/_data/people/slava77.yml
+++ b/_data/people/slava77.yml
@@ -1,47 +1,49 @@
+---
 name: Slava Krutelyov
 shortname: slava77
 title:
 active: true
 institution: University of California, San Diego
 website:
-photo: /assets/images/team/Slava-Krutelyov.jpg
+photo: "/assets/images/team/Slava-Krutelyov.jpg"
 presentations:
-  - title: "Charged Particle Tracking Reconstruction (Guest Lecture)"
-    date: 2019-07-25
-    url: https://indico.cern.ch/event/814979/contributions/3401167/attachments/1831465/3110068/trackingCODAS19.pdf
-    meeting: Third Computational and Data Science school for HEP (CoDaS-HEP 2019)
-    meetingurl: https://indico.cern.ch/event/814979
-    location: Princeton
-    project: mkfit
-  - title: "Reconstruction R&D for HEP in the next decade"
-    date: 2019-11-22
-    url: https://indico.cern.ch/event/813325/contributions/3603480/attachments/1949438/3235400/lawshepRECO_112119.pdf
-    meeting: Latin American Workshop on Software and Computing challenges in High-Energy Particle Physics (LAWSCHEP 2019)
-    meetingurl: https://indico.cern.ch/event/813325
-    location: Mexico City, Mexico
-    focus-area: ia
-    project: mkfit
-  - title: "Update on mkFit developments"
-    date: 2019-12-16
-    url: https://indico.cern.ch/event/869552/contributions/3669454
-    meeting: CMS Tracking POG Meeting (CMS restricted)
-    meetingurl: https://indico.cern.ch/event/869552
-    location: CERN
-    focus-area: ia
-    project: mkfit
-  - title: "mkFit report: plans for offline tracking in Run3"
-    date: 2020-10-06
-    url: https://indico.cern.ch/event/934824/contributions/4042760
-    meeting: CMS Tracker DPG - Tracking POG General Meeting (CMS restricted)
-    meetingurl: https://indico.cern.ch/event/934824/#b-382385-tracker-dpg-tracking
-    location: CERN
-    focus-area: ia
-    project: mkfit
-  - title: "mkFit report: plans for offline tracking in Run3"
-    date: 2020-10-19
-    url: https://indico.cern.ch/event/961478/contributions/4056656
-    meeting: CMS Tracking POG Meeting (CMS restricted)
-    meetingurl: https://indico.cern.ch/event/961478
-    location: CERN
-    focus-area: ia
-    project: mkfit
+- title: Charged Particle Tracking Reconstruction (Guest Lecture)
+  date: 2019-07-25
+  url: https://indico.cern.ch/event/814979/contributions/3401167/attachments/1831465/3110068/trackingCODAS19.pdf
+  meeting: Third Computational and Data Science school for HEP (CoDaS-HEP 2019)
+  meetingurl: https://indico.cern.ch/event/814979
+  location: Princeton
+  project: mkfit
+- title: Reconstruction R&D for HEP in the next decade
+  date: 2019-11-22
+  url: https://indico.cern.ch/event/813325/contributions/3603480/attachments/1949438/3235400/lawshepRECO_112119.pdf
+  meeting: Latin American Workshop on Software and Computing challenges in High-Energy
+    Particle Physics (LAWSCHEP 2019)
+  meetingurl: https://indico.cern.ch/event/813325
+  location: Mexico City, Mexico
+  focus-area: ia
+  project: mkfit
+- title: Update on mkFit developments
+  date: 2019-12-16
+  url: https://indico.cern.ch/event/869552/contributions/3669454
+  meeting: CMS Tracking POG Meeting (CMS restricted)
+  meetingurl: https://indico.cern.ch/event/869552
+  location: CERN
+  focus-area: ia
+  project: mkfit
+- title: 'mkFit report: plans for offline tracking in Run3'
+  date: 2020-10-06
+  url: https://indico.cern.ch/event/934824/contributions/4042760
+  meeting: CMS Tracker DPG - Tracking POG General Meeting (CMS restricted)
+  meetingurl: https://indico.cern.ch/event/934824/#b-382385-tracker-dpg-tracking
+  location: CERN
+  focus-area: ia
+  project: mkfit
+- title: 'mkFit report: plans for offline tracking in Run3'
+  date: 2020-10-19
+  url: https://indico.cern.ch/event/961478/contributions/4056656
+  meeting: CMS Tracking POG Meeting (CMS restricted)
+  meetingurl: https://indico.cern.ch/event/961478
+  location: CERN
+  focus-area: ia
+  project: mkfit

--- a/_data/people/smckee.yml
+++ b/_data/people/smckee.yml
@@ -273,3 +273,6 @@ presentations:
   location: Zoom
   focus-area: osglhc
   project: osg-networking
+focus-area:
+- osglhc
+- doma

--- a/_data/people/smckee.yml
+++ b/_data/people/smckee.yml
@@ -1,11 +1,13 @@
----
+active: true
+focus-area:
+- osglhc
+- doma
+institution: University of Michigan-Ann Arbor
 name: Shawn McKee
+photo: "/assets/images/team/Shawn-McKee.jpg"
 shortname: smckee
 title: OSG Networking Area Coordinator
-active: true
-institution: University of Michigan-Ann Arbor
 website: https://lsa.umich.edu/physics/people/research-scientists/smckee.html
-photo: "/assets/images/team/Shawn-McKee.jpg"
 presentations:
 - title: WLCG/OSG Network Activities, Status and Plans
   date: 2019-03-26
@@ -273,6 +275,3 @@ presentations:
   location: Zoom
   focus-area: osglhc
   project: osg-networking
-focus-area:
-- osglhc
-- doma

--- a/_data/people/smckee.yml
+++ b/_data/people/smckee.yml
@@ -1,272 +1,275 @@
+---
 name: Shawn McKee
 shortname: smckee
 title: OSG Networking Area Coordinator
 active: true
 institution: University of Michigan-Ann Arbor
 website: https://lsa.umich.edu/physics/people/research-scientists/smckee.html
-photo: /assets/images/team/Shawn-McKee.jpg
+photo: "/assets/images/team/Shawn-McKee.jpg"
 presentations:
-  - title: WLCG/OSG Network Activities, Status and Plans
-    date: 2019-03-26
-    url: https://indico.cern.ch/event/765497/contributions/3351215/attachments/1818575/2973383/HEPiX_Spring_2019_OSG_WLCG_Networking_Update.pdf
-    meeting: HEPiX Spring 2019
-    meetingurl: https://indico.cern.ch/event/765497
-    location: San Diego, CA, US
-    focus-area: osglhc
-    project: osg-networking
-  - title: "OSG Networking: Status, Collaborations and Plans"
-    date: 2019-03-20
-    url: https://indico.cern.ch/event/759388/contributions/3352523/attachments/1815087/2966245/OSG_Networking__Status_Collaborations_and_Plans.pdf
-    meeting: Joint HSF/OSG/WLCG Workshop (HOW2019)
-    meetingurl: https://indico.cern.ch/event/759388
-    location: Newport News, VA, US
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Scientific Data Lifecycle: Perspectives from an LHC Physicist"
-    date: 2019-03-06
-    url: https://www.nitrd.gov/nitrdgroups/images/9/98/Scientific-Data-Lifecycle-Shawn-McKee.pdf
-    meeting: MAGIC Meeting
-    meetingurl: https://www.nitrd.gov/nitrdgroups/index.php?title=MAGIC-Meetings-2019
-    location: Videoconference
-    focus-area: doma
-    project:
-  - title: "LHCOPN/LHCONE perfSONAR Update"
-    date: 2019-06-04
-    url: https://indico.cern.ch/event/772031/contributions/3360614/attachments/1855592/3047650/LHCOPN_LHCONE_perfSONAR_Update_2019spring.pdf
-    meeting: LHCONE/LHCOPN Meeting
-    meetingurl: https://indico.cern.ch/event/772031
-    location: Umea, Sweden
-    focus-area: osglhc
-    project: osg-networking
-  - title: "The Service Analysis and Network Diagnostic (SAND) Project"
-    date: 2019-07-02
-    url: https://wiki.geant.org/download/attachments/123774072/SIG-PMV-DUblin-SAND-McKee-02-Jul-2019.pdf?version=2&modificationDate=1562073472330&api=v2
-    meeting: The 6th Special Interest Group on Performance Monitoring and Verification Meeting
-    meetingurl: https://wiki.geant.org/display/PMV/6th+SIG-PMV+Meeting+@+Dublin
-    location: Dublin, Ireland
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Data Lakes, Data Caching for Science and the OSIRIS Distributed Storage System"
-    date: 2019-09-18
-    url: http://grp-workshop-2019.ucsd.edu/presentations/3_McKEE-GRP-2019-OSIRIS-Caching.pdf
-    meeting: The Global Research Platform Workshop
-    meetingurl: http://grp-workshop-2019.ucsd.edu/
-    location: San Diego, California
-    focus-area: doma
-    project:
-  - title: "WLCG/OSG Network Activities, Status and Plans"
-    date: 2019-10-16
-    url: https://indico.cern.ch/event/810635/contributions/3593246/attachments/1926442/3223199/HEPiX_Fall_2019_OSG_WLCG_Networking_Update.pdf
-    meeting: The Fall 2019 HEPiX Meeting
-    meetingurl: https://indico.cern.ch/event/810635/
-    location: Amsterdam, Netherlands
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Network Function Virtualization Working Group Update"
-    date: 2019-10-16
-    url: https://indico.cern.ch/event/810635/contributions/3593247/attachments/1927128/3223214/HEPiX_Network_Virtualisation_Working_Group_Update_Oct_2019_HEPiX.pdf
-    meeting: The Fall 2019 HEPiX Meeting
-    meetingurl: https://indico.cern.ch/event/810635/
-    location: Amsterdam, Netherlands
-    focus-area: osglhc
-    project: osg-networking
-  - title: "The SAND Project a the Halfway Point"
-    date: 2019-10-16
-    url: https://indico.cern.ch/event/810635/contributions/3593348/attachments/1926847/3223164/HEPiX-SAND-Fall-2019.pdf
-    meeting: The Fall 2019 HEPiX Meeting
-    meetingurl: https://indico.cern.ch/event/810635/
-    location: Amsterdam, Netherlands
-    focus-area: osglhc
-    project: osg-networking
-  - title: "WLCG Networks: Update on Monitoring and Analytics"
-    date: 2019-11-04
-    url: https://indico.cern.ch/event/773049/contributions/3473823/attachments/1937475/3213791/CHEP_2019_OSG_WLCG_Networking_Update.pdf
-    meeting: CHEP2019
-    meetingurl: http://chep2019.org/
-    location: Adelaide, Australia
-    focus-area: osglhc
-    project: osg-networking
-  - title: "A distributed R&D storage platform implementing quality of service"
-    date: 2019-11-05
-    url: https://indico.cern.ch/event/773049/contributions/3474403/attachments/1937924/3212138/CHEP-RandD-DataLake-v2.pdf
-    meeting: CHEP2019
-    meetingurl: http://chep2019.org/
-    location: Adelaide, Australia
-    focus-area: doma
-    project:
-  - title: "Network Capabilities for the HL-LHC Era"
-    date: 2019-11-07
-    url: https://indico.cern.ch/event/773049/contributions/3473832/attachments/1939678/3215613/CHEP_Network_Capabilities_for_HL-LHC_Nov_19.pdf
-    meeting: CHEP2019
-    meetingurl: http://chep2019.org/
-    location: Adelaide, Australia
-    focus-area: osglhc
-    project: osg-networking
-  - title: "perfSONAR Analytics"
-    date: 2019-12-03
-    url: https://indico.cern.ch/event/823341/contributions/3645036/attachments/1955228/3247468/perfSONAR_Analytics.pdf
-    meeting: ATLAS Software and Computing Week #64
-    meetingurl: https://indico.cern.ch/event/823341/
-    location: CERN, Geneva, Switzerland
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Network Function Virtualization Report and Next Steps for Experiments"
-    date: 2020-01-14
-    url: https://indico.cern.ch/event/828520/contributions/3699233/attachments/1968544/3274004/Network-Discussion-LHCOPN_LHCONE-2020.pdf
-    meeting: LHCONE/LHCOPN Meeting
-    meetingurl: https://indico.cern.ch/event/828520/
-    location: CERN, Geneva, Switzerland
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Updates on OSG/WLCG perfSONAR Network Monitoring and Analytics"
-    date: 2020-01-15
-    url: https://indico.cern.ch/event/813757/contributions/3698520/attachments/1969584/3276449/Updates_on_OSG_WLCG_perfSONAR_Network_Monitoring_and_Analytics_2.pdf
-    meeting: Grid Deployment Board
-    meetingurl: https://indico.cern.ch/event/813757/
-    location: CERN, Geneva, Switzerland
-    focus-area: osglhc
-    project: osg-networking
-  - title: "LHCONE/LHCOPN Meeting Summary"
-    date: 2020-01-15
-    url: https://indico.cern.ch/event/813757/contributions/3698521/attachments/1969608/3276108/LHCOPNE-20200114-CERN-meeting-report-v1.0.pptx_1.pdf
-    meeting: Grid Deployment Board
-    meetingurl: https://indico.cern.ch/event/813757/
-    location: CERN, Geneva, Switzerland
-    focus-area: osglhc
-    project: osg-networking
-  - title: "OSG Network Monitoring (poster)"
-    date: 2020-02-27
-    url: https://indico.cern.ch/event/894127/attachments/1996570/3331193/23_-_IRIS-HEP_LHC-OSG_Network_Monitoring.pdf
-    meeting: IRIS-HEP Poster Session
-    meetingurl: https://indico.cern.ch/event/894127/
-    location: Princeton, New Jersey, US
-    focus-area: osglhc
-    project: osg-networking
-  - title: "USATLAS: OSG/WLCG perfSONAR Network Monitoring and Analytics"
-    date: 2020-04-01
-    url: https://indico.cern.ch/event/895416/contributions/3775747/attachments/2013505/3364898/go
-    meeting: USATLAS Facilities Meeting
-    meetingurl: https://indico.cern.ch/event/895416/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "New National Science Foundation International Research and education Network Connections Testbed Solicitation"
-    date: 2020-04-14
-    url: https://indico.cern.ch/event/870360/contributions/3670577/attachments/2019180/3376379/WLCG-IRNC-April-14-2020.pdf
-    meeting: WLCG Management Board
-    meetingurl: https://indico.cern.ch/event/870360/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "FABRIC for High-Energy Physics Prototyping"
-    date: 2020-04-16
-    url: https://drive.google.com/drive/u/0/folders/1Sp_m_9j1_x747B6CR0zhc2dM-JcoDvcz
-    meeting: FABRIC Community Workshop
-    meetingurl: https://fabric-testbed.net/events/fabric-community-workshop-2020
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Networking: Status and Discussion"
-    date: 2020-05-05
-    url: https://docs.google.com/presentation/d/1OIKGxvq4vkPzUkXtx06LJ8Ka569Zyi8PFWYYrQNkmsE/edit#slide=id.g76f5dacfb4_0_90
-    meeting: ATLAS Distributed Data Management Roundtable
-    meetingurl: https://indico.cern.ch/event/915025/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "The SAND Project and a New Research Networking Technical Working Group"
-    date: 2020-05-12
-    url: https://docs.google.com/presentation/d/1ui5cVngu72c3DsiAtpBJWKZ3jKiC_1nCCxS-kmG9NCM/edit?usp=sharing
-    meeting: Internet2 Community Measurement, Metrics and Telemetry Meeting
-    meetingurl: https://docs.google.com/document/d/1A_6Ooowm33MZR3A-fuTnhGwIUX6UEeaPumRfGUSBEgI/edit?usp=sharing
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Report on the Research Networking Technical WG"
-    date: 2020-05-12
-    url: https://docs.google.com/presentation/d/1Rfr-zLrd2gYhiIgTag9XMIEPRcD9ireGOisGY3xRfOY/edit#slide=id.g8036819354_0_7
-    meeting: Internet2 Community Measurement, Metrics and Telemetry Meeting
-    meetingurl: https://docs.google.com/document/d/1A_6Ooowm33MZR3A-fuTnhGwIUX6UEeaPumRfGUSBEgI/edit?usp=sharing
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "LHCOPN/LHCONE perfSONAR Update"
-    date: 2020-05-13
-    url: https://indico.cern.ch/event/888924/contributions/3792412/attachments/2037674/3412900/LHCOPN_LHCONE_perfSONAR_Update_2020spring.pdf
-    meeting: LHCONE/LHCOPN Spring 2020 Meeting
-    meetingurl: https://indico.cern.ch/event/888924/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Research Network Technology Working Group"
-    date: 2020-05-13
-    url: https://indico.cern.ch/event/888924/contributions/3792419/attachments/2037093/3411000/Research_Networking_Technical_Working_Group.pdf
-    meeting: LHCONE/LHCOPN Spring 2020 Meeting
-    meetingurl: https://indico.cern.ch/event/888924/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "IPv6 and RNTWG Sub-groups"
-    date: 2020-06-03
-    url: https://indico.cern.ch/event/924996/contributions/3887247/attachments/2049467/3436039/IPv6_and_RNTWG_Sub-Groups.pdf
-    meeting: HEPiX IPv6 Working Group
-    meetingurl: https://indico.cern.ch/event/924996/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Research Networking Technical WG (RNTWG) Update"
-    date: 2020-09-16
-    url: https://indico.cern.ch/event/932306/contributions/3937507/attachments/2104416/3538776/Research_Networking_Technical_Working_Group_Update.pdf
-    meeting: LHCONE/LHCOPN Fall 2020 Meeting
-    meetingurl: https://indico.cern.ch/event/932306/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Update from RNTWG - Packet Marking Subgroup"
-    date: 2020-09-29
-    url: https://indico.cern.ch/event/959585/contributions/4034267/attachments/2111250/3551438/Update_from_RNTWG_-_Packet_Marking_Subgroup.pdf
-    meeting: HEPiX IPv6 Working Group
-    meetingurl: https://indico.cern.ch/event/959585/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Update on the Packet Marking WG"
-    date: 2021-01-19
-    url: https://indico.cern.ch/event/995980/contributions/4185460/attachments/2174072/3670811/Update%20on%20the%20Packet%20Marking%20WG%20%281%29.pdf
-    meeting: HEPiX IPv6 Working Group Virtual F2F
-    meetingurl: https://indico.cern.ch/event/995980/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Network Topics For Discussion"
-    date: 2021-03-05
-    url: https://indico.fnal.gov/event/47040/contributions/209607/subcontributions/7880/attachments/140685/176868/OSG-AHM-2021_Network_Topics_Part_1.pdf
-    meeting: Open Science Grid All-Hands Meeting, Joint USATLAS-USCMS Session
-    meetingurl: https://indico.fnal.gov/event/47040/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "WLCG/OSG Network Activities, Status and Plans"
-    date: 2021-03-16
-    url: https://indico.cern.ch/event/995485/contributions/4256471/attachments/2209460/3739050/HEPiX%20perfSONAR%20Update%20Spring%202021.pdf
-    meeting: HEPiX Spring 2021 Meeting
-    meetingurl: https://indico.cern.ch/event/995485/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "LHCOPN/LHCONE Monitoring Updated"
-    date: 2021-03-23
-    url: https://indico.cern.ch/event/983436/contributions/4232157/attachments/2213899/3748225/LHCONE%20Monitoring%20Update%20Spring%202021.pdf
-    meeting: LHCONE/LHCOPN Spring 2021 Meeting
-    meetingurl: https://indico.cern.ch/event/983436/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
-  - title: "Network Monitoring R&D (and data challenge needs)"
-    date: 2021-04-27
-    url: https://indico.cern.ch/event/1027287/contributions/4335184/attachments/2234157/3786307/Network%20Monitoring%20R%26D.pdf
-    meeting: Data Challenge Monitoring Mini-Workshop
-    meetingurl: https://indico.cern.ch/event/1027287/
-    location: Zoom
-    focus-area: osglhc
-    project: osg-networking
+- title: WLCG/OSG Network Activities, Status and Plans
+  date: 2019-03-26
+  url: https://indico.cern.ch/event/765497/contributions/3351215/attachments/1818575/2973383/HEPiX_Spring_2019_OSG_WLCG_Networking_Update.pdf
+  meeting: HEPiX Spring 2019
+  meetingurl: https://indico.cern.ch/event/765497
+  location: San Diego, CA, US
+  focus-area: osglhc
+  project: osg-networking
+- title: 'OSG Networking: Status, Collaborations and Plans'
+  date: 2019-03-20
+  url: https://indico.cern.ch/event/759388/contributions/3352523/attachments/1815087/2966245/OSG_Networking__Status_Collaborations_and_Plans.pdf
+  meeting: Joint HSF/OSG/WLCG Workshop (HOW2019)
+  meetingurl: https://indico.cern.ch/event/759388
+  location: Newport News, VA, US
+  focus-area: osglhc
+  project: osg-networking
+- title: 'Scientific Data Lifecycle: Perspectives from an LHC Physicist'
+  date: 2019-03-06
+  url: https://www.nitrd.gov/nitrdgroups/images/9/98/Scientific-Data-Lifecycle-Shawn-McKee.pdf
+  meeting: MAGIC Meeting
+  meetingurl: https://www.nitrd.gov/nitrdgroups/index.php?title=MAGIC-Meetings-2019
+  location: Videoconference
+  focus-area: doma
+  project:
+- title: LHCOPN/LHCONE perfSONAR Update
+  date: 2019-06-04
+  url: https://indico.cern.ch/event/772031/contributions/3360614/attachments/1855592/3047650/LHCOPN_LHCONE_perfSONAR_Update_2019spring.pdf
+  meeting: LHCONE/LHCOPN Meeting
+  meetingurl: https://indico.cern.ch/event/772031
+  location: Umea, Sweden
+  focus-area: osglhc
+  project: osg-networking
+- title: The Service Analysis and Network Diagnostic (SAND) Project
+  date: 2019-07-02
+  url: https://wiki.geant.org/download/attachments/123774072/SIG-PMV-DUblin-SAND-McKee-02-Jul-2019.pdf?version=2&modificationDate=1562073472330&api=v2
+  meeting: The 6th Special Interest Group on Performance Monitoring and Verification
+    Meeting
+  meetingurl: https://wiki.geant.org/display/PMV/6th+SIG-PMV+Meeting+@+Dublin
+  location: Dublin, Ireland
+  focus-area: osglhc
+  project: osg-networking
+- title: Data Lakes, Data Caching for Science and the OSIRIS Distributed Storage System
+  date: 2019-09-18
+  url: http://grp-workshop-2019.ucsd.edu/presentations/3_McKEE-GRP-2019-OSIRIS-Caching.pdf
+  meeting: The Global Research Platform Workshop
+  meetingurl: http://grp-workshop-2019.ucsd.edu/
+  location: San Diego, California
+  focus-area: doma
+  project:
+- title: WLCG/OSG Network Activities, Status and Plans
+  date: 2019-10-16
+  url: https://indico.cern.ch/event/810635/contributions/3593246/attachments/1926442/3223199/HEPiX_Fall_2019_OSG_WLCG_Networking_Update.pdf
+  meeting: The Fall 2019 HEPiX Meeting
+  meetingurl: https://indico.cern.ch/event/810635/
+  location: Amsterdam, Netherlands
+  focus-area: osglhc
+  project: osg-networking
+- title: Network Function Virtualization Working Group Update
+  date: 2019-10-16
+  url: https://indico.cern.ch/event/810635/contributions/3593247/attachments/1927128/3223214/HEPiX_Network_Virtualisation_Working_Group_Update_Oct_2019_HEPiX.pdf
+  meeting: The Fall 2019 HEPiX Meeting
+  meetingurl: https://indico.cern.ch/event/810635/
+  location: Amsterdam, Netherlands
+  focus-area: osglhc
+  project: osg-networking
+- title: The SAND Project a the Halfway Point
+  date: 2019-10-16
+  url: https://indico.cern.ch/event/810635/contributions/3593348/attachments/1926847/3223164/HEPiX-SAND-Fall-2019.pdf
+  meeting: The Fall 2019 HEPiX Meeting
+  meetingurl: https://indico.cern.ch/event/810635/
+  location: Amsterdam, Netherlands
+  focus-area: osglhc
+  project: osg-networking
+- title: 'WLCG Networks: Update on Monitoring and Analytics'
+  date: 2019-11-04
+  url: https://indico.cern.ch/event/773049/contributions/3473823/attachments/1937475/3213791/CHEP_2019_OSG_WLCG_Networking_Update.pdf
+  meeting: CHEP2019
+  meetingurl: http://chep2019.org/
+  location: Adelaide, Australia
+  focus-area: osglhc
+  project: osg-networking
+- title: A distributed R&D storage platform implementing quality of service
+  date: 2019-11-05
+  url: https://indico.cern.ch/event/773049/contributions/3474403/attachments/1937924/3212138/CHEP-RandD-DataLake-v2.pdf
+  meeting: CHEP2019
+  meetingurl: http://chep2019.org/
+  location: Adelaide, Australia
+  focus-area: doma
+  project:
+- title: Network Capabilities for the HL-LHC Era
+  date: 2019-11-07
+  url: https://indico.cern.ch/event/773049/contributions/3473832/attachments/1939678/3215613/CHEP_Network_Capabilities_for_HL-LHC_Nov_19.pdf
+  meeting: CHEP2019
+  meetingurl: http://chep2019.org/
+  location: Adelaide, Australia
+  focus-area: osglhc
+  project: osg-networking
+- title: perfSONAR Analytics
+  date: 2019-12-03
+  url: https://indico.cern.ch/event/823341/contributions/3645036/attachments/1955228/3247468/perfSONAR_Analytics.pdf
+  meeting: ATLAS Software and Computing Week
+  meetingurl: https://indico.cern.ch/event/823341/
+  location: CERN, Geneva, Switzerland
+  focus-area: osglhc
+  project: osg-networking
+- title: Network Function Virtualization Report and Next Steps for Experiments
+  date: 2020-01-14
+  url: https://indico.cern.ch/event/828520/contributions/3699233/attachments/1968544/3274004/Network-Discussion-LHCOPN_LHCONE-2020.pdf
+  meeting: LHCONE/LHCOPN Meeting
+  meetingurl: https://indico.cern.ch/event/828520/
+  location: CERN, Geneva, Switzerland
+  focus-area: osglhc
+  project: osg-networking
+- title: Updates on OSG/WLCG perfSONAR Network Monitoring and Analytics
+  date: 2020-01-15
+  url: https://indico.cern.ch/event/813757/contributions/3698520/attachments/1969584/3276449/Updates_on_OSG_WLCG_perfSONAR_Network_Monitoring_and_Analytics_2.pdf
+  meeting: Grid Deployment Board
+  meetingurl: https://indico.cern.ch/event/813757/
+  location: CERN, Geneva, Switzerland
+  focus-area: osglhc
+  project: osg-networking
+- title: LHCONE/LHCOPN Meeting Summary
+  date: 2020-01-15
+  url: https://indico.cern.ch/event/813757/contributions/3698521/attachments/1969608/3276108/LHCOPNE-20200114-CERN-meeting-report-v1.0.pptx_1.pdf
+  meeting: Grid Deployment Board
+  meetingurl: https://indico.cern.ch/event/813757/
+  location: CERN, Geneva, Switzerland
+  focus-area: osglhc
+  project: osg-networking
+- title: OSG Network Monitoring (poster)
+  date: 2020-02-27
+  url: https://indico.cern.ch/event/894127/attachments/1996570/3331193/23_-_IRIS-HEP_LHC-OSG_Network_Monitoring.pdf
+  meeting: IRIS-HEP Poster Session
+  meetingurl: https://indico.cern.ch/event/894127/
+  location: Princeton, New Jersey, US
+  focus-area: osglhc
+  project: osg-networking
+- title: 'USATLAS: OSG/WLCG perfSONAR Network Monitoring and Analytics'
+  date: 2020-04-01
+  url: https://indico.cern.ch/event/895416/contributions/3775747/attachments/2013505/3364898/go
+  meeting: USATLAS Facilities Meeting
+  meetingurl: https://indico.cern.ch/event/895416/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: New National Science Foundation International Research and education Network
+    Connections Testbed Solicitation
+  date: 2020-04-14
+  url: https://indico.cern.ch/event/870360/contributions/3670577/attachments/2019180/3376379/WLCG-IRNC-April-14-2020.pdf
+  meeting: WLCG Management Board
+  meetingurl: https://indico.cern.ch/event/870360/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: FABRIC for High-Energy Physics Prototyping
+  date: 2020-04-16
+  url: https://drive.google.com/drive/u/0/folders/1Sp_m_9j1_x747B6CR0zhc2dM-JcoDvcz
+  meeting: FABRIC Community Workshop
+  meetingurl: https://fabric-testbed.net/events/fabric-community-workshop-2020
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: 'Networking: Status and Discussion'
+  date: 2020-05-05
+  url: https://docs.google.com/presentation/d/1OIKGxvq4vkPzUkXtx06LJ8Ka569Zyi8PFWYYrQNkmsE/edit#slide=id.g76f5dacfb4_0_90
+  meeting: ATLAS Distributed Data Management Roundtable
+  meetingurl: https://indico.cern.ch/event/915025/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: The SAND Project and a New Research Networking Technical Working Group
+  date: 2020-05-12
+  url: https://docs.google.com/presentation/d/1ui5cVngu72c3DsiAtpBJWKZ3jKiC_1nCCxS-kmG9NCM/edit?usp=sharing
+  meeting: Internet2 Community Measurement, Metrics and Telemetry Meeting
+  meetingurl: https://docs.google.com/document/d/1A_6Ooowm33MZR3A-fuTnhGwIUX6UEeaPumRfGUSBEgI/edit?usp=sharing
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: Report on the Research Networking Technical WG
+  date: 2020-05-12
+  url: https://docs.google.com/presentation/d/1Rfr-zLrd2gYhiIgTag9XMIEPRcD9ireGOisGY3xRfOY/edit#slide=id.g8036819354_0_7
+  meeting: Internet2 Community Measurement, Metrics and Telemetry Meeting
+  meetingurl: https://docs.google.com/document/d/1A_6Ooowm33MZR3A-fuTnhGwIUX6UEeaPumRfGUSBEgI/edit?usp=sharing
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: LHCOPN/LHCONE perfSONAR Update
+  date: 2020-05-13
+  url: https://indico.cern.ch/event/888924/contributions/3792412/attachments/2037674/3412900/LHCOPN_LHCONE_perfSONAR_Update_2020spring.pdf
+  meeting: LHCONE/LHCOPN Spring 2020 Meeting
+  meetingurl: https://indico.cern.ch/event/888924/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: Research Network Technology Working Group
+  date: 2020-05-13
+  url: https://indico.cern.ch/event/888924/contributions/3792419/attachments/2037093/3411000/Research_Networking_Technical_Working_Group.pdf
+  meeting: LHCONE/LHCOPN Spring 2020 Meeting
+  meetingurl: https://indico.cern.ch/event/888924/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: IPv6 and RNTWG Sub-groups
+  date: 2020-06-03
+  url: https://indico.cern.ch/event/924996/contributions/3887247/attachments/2049467/3436039/IPv6_and_RNTWG_Sub-Groups.pdf
+  meeting: HEPiX IPv6 Working Group
+  meetingurl: https://indico.cern.ch/event/924996/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: Research Networking Technical WG (RNTWG) Update
+  date: 2020-09-16
+  url: https://indico.cern.ch/event/932306/contributions/3937507/attachments/2104416/3538776/Research_Networking_Technical_Working_Group_Update.pdf
+  meeting: LHCONE/LHCOPN Fall 2020 Meeting
+  meetingurl: https://indico.cern.ch/event/932306/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: Update from RNTWG - Packet Marking Subgroup
+  date: 2020-09-29
+  url: https://indico.cern.ch/event/959585/contributions/4034267/attachments/2111250/3551438/Update_from_RNTWG_-_Packet_Marking_Subgroup.pdf
+  meeting: HEPiX IPv6 Working Group
+  meetingurl: https://indico.cern.ch/event/959585/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: Update on the Packet Marking WG
+  date: 2021-01-19
+  url: https://indico.cern.ch/event/995980/contributions/4185460/attachments/2174072/3670811/Update%20on%20the%20Packet%20Marking%20WG%20%281%29.pdf
+  meeting: HEPiX IPv6 Working Group Virtual F2F
+  meetingurl: https://indico.cern.ch/event/995980/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: Network Topics For Discussion
+  date: 2021-03-05
+  url: https://indico.fnal.gov/event/47040/contributions/209607/subcontributions/7880/attachments/140685/176868/OSG-AHM-2021_Network_Topics_Part_1.pdf
+  meeting: Open Science Grid All-Hands Meeting, Joint USATLAS-USCMS Session
+  meetingurl: https://indico.fnal.gov/event/47040/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: WLCG/OSG Network Activities, Status and Plans
+  date: 2021-03-16
+  url: https://indico.cern.ch/event/995485/contributions/4256471/attachments/2209460/3739050/HEPiX%20perfSONAR%20Update%20Spring%202021.pdf
+  meeting: HEPiX Spring 2021 Meeting
+  meetingurl: https://indico.cern.ch/event/995485/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: LHCOPN/LHCONE Monitoring Updated
+  date: 2021-03-23
+  url: https://indico.cern.ch/event/983436/contributions/4232157/attachments/2213899/3748225/LHCONE%20Monitoring%20Update%20Spring%202021.pdf
+  meeting: LHCONE/LHCOPN Spring 2021 Meeting
+  meetingurl: https://indico.cern.ch/event/983436/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking
+- title: Network Monitoring R&D (and data challenge needs)
+  date: 2021-04-27
+  url: https://indico.cern.ch/event/1027287/contributions/4335184/attachments/2234157/3786307/Network%20Monitoring%20R%26D.pdf
+  meeting: Data Challenge Monitoring Mini-Workshop
+  meetingurl: https://indico.cern.ch/event/1027287/
+  location: Zoom
+  focus-area: osglhc
+  project: osg-networking

--- a/_data/people/srlantz.yml
+++ b/_data/people/srlantz.yml
@@ -1,17 +1,17 @@
+---
 name: Steve Lantz
 shortname: srlantz
 title:
 active: true
 institution: Cornell University
 website: https://www.cac.cornell.edu/slantz/index.html
-photo: /assets/images/team/Steve-Lantz.jpg
+photo: "/assets/images/team/Steve-Lantz.jpg"
 presentations:
-  - title: "Vector Parallelism on Multi-Core Processors"
-    date: 2019-07-25
-    url: https://indico.cern.ch/event/814979/contributions/3401203/attachments/1831468/3115808/VectorParallelismMultiCoreProc.pdf
-    meeting: "Third Computational and Data Science school for HEP (CoDaS-HEP 2019)"
-    meetingurl: https://indico.cern.ch/event/814979/timetable/
-    location: Princeton University
-    focus-area: ia
-    project: mkfit
-
+- title: Vector Parallelism on Multi-Core Processors
+  date: 2019-07-25
+  url: https://indico.cern.ch/event/814979/contributions/3401203/attachments/1831468/3115808/VectorParallelismMultiCoreProc.pdf
+  meeting: Third Computational and Data Science school for HEP (CoDaS-HEP 2019)
+  meetingurl: https://indico.cern.ch/event/814979/timetable/
+  location: Princeton University
+  focus-area: ia
+  project: mkfit

--- a/_data/people/srlantz.yml
+++ b/_data/people/srlantz.yml
@@ -15,3 +15,5 @@ presentations:
   location: Princeton University
   focus-area: ia
   project: mkfit
+focus-area:
+- ia

--- a/_data/people/srlantz.yml
+++ b/_data/people/srlantz.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ia
+institution: Cornell University
 name: Steve Lantz
+photo: "/assets/images/team/Steve-Lantz.jpg"
 shortname: srlantz
 title:
-active: true
-institution: Cornell University
 website: https://www.cac.cornell.edu/slantz/index.html
-photo: "/assets/images/team/Steve-Lantz.jpg"
 presentations:
 - title: Vector Parallelism on Multi-Core Processors
   date: 2019-07-25
@@ -15,5 +16,3 @@ presentations:
   location: Princeton University
   focus-area: ia
   project: mkfit
-focus-area:
-- ia

--- a/_data/people/sthapa.yml
+++ b/_data/people/sthapa.yml
@@ -1,9 +1,8 @@
----
-name: Suchandra Thapa
-shortname: sthapa
-title: Suchandra Thapa
 active: true
 institution: University of Chicago
-website: https://github.com/sthapa/
+name: Suchandra Thapa
 photo: "/assets/images/team/Suchandra-Thapa.jpg"
+shortname: sthapa
+title: Suchandra Thapa
+website: https://github.com/sthapa/
 presentations:

--- a/_data/people/sthapa.yml
+++ b/_data/people/sthapa.yml
@@ -1,9 +1,9 @@
+---
 name: Suchandra Thapa
 shortname: sthapa
 title: Suchandra Thapa
 active: true
 institution: University of Chicago
 website: https://github.com/sthapa/
-photo: /assets/images/team/Suchandra-Thapa.jpg
+photo: "/assets/images/team/Suchandra-Thapa.jpg"
 presentations:
-

--- a/_data/people/t_boccali.yml
+++ b/_data/people/t_boccali.yml
@@ -1,10 +1,9 @@
----
+active: false
+hidden: true
+institution: INFN-Pisa
 name: Tommaso Boccali
+photo: "/assets/images/team/Tommaso-Boccali.png"
 shortname: t_boccali
 title: CMS Experiment
-active: false
-institution: INFN-Pisa
 website:
-photo: "/assets/images/team/Tommaso-Boccali.png"
-hidden: true
 presentations:

--- a/_data/people/t_boccali.yml
+++ b/_data/people/t_boccali.yml
@@ -1,9 +1,10 @@
+---
 name: Tommaso Boccali
 shortname: t_boccali
 title: CMS Experiment
 active: false
 institution: INFN-Pisa
 website:
-photo: /assets/images/team/Tommaso-Boccali.png
+photo: "/assets/images/team/Tommaso-Boccali.png"
 hidden: true
 presentations:

--- a/_data/people/tatiana-m.yml
+++ b/_data/people/tatiana-m.yml
@@ -1,10 +1,10 @@
+---
 name: Tatiana Medvedeva
 shortname: tatiana-m
 title:
 active: false
 institution: Princeton University
 website:
-photo: /assets/images/atom.png
+photo: "/assets/images/atom.png"
 hidden: true
 presentations:
-

--- a/_data/people/tatiana-m.yml
+++ b/_data/people/tatiana-m.yml
@@ -1,10 +1,9 @@
----
+active: false
+hidden: true
+institution: Princeton University
 name: Tatiana Medvedeva
+photo: "/assets/images/atom.png"
 shortname: tatiana-m
 title:
-active: false
-institution: Princeton University
 website:
-photo: "/assets/images/atom.png"
-hidden: true
 presentations:

--- a/_data/people/timtheisen.yml
+++ b/_data/people/timtheisen.yml
@@ -7,3 +7,5 @@ institution: University of Wisconsin–Madison
 website:
 photo: "/assets/images/team/Tim-Theisen.png"
 presentations:
+focus-area:
+- osglhc

--- a/_data/people/timtheisen.yml
+++ b/_data/people/timtheisen.yml
@@ -1,11 +1,10 @@
----
-name: Tim Theisen
-shortname: timtheisen
-title: OSG Release Manager
 active: true
-institution: University of Wisconsin–Madison
-website:
-photo: "/assets/images/team/Tim-Theisen.png"
-presentations:
 focus-area:
 - osglhc
+institution: University of Wisconsin–Madison
+name: Tim Theisen
+photo: "/assets/images/team/Tim-Theisen.png"
+shortname: timtheisen
+title: OSG Release Manager
+website:
+presentations:

--- a/_data/people/timtheisen.yml
+++ b/_data/people/timtheisen.yml
@@ -1,9 +1,9 @@
+---
 name: Tim Theisen
 shortname: timtheisen
 title: OSG Release Manager
 active: true
 institution: University of Wisconsin–Madison
 website:
-photo: /assets/images/team/Tim-Theisen.png
+photo: "/assets/images/team/Tim-Theisen.png"
 presentations:
-

--- a/_data/people/tresreid.yml
+++ b/_data/people/tresreid.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- ia
+institution: Cornell University
 name: Michael (Tres) Reid
+photo: "/assets/images/team/Tres-Reid.jpg"
 shortname: tresreid
 title: PhD Student
-active: true
-institution: Cornell University
 website: https://github.com/
-photo: "/assets/images/team/Tres-Reid.jpg"
 presentations:
 - title: Segment Linking Development on GPUs
   date: 2020-12-07
@@ -14,5 +15,3 @@ presentations:
   meetingurl: https://indico.cern.ch/event/962048/
   project: mkfit
   focus-area: ia
-focus-area:
-- ia

--- a/_data/people/tresreid.yml
+++ b/_data/people/tresreid.yml
@@ -14,3 +14,5 @@ presentations:
   meetingurl: https://indico.cern.ch/event/962048/
   project: mkfit
   focus-area: ia
+focus-area:
+- ia

--- a/_data/people/tresreid.yml
+++ b/_data/people/tresreid.yml
@@ -1,15 +1,16 @@
+---
 name: Michael (Tres) Reid
 shortname: tresreid
 title: PhD Student
 active: true
 institution: Cornell University
 website: https://github.com/
-photo: /assets/images/team/Tres-Reid.jpg
+photo: "/assets/images/team/Tres-Reid.jpg"
 presentations:
-  - title: "Segment Linking Development on GPUs"
-    date: 2020-12-07
-    url: https://indico.cern.ch/event/962048/contributions/4126142/attachments/2157798/3640167/Segment%20Linking%20HLT-GPU%2012-7.pdf
-    meeting: HLT developments with GPUs
-    meetingurl: https://indico.cern.ch/event/962048/
-    project: mkfit
-    focus-area: ia
+- title: Segment Linking Development on GPUs
+  date: 2020-12-07
+  url: https://indico.cern.ch/event/962048/contributions/4126142/attachments/2157798/3640167/Segment%20Linking%20HLT-GPU%2012-7.pdf
+  meeting: HLT developments with GPUs
+  meetingurl: https://indico.cern.ch/event/962048/
+  project: mkfit
+  focus-area: ia

--- a/_data/people/vgvassilev.yml
+++ b/_data/people/vgvassilev.yml
@@ -1,9 +1,10 @@
+---
 name: Vassil Vassilev
 shortname: vgvassilev
 title: Compiler Research + USCMS collaborator
 active: true
 institution: Princeton University
 website: http://vassil.vassilev.info
-photo: /assets/images/team/Vassil-Vassilev.jpg
+photo: "/assets/images/team/Vassil-Vassilev.jpg"
 e-mail: vvasilev@cern.ch
 presentations:

--- a/_data/people/vgvassilev.yml
+++ b/_data/people/vgvassilev.yml
@@ -1,10 +1,9 @@
----
+active: true
+e-mail: vvasilev@cern.ch
+institution: Princeton University
 name: Vassil Vassilev
+photo: "/assets/images/team/Vassil-Vassilev.jpg"
 shortname: vgvassilev
 title: Compiler Research + USCMS collaborator
-active: true
-institution: Princeton University
 website: http://vassil.vassilev.info
-photo: "/assets/images/team/Vassil-Vassilev.jpg"
-e-mail: vvasilev@cern.ch
 presentations:

--- a/_data/people/wguan.yml
+++ b/_data/people/wguan.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- doma
+institution: University of Wisconsin-Madison
 name: Wen Guan
+photo: "/assets/images/team/Wen-Guan.png"
 shortname: wguan
 title:
-active: true
-institution: University of Wisconsin-Madison
 website:
-photo: "/assets/images/team/Wen-Guan.png"
 presentations:
 - title: IDDS
   date: 2019-09-30
@@ -92,5 +93,3 @@ presentations:
   url: https://indico.cern.ch/event/1006816/contributions/4226051/attachments/2217725/3754939/iDDS_iris_hep_20210329-2.pdf
   focus-area: doma
   project: idds
-focus-area:
-- doma

--- a/_data/people/wguan.yml
+++ b/_data/people/wguan.yml
@@ -1,92 +1,94 @@
+---
 name: Wen Guan
 shortname: wguan
 title:
 active: true
 institution: University of Wisconsin-Madison
 website:
-photo: /assets/images/team/Wen-Guan.png
+photo: "/assets/images/team/Wen-Guan.png"
 presentations:
-  - title: "IDDS"
-    date: 2019-09-30
-    meeting: HSF & ATLAS Joint Event Delivery Workshop
-    meetingurl: https://indico.cern.ch/event/849155/
-    url: https://indico.cern.ch/event/849155/contributions/3576915/attachments/1917085/3170006/idds_20100927_atlas_sc_week.pdf
-    focus-area: doma
-    project: idds
-  - title: "Event Streaming Service for ATLAS Event Processing"
-    date: 2019-11-07
-    meeting: 24th International Conference on Computing in High Energy Physics(CHEP2019)
-    meetingurl: https://indico.cern.ch/event/773049/
-    url: https://indico.cern.ch/event/773049/contributions/3474484/attachments/1943110/3222885/idds_chep2019.pdf
-    focus-area: doma
-    project: idds
-  - title: "intelligent Data Delivery Service (iDDS) (Poster)"
-    date: 2020-02-27
-    meeting: IRIS-HEP poster session
-    meetingurl: https://indico.cern.ch/event/855317/
-    url: https://indico.cern.ch/event/855317/
-    focus-area: doma
-    project: idds
-  - title: "iDDS: A New Service with Intelligent Orchestration and Data Transformation and Delivery"
-    date: 2020-03-11
-    meeting: 3rd Rucio Community Workshop
-    meetingurl: https://indico.cern.ch/event/867913/
-    url: https://indico.cern.ch/event/867913/contributions/3769422/attachments/2002255/3342767/idds_20200311_rucio_workshop2.pdf
-    focus-area: doma
-    project: idds
-  - title: "iDDS integration"
-    date: 2020-05-28
-    meeting: ATLAS ADC WFMS meeting
-    meetingurl: https://indico.cern.ch/event/922721/
-    url: https://indico.cern.ch/event/922721/contributions/3876672/subcontributions/307613/attachments/2046593/3429101/idds_wfms_20200528.pdf
-    focus-area: doma
-    project: idds
-  - title: "iDDS HyperParameter Optimization development for machine learning"
-    date: 2020-06-15
-    meeting: ATLAS Software & Computing Week
-    meetingurl: https://indico.cern.ch/event/823142/
-    url: https://indico.cern.ch/event/823142/contributions/3884226/subcontributions/308943/attachments/2056851/3449291/idds_sC_20200613.pdf
-    focus-area: doma
-    project: idds
-  - title: "iDDS for machine learning"
-    date: 2020-07-09
-    meeting: Joint Atlas Machine Learning / Workflow Management Meeting
-    meetingurl: https://indico.cern.ch/event/937451/
-    url: https://indico.cern.ch/event/937451/contributions/3938474/attachments/2071775/3478128/idds_ml_20200707.pdf
-    focus-area: doma
-    project: idds
-  - title: "iDDS news for machine learning"
-    date: 2020-10-01
-    meeting: Joint Atlas Machine Learning / Workflow Management Meeting
-    meetingurl: https://indico.cern.ch/event/958113/
-    url: https://indico.cern.ch/event/958113/contributions/4027378/attachments/2113937/3556258/idds_ml_20201001-2.pdf
-    focus-area: doma
-    project: idds
-  - title: "iDDS: new workflow structure"
-    date: 2020-10-05
-    meeting: ADC @ ATLAS Software & Computing Week
-    meetingurl: https://indico.cern.ch/event/956962/
-    url: https://indico.cern.ch/event/958089/contributions/4039386/subcontributions/316213/attachments/2115633/3559950/idds_s%26c_20201005.pdf
-    focus-area: doma
-    project: idds
-  - title: "iDDS 2021"
-    date: 2021-01-21
-    meeting: ATLAS ADC WFMS meeting
-    meetingurl: https://indico.cern.ch/event/999044
-    url: https://indico.cern.ch/event/999044/contributions/4196418/attachments/2175710/3673870/iDDS_status_plans_20200121.pdf
-    focus-area: doma
-    project: idds
-  - title: "iDDS active learning status and iDDS plans"
-    date: 2021-01-27
-    meeting: ADC @ ATLAS Software & Computing Week
-    meetingurl: https://indico.cern.ch/event/998138/
-    url: https://indico.cern.ch/event/998138/contributions/4197626/attachments/2179034/3680483/iDDS_ws%26c_20200127-2.pdf
-    focus-area: doma
-    project: idds
-  - title: "intelligent Data Delivery Service"
-    date: 2021-03-29
-    meeting: HL-LHC R&D topics
-    meetingurl: https://indico.cern.ch/event/1006816/
-    url: https://indico.cern.ch/event/1006816/contributions/4226051/attachments/2217725/3754939/iDDS_iris_hep_20210329-2.pdf
-    focus-area: doma
-    project: idds
+- title: IDDS
+  date: 2019-09-30
+  meeting: HSF & ATLAS Joint Event Delivery Workshop
+  meetingurl: https://indico.cern.ch/event/849155/
+  url: https://indico.cern.ch/event/849155/contributions/3576915/attachments/1917085/3170006/idds_20100927_atlas_sc_week.pdf
+  focus-area: doma
+  project: idds
+- title: Event Streaming Service for ATLAS Event Processing
+  date: 2019-11-07
+  meeting: 24th International Conference on Computing in High Energy Physics(CHEP2019)
+  meetingurl: https://indico.cern.ch/event/773049/
+  url: https://indico.cern.ch/event/773049/contributions/3474484/attachments/1943110/3222885/idds_chep2019.pdf
+  focus-area: doma
+  project: idds
+- title: intelligent Data Delivery Service (iDDS) (Poster)
+  date: 2020-02-27
+  meeting: IRIS-HEP poster session
+  meetingurl: https://indico.cern.ch/event/855317/
+  url: https://indico.cern.ch/event/855317/
+  focus-area: doma
+  project: idds
+- title: 'iDDS: A New Service with Intelligent Orchestration and Data Transformation
+    and Delivery'
+  date: 2020-03-11
+  meeting: 3rd Rucio Community Workshop
+  meetingurl: https://indico.cern.ch/event/867913/
+  url: https://indico.cern.ch/event/867913/contributions/3769422/attachments/2002255/3342767/idds_20200311_rucio_workshop2.pdf
+  focus-area: doma
+  project: idds
+- title: iDDS integration
+  date: 2020-05-28
+  meeting: ATLAS ADC WFMS meeting
+  meetingurl: https://indico.cern.ch/event/922721/
+  url: https://indico.cern.ch/event/922721/contributions/3876672/subcontributions/307613/attachments/2046593/3429101/idds_wfms_20200528.pdf
+  focus-area: doma
+  project: idds
+- title: iDDS HyperParameter Optimization development for machine learning
+  date: 2020-06-15
+  meeting: ATLAS Software & Computing Week
+  meetingurl: https://indico.cern.ch/event/823142/
+  url: https://indico.cern.ch/event/823142/contributions/3884226/subcontributions/308943/attachments/2056851/3449291/idds_sC_20200613.pdf
+  focus-area: doma
+  project: idds
+- title: iDDS for machine learning
+  date: 2020-07-09
+  meeting: Joint Atlas Machine Learning / Workflow Management Meeting
+  meetingurl: https://indico.cern.ch/event/937451/
+  url: https://indico.cern.ch/event/937451/contributions/3938474/attachments/2071775/3478128/idds_ml_20200707.pdf
+  focus-area: doma
+  project: idds
+- title: iDDS news for machine learning
+  date: 2020-10-01
+  meeting: Joint Atlas Machine Learning / Workflow Management Meeting
+  meetingurl: https://indico.cern.ch/event/958113/
+  url: https://indico.cern.ch/event/958113/contributions/4027378/attachments/2113937/3556258/idds_ml_20201001-2.pdf
+  focus-area: doma
+  project: idds
+- title: 'iDDS: new workflow structure'
+  date: 2020-10-05
+  meeting: ADC @ ATLAS Software & Computing Week
+  meetingurl: https://indico.cern.ch/event/956962/
+  url: https://indico.cern.ch/event/958089/contributions/4039386/subcontributions/316213/attachments/2115633/3559950/idds_s%26c_20201005.pdf
+  focus-area: doma
+  project: idds
+- title: iDDS 2021
+  date: 2021-01-21
+  meeting: ATLAS ADC WFMS meeting
+  meetingurl: https://indico.cern.ch/event/999044
+  url: https://indico.cern.ch/event/999044/contributions/4196418/attachments/2175710/3673870/iDDS_status_plans_20200121.pdf
+  focus-area: doma
+  project: idds
+- title: iDDS active learning status and iDDS plans
+  date: 2021-01-27
+  meeting: ADC @ ATLAS Software & Computing Week
+  meetingurl: https://indico.cern.ch/event/998138/
+  url: https://indico.cern.ch/event/998138/contributions/4197626/attachments/2179034/3680483/iDDS_ws%26c_20200127-2.pdf
+  focus-area: doma
+  project: idds
+- title: intelligent Data Delivery Service
+  date: 2021-03-29
+  meeting: HL-LHC R&D topics
+  meetingurl: https://indico.cern.ch/event/1006816/
+  url: https://indico.cern.ch/event/1006816/contributions/4226051/attachments/2217725/3754939/iDDS_iris_hep_20210329-2.pdf
+  focus-area: doma
+  project: idds

--- a/_data/people/wguan.yml
+++ b/_data/people/wguan.yml
@@ -92,3 +92,5 @@ presentations:
   url: https://indico.cern.ch/event/1006816/contributions/4226051/attachments/2217725/3754939/iDDS_iris_hep_20210329-2.pdf
   focus-area: doma
   project: idds
+focus-area:
+- doma

--- a/_data/people/xiaocong-ai.yml
+++ b/_data/people/xiaocong-ai.yml
@@ -1,10 +1,11 @@
----
+active: false
+focus-area:
+- ia
+institution: University of California, Berkeley
 name: Xiaocong Ai
+photo: "/assets/images/team/Xiaocong-Ai.jpg"
 shortname: xiaocong-ai
 title: Postdoc and ACTS
-active: false
-institution: University of California, Berkeley
-photo: "/assets/images/team/Xiaocong-Ai.jpg"
 presentations:
 - title: Initial studies of ACTS tracking performance with GPUs
   date: 2020-08-26
@@ -69,5 +70,3 @@ presentations:
   meetingurl: https://indico.cern.ch/event/782953/
   focus-area: ia
   project: acts
-focus-area:
-- ia

--- a/_data/people/xiaocong-ai.yml
+++ b/_data/people/xiaocong-ai.yml
@@ -1,70 +1,71 @@
+---
 name: Xiaocong Ai
 shortname: xiaocong-ai
 title: Postdoc and ACTS
 active: false
 institution: University of California, Berkeley
-photo: /assets/images/team/Xiaocong-Ai.jpg
+photo: "/assets/images/team/Xiaocong-Ai.jpg"
 presentations:
-  - title: Initial studies of ACTS tracking performance with GPUs
-    date: 2020-08-26
-    url: https://indico.cern.ch/event/939577/contributions/3947654/attachments/2091938/3515237/IRIS_HEP_GPU_Xiaocong.pdf
-    meeting: IRIS-HEP Topical meeting
-    meetingurl: https://indico.cern.ch/event/939577
-    focus-area: ia
-    project: acts
-  - title: "Summary of Wednesday Session: Core Developments"
-    date: 2020-05-29
-    url: https://indico.cern.ch/event/917970/contributions/3884685/attachments/2047803/3431426/ACTS_workshop_CoreDev_Summary.pdf
-    meeting: ACTS Tracking for HEP Workshop
-    meetingurl: https://indico.cern.ch/event/917970/
-    focus-area: ia
-    project: acts
-  - title: "ACTS Propagation on GPUs"
-    date: 2020-05-28
-    url: https://indico.cern.ch/event/917970/contributions/3878405/attachments/2046225/3429441/ACTS_workshop_propagator_GPU.pdf
-    meeting: ACTS Tracking for HEP Workshop
-    meetingurl: https://indico.cern.ch/event/917970/
-    focus-area: ia
-    project: acts
-  - title: "ACTS Track fitting/finding Tutorial"
-    date: 2020-05-26
-    url: https://indico.cern.ch/event/917970/contributions/3862004/attachments/2043773/3426210/ACTS_Track_fitting_finding_Tutorial.pdf
-    meeting: ACTS Tracking for HEP Workshop
-    meetingurl: https://indico.cern.ch/event/917970/
-    focus-area: ia
-    project: acts
-  - title: "ACTS Project Status"
-    date: 2020-05-25
-    url: https://indico.cern.ch/event/917970/contributions/3861752/attachments/2043758/3424088/ACTS_workshop_Xiaocong.pdf
-    meeting: ACTS Tracking for HEP Workshop
-    meetingurl: https://indico.cern.ch/event/917970/
-    focus-area: ia
-    project: acts
-  - title: "Tracking performance with ACTS"
-    date: 2020-04-22
-    url: https://indico.cern.ch/event/831165/contributions/3717113/attachments/2024363/3396410/ACTS_CTD_Xiaocong.pdf
-    meeting: Connecting The Dots 2020
-    meetingurl: https://indico.cern.ch/event/831165/
-    focus-area: ia
-    project: acts
-  - title: "Track fitting/finding with ACTS"
-    date: 2020-02-19
-    url: https://indico.cern.ch/event/889047/contributions/3749030/attachments/1990315/3319040/IRIS_HEP_topical_meeting_Xiaocong.pdf
-    meeting: Iris-hep topical meeting
-    meetingurl: https://indico.cern.ch/event/889047/
-    focus-area: ia
-    project: acts
-  - title: "ACTS Status"
-    date: 2019-08-08
-    url: https://indico.cern.ch/event/813855/contributions/3504321/attachments/1891443/3119406/USATLAS_ACTS_Xiaocong.pdf
-    meeting: USATLAS Summer Workshop
-    meetingurl: https://indico.cern.ch/event/813855/
-    focus-area: ia
-    project: acts
-  - title: "ACTS: a common track reconstruction software"
-    date: 2019-07-31
-    url: https://indico.cern.ch/event/782953/contributions/3462562/attachments/1888325/3115216/DPF2019_ACTS_Xiaocong.pdf
-    meeting: DPF 2019
-    meetingurl: https://indico.cern.ch/event/782953/
-    focus-area: ia
-    project: acts
+- title: Initial studies of ACTS tracking performance with GPUs
+  date: 2020-08-26
+  url: https://indico.cern.ch/event/939577/contributions/3947654/attachments/2091938/3515237/IRIS_HEP_GPU_Xiaocong.pdf
+  meeting: IRIS-HEP Topical meeting
+  meetingurl: https://indico.cern.ch/event/939577
+  focus-area: ia
+  project: acts
+- title: 'Summary of Wednesday Session: Core Developments'
+  date: 2020-05-29
+  url: https://indico.cern.ch/event/917970/contributions/3884685/attachments/2047803/3431426/ACTS_workshop_CoreDev_Summary.pdf
+  meeting: ACTS Tracking for HEP Workshop
+  meetingurl: https://indico.cern.ch/event/917970/
+  focus-area: ia
+  project: acts
+- title: ACTS Propagation on GPUs
+  date: 2020-05-28
+  url: https://indico.cern.ch/event/917970/contributions/3878405/attachments/2046225/3429441/ACTS_workshop_propagator_GPU.pdf
+  meeting: ACTS Tracking for HEP Workshop
+  meetingurl: https://indico.cern.ch/event/917970/
+  focus-area: ia
+  project: acts
+- title: ACTS Track fitting/finding Tutorial
+  date: 2020-05-26
+  url: https://indico.cern.ch/event/917970/contributions/3862004/attachments/2043773/3426210/ACTS_Track_fitting_finding_Tutorial.pdf
+  meeting: ACTS Tracking for HEP Workshop
+  meetingurl: https://indico.cern.ch/event/917970/
+  focus-area: ia
+  project: acts
+- title: ACTS Project Status
+  date: 2020-05-25
+  url: https://indico.cern.ch/event/917970/contributions/3861752/attachments/2043758/3424088/ACTS_workshop_Xiaocong.pdf
+  meeting: ACTS Tracking for HEP Workshop
+  meetingurl: https://indico.cern.ch/event/917970/
+  focus-area: ia
+  project: acts
+- title: Tracking performance with ACTS
+  date: 2020-04-22
+  url: https://indico.cern.ch/event/831165/contributions/3717113/attachments/2024363/3396410/ACTS_CTD_Xiaocong.pdf
+  meeting: Connecting The Dots 2020
+  meetingurl: https://indico.cern.ch/event/831165/
+  focus-area: ia
+  project: acts
+- title: Track fitting/finding with ACTS
+  date: 2020-02-19
+  url: https://indico.cern.ch/event/889047/contributions/3749030/attachments/1990315/3319040/IRIS_HEP_topical_meeting_Xiaocong.pdf
+  meeting: Iris-hep topical meeting
+  meetingurl: https://indico.cern.ch/event/889047/
+  focus-area: ia
+  project: acts
+- title: ACTS Status
+  date: 2019-08-08
+  url: https://indico.cern.ch/event/813855/contributions/3504321/attachments/1891443/3119406/USATLAS_ACTS_Xiaocong.pdf
+  meeting: USATLAS Summer Workshop
+  meetingurl: https://indico.cern.ch/event/813855/
+  focus-area: ia
+  project: acts
+- title: 'ACTS: a common track reconstruction software'
+  date: 2019-07-31
+  url: https://indico.cern.ch/event/782953/contributions/3462562/attachments/1888325/3115216/DPF2019_ACTS_Xiaocong.pdf
+  meeting: DPF 2019
+  meetingurl: https://indico.cern.ch/event/782953/
+  focus-area: ia
+  project: acts

--- a/_data/people/xiaocong-ai.yml
+++ b/_data/people/xiaocong-ai.yml
@@ -69,3 +69,5 @@ presentations:
   meetingurl: https://indico.cern.ch/event/782953/
   focus-area: ia
   project: acts
+focus-area:
+- ia

--- a/_data/people/xweichu.yml
+++ b/_data/people/xweichu.yml
@@ -19,3 +19,5 @@ presentations:
   meeting: CROSS Research Symposium 2019
   meetingurl: https://cross.ucsc.edu/2019-symposium/
   focus-area: doma
+focus-area:
+- doma

--- a/_data/people/xweichu.yml
+++ b/_data/people/xweichu.yml
@@ -1,20 +1,21 @@
+---
 name: Xiaowei (Aaron) Chu
 shortname: xweichu
 title: Ph.D Student
 active: true
 institution: University of California, Santa Cruz
 website: https://xweichu.xyz
-photo: /assets/images/team/xweichu.png
+photo: "/assets/images/team/xweichu.png"
 presentations:
-  - title: "Mapping datasets to object storage"
-    date: 2019-11-05
-    url: https://indico.cern.ch/event/773049/contributions/3474413/attachments/1936811/3213825/CHEP2019-Mapping_datasets_to_object_storage.pdf
-    meeting: "CHEP 2019"
-    meetingurl: https://indico.cern.ch/event/773049/contributions/3474413/
-    focus-area: doma
-  - title: "Mapping datasets to object storage"
-    date: 2019-10-03
-    url: https://cross.ucsc.edu/2019-symposium/
-    meeting: "CROSS Research Symposium 2019"
-    meetingurl: https://cross.ucsc.edu/2019-symposium/
-    focus-area: doma
+- title: Mapping datasets to object storage
+  date: 2019-11-05
+  url: https://indico.cern.ch/event/773049/contributions/3474413/attachments/1936811/3213825/CHEP2019-Mapping_datasets_to_object_storage.pdf
+  meeting: CHEP 2019
+  meetingurl: https://indico.cern.ch/event/773049/contributions/3474413/
+  focus-area: doma
+- title: Mapping datasets to object storage
+  date: 2019-10-03
+  url: https://cross.ucsc.edu/2019-symposium/
+  meeting: CROSS Research Symposium 2019
+  meetingurl: https://cross.ucsc.edu/2019-symposium/
+  focus-area: doma

--- a/_data/people/xweichu.yml
+++ b/_data/people/xweichu.yml
@@ -1,11 +1,12 @@
----
+active: true
+focus-area:
+- doma
+institution: University of California, Santa Cruz
 name: Xiaowei (Aaron) Chu
+photo: "/assets/images/team/xweichu.png"
 shortname: xweichu
 title: Ph.D Student
-active: true
-institution: University of California, Santa Cruz
 website: https://xweichu.xyz
-photo: "/assets/images/team/xweichu.png"
 presentations:
 - title: Mapping datasets to object storage
   date: 2019-11-05
@@ -19,5 +20,3 @@ presentations:
   meeting: CROSS Research Symposium 2019
   meetingurl: https://cross.ucsc.edu/2019-symposium/
   focus-area: doma
-focus-area:
-- doma

--- a/_data/people/yk_kim.yml
+++ b/_data/people/yk_kim.yml
@@ -1,14 +1,13 @@
----
-name: Young-Kee Kim
-shortname: yk_kim
-title:
-active: true
-institution: University of Chicago
-website:
-photo: "/assets/images/team/yk_kim.png"
-presentations:
 about: Chair of U Chicago, member of ATLAS, former deputy director of Research at
   Fermilab, and co-spokesperson of the CDF experiment at the Tevatron.
+active: true
+hidden: true
+institution: University of Chicago
+name: Young-Kee Kim
+photo: "/assets/images/team/yk_kim.png"
 role: Young-Kee Kim has a global view of physics research priorities in the field
   and within ATLAS.
-hidden: true
+shortname: yk_kim
+title:
+website:
+presentations:

--- a/_data/people/yk_kim.yml
+++ b/_data/people/yk_kim.yml
@@ -1,14 +1,14 @@
+---
 name: Young-Kee Kim
 shortname: yk_kim
 title:
 active: true
 institution: University of Chicago
 website:
-photo: /assets/images/team/yk_kim.png
+photo: "/assets/images/team/yk_kim.png"
 presentations:
 about: Chair of U Chicago, member of ATLAS, former deputy director of Research at
-   Fermilab, and co-spokesperson of the CDF
-   experiment at the Tevatron.
-role: Young-Kee Kim has a global view of
-   physics research priorities in the field and within ATLAS.
+  Fermilab, and co-spokesperson of the CDF experiment at the Tevatron.
+role: Young-Kee Kim has a global view of physics research priorities in the field
+  and within ATLAS.
 hidden: true

--- a/_data/people/zsshah.yml
+++ b/_data/people/zsshah.yml
@@ -7,3 +7,5 @@ institution: Indiana University
 website: https://cacr.iu.edu/about/people/staff/zalak-shah.php
 photo: "/assets/images/team/Zalak-Shah.jpg"
 presentations:
+focus-area:
+- osglhc

--- a/_data/people/zsshah.yml
+++ b/_data/people/zsshah.yml
@@ -1,8 +1,9 @@
+---
 name: Zalak Shah
 shortname: zsshah
 title: Systems Analyst
 active: true
 institution: Indiana University
 website: https://cacr.iu.edu/about/people/staff/zalak-shah.php
-photo: /assets/images/team/Zalak-Shah.jpg
+photo: "/assets/images/team/Zalak-Shah.jpg"
 presentations:

--- a/_data/people/zsshah.yml
+++ b/_data/people/zsshah.yml
@@ -1,11 +1,10 @@
----
-name: Zalak Shah
-shortname: zsshah
-title: Systems Analyst
 active: true
-institution: Indiana University
-website: https://cacr.iu.edu/about/people/staff/zalak-shah.php
-photo: "/assets/images/team/Zalak-Shah.jpg"
-presentations:
 focus-area:
 - osglhc
+institution: Indiana University
+name: Zalak Shah
+photo: "/assets/images/team/Zalak-Shah.jpg"
+shortname: zsshah
+title: Systems Analyst
+website: https://cacr.iu.edu/about/people/staff/zalak-shah.php
+presentations:

--- a/_data/people/zvada.yml
+++ b/_data/people/zvada.yml
@@ -1,12 +1,11 @@
----
-name: Marian Zvada
-shortname: zvada
-title: Systems Integrator
 active: true
-institution: University of Nebraska - Lincoln
-website:
-photo: "/assets/images/team/Marian-Zvada.jpg"
-presentations:
 focus-area:
 - doma
 - osglhc
+institution: University of Nebraska - Lincoln
+name: Marian Zvada
+photo: "/assets/images/team/Marian-Zvada.jpg"
+shortname: zvada
+title: Systems Integrator
+website:
+presentations:

--- a/_data/people/zvada.yml
+++ b/_data/people/zvada.yml
@@ -7,3 +7,6 @@ institution: University of Nebraska - Lincoln
 website:
 photo: "/assets/images/team/Marian-Zvada.jpg"
 presentations:
+focus-area:
+- doma
+- osglhc

--- a/_data/people/zvada.yml
+++ b/_data/people/zvada.yml
@@ -1,8 +1,9 @@
+---
 name: Marian Zvada
 shortname: zvada
 title: Systems Integrator
 active: true
 institution: University of Nebraska - Lincoln
 website:
-photo: /assets/images/team/Marian-Zvada.jpg
+photo: "/assets/images/team/Marian-Zvada.jpg"
 presentations:

--- a/_layouts/focus-area.html
+++ b/_layouts/focus-area.html
@@ -16,7 +16,7 @@
 {% assign page_focus_area = page.name | basename %}
 {% assign sorted = site.pages | where: "pagetype", "project" | where_exp: "item", "item.focus-area contains page_focus_area" | smart_title_sort %}
 
-{% assign fa_team = sorted | map: "team" | flat_map | uniq | sort | hash_fetch: site.data.people | compact %}
+{% assign fa_team = site.data.people | where_exp: "item", "item.focus-area contains page_focus_area" %}
 
 {% if fa_team.size > 0 %}
 <div class="container-fluid">

--- a/_plugins/checkusers.rb
+++ b/_plugins/checkusers.rb
@@ -24,6 +24,7 @@ module Checks
         person.key 'title'
         person.key 'institution', :nonempty
         person.key 'photo', :optional
+        person.key 'focus-area', :optional
 
         person.print_warnings
 

--- a/_scripts/focus_area.rb
+++ b/_scripts/focus_area.rb
@@ -32,5 +32,8 @@ people_files.each do |fn|
   all_fa = (user_fa || Set.new) | (proj_fa || Set.new)
   info['focus-area'] = all_fa.to_a unless all_fa.empty?
 
-  fn.write(info.to_yaml)
+  sorted = info.sort_by { _1 }.to_h
+  sorted['presentations'] = sorted.delete 'presentations'
+
+  fn.write(sorted.to_yaml.lines[1..-1].join)
 end

--- a/_scripts/focus_area.rb
+++ b/_scripts/focus_area.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'pathname'
+require 'set'
+
+def ensure_array(arr)
+  return [] if arr.nil?
+
+  arr.is_a?(Array) ? arr : [arr]
+end
+
+project_files = Pathname.glob('pages/projects/*.md')
+counter = {}
+project_files.each do |fn|
+  proj = YAML.load_file fn
+
+  fa = ensure_array proj['focus-area']
+  team = ensure_array proj['team']
+  team.reject! { _1.include?(' ') }&.reject! { _1.include?('@') }
+
+  fa.each { |a| team.each { |t| counter[t] = (counter[t] || Set.new) << a } }
+end
+
+people_files = Pathname.glob('_data/people/*.yml')
+people_files.each do |fn|
+  info = YAML.load_file fn
+
+  user_fa = info['presentations']&.flat_map { ensure_array(_1['focus-area']) }&.to_set&.delete('core')
+  proj_fa = counter[info['shortname']]&.delete('core')
+  puts "#{info['name']}: #{user_fa.to_a} | #{proj_fa.to_a}"
+  all_fa = (user_fa || Set.new) | (proj_fa || Set.new)
+  info['focus-area'] = all_fa.to_a unless all_fa.empty?
+
+  fn.write(info.to_yaml)
+end

--- a/pages/docs/newteammember.md
+++ b/pages/docs/newteammember.md
@@ -18,20 +18,24 @@ not mentioned here, or missing/unclear information, please [contribute an improv
 * Add a "`<your github username>.yml`" file to the [people folder in the website repository][people]. Here is an example:
 
 ```yml
+active: true
+focus-area:
+- <primary focus area(s), a list>
+institution: <Your University>
 name: <Your name>
+photo: /assets/images/team/<First name>-<Last name>.jpg
 shortname: <Your GitHub user ID>
 title: <Can be blank - will show a title under your picture>
-active: true
-institution: <Your University>
 website: <Optional, your website>
-photo: /assets/images/team/<First name>-<Last name>.jpg
 presentations:
   - title: How to make green eggs and ham
     date: 2018-09-10
     url: https://indico.cern.ch/event/697389/contributions/3062046/attachments/1712602/2761531/ROOT2018-Union.pdf
     meeting: ROOT 2018 Users Workshop
     meetingurl: https://cern.ch/root2018
-    location: Sarajevo
+    project: greeneggs
+    focus-area: as
+    location: Virtual
 ```
 
 * Add your GitHub username to the proper [university file][]. Note that you will *not* show up in the full team page if you are not in a university file!
@@ -67,11 +71,11 @@ the following criteria:
 
 The meaning of the fields is the following:
 
-  * title - the title of the talk: you made need to place it in double quotes, if certain characters like a colon (":") are included in the title
-  * date - the date on which the presentation was made, in the numeric format "YYYY-MM-DD"
-  * url - this should be a direct URL to the presentation file (e.g. pdf)
-  * meeting - the name of the meeting
-  * meetingurl - the URL for the meeting in which the presentation was made
-  * location - optionally list the location of a meeting if it was a workshop or dedicated gathering. Meetings that are mostly in Vidyo can just omit this.
-  * focus-area - optionally list the relevant focus area for this presentation, using its short name, i.e. one of [ia,ssl,ssc,doma,as,osglhc]
-  * project - optionally list the relevant project for this presentation, using its short name, i.e. those found in the [pages/projects/](https://github.com/iris-hep/iris-hep.github.io-source/tree/master/pages/projects) area
+  * title - the title of the talk: you made need to place it in double quotes if certain characters like a colon space ": " are included in the title.
+  * date - the date on which the presentation was made, in the numeric format "YYYY-MM-DD".
+  * url - this should be a direct URL to the presentation file (e.g. pdf).
+  * meeting - the name of the meeting.
+  * meetingurl - the URL for the meeting in which the presentation was made.
+  * location - optionally list the location of a meeting if it was a workshop or dedicated gathering. Meetings that are mostly in Vidyo can use "Virtual".
+  * focus-area - optionally list the relevant focus area for this presentation, using its short name, i.e. one of [ia,ssl,ssc,doma,as,osglhc,blueprint,core]. Can be a list, leave blank if none. 
+  * project - optionally list the relevant project for this presentation, using its short name, i.e. those found in the [pages/projects/](https://github.com/iris-hep/iris-hep.github.io-source/tree/master/pages/projects) area. Can be a list, leave blank if none.

--- a/pages/docs/newteammember.md
+++ b/pages/docs/newteammember.md
@@ -77,5 +77,5 @@ The meaning of the fields is the following:
   * meeting - the name of the meeting.
   * meetingurl - the URL for the meeting in which the presentation was made.
   * location - optionally list the location of a meeting if it was a workshop or dedicated gathering. Meetings that are mostly in Vidyo can use "Virtual".
-  * focus-area - optionally list the relevant focus area for this presentation, using its short name, i.e. one of [ia,ssl,ssc,doma,as,osglhc,blueprint,core]. Can be a list, leave blank if none. 
+  * focus-area - optionally list the relevant focus area for this presentation, using its short name, i.e. one of [ia,ssl,ssc,doma,as,osglhc,blueprint,core]. Can be a list, leave blank if none.
   * project - optionally list the relevant project for this presentation, using its short name, i.e. those found in the [pages/projects/](https://github.com/iris-hep/iris-hep.github.io-source/tree/master/pages/projects) area. Can be a list, leave blank if none.


### PR DESCRIPTION
This adds a quick conversion to people.focus-area, then applies this to the people files. Anyone who has given a presentation or is part of a project for a focus area was added. Users are expected to keep the focus areas up to date.

Closes #715 

Probably could add a warning if focus-area is not present. Not sure if that will be all that motivating, though. Edit: added. Also sorted the keys (except for presentation, which is last).