### PR TITLE
fix: use focus-area and project for videos, like other areas

### DIFF
--- a/_data/videos/26YXz0fzMNQ_0.yml
+++ b/_data/videos/26YXz0fzMNQ_0.yml
@@ -1,7 +1,7 @@
 title: "Using GPUs and FPGAs as-a-service for LHC computing"
 speaker: Dylan Rankin
 focus-area: ia
-projects:
+project:
 date: 2020-09-09
 startsec: 0
 url: https://www.youtube.com/embed/26YXz0fzMNQ

--- a/_data/videos/26YXz0fzMNQ_0.yml
+++ b/_data/videos/26YXz0fzMNQ_0.yml
@@ -1,6 +1,6 @@
 title: "Using GPUs and FPGAs as-a-service for LHC computing"
 speaker: Dylan Rankin
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2020-09-09
 startsec: 0

--- a/_data/videos/2QamxiCawXM_0.yml
+++ b/_data/videos/2QamxiCawXM_0.yml
@@ -1,7 +1,7 @@
 title: "Primary vertex finding at LHCb"
 speaker: Marian Stahl
 focus-area: ia
-projects:
+project:
 date: 2020-01-29
 startsec: 0
 url: https://www.youtube.com/embed/2QamxiCawXM

--- a/_data/videos/2QamxiCawXM_0.yml
+++ b/_data/videos/2QamxiCawXM_0.yml
@@ -1,6 +1,6 @@
 title: "Primary vertex finding at LHCb"
 speaker: Marian Stahl
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2020-01-29
 startsec: 0

--- a/_data/videos/6gCp1BwQHdg_0.yml
+++ b/_data/videos/6gCp1BwQHdg_0.yml
@@ -1,6 +1,6 @@
 title: "Reproducible Large Scale SkyhookDM Experiments"
 speaker: Jayjeet Chakraborty
-focus_areas:
+focus-area:
 projects:
 date: 2020-10-05
 startsec: 55

--- a/_data/videos/6gCp1BwQHdg_0.yml
+++ b/_data/videos/6gCp1BwQHdg_0.yml
@@ -1,7 +1,7 @@
 title: "Reproducible Large Scale SkyhookDM Experiments"
 speaker: Jayjeet Chakraborty
 focus-area:
-projects:
+project:
 date: 2020-10-05
 startsec: 55
 url: https://www.youtube.com/embed/6gCp1BwQHdg

--- a/_data/videos/6gCp1BwQHdg_1.yml
+++ b/_data/videos/6gCp1BwQHdg_1.yml
@@ -1,7 +1,7 @@
 title: "Matrix Factorization for PV finding in LHCb"
 speaker: Alan Joshua Jegaraj
 focus-area: ia
-projects:
+project:
 date: 2020-10-05
 startsec: 901
 url: https://www.youtube.com/embed/6gCp1BwQHdg

--- a/_data/videos/6gCp1BwQHdg_1.yml
+++ b/_data/videos/6gCp1BwQHdg_1.yml
@@ -1,6 +1,6 @@
 title: "Matrix Factorization for PV finding in LHCb"
 speaker: Alan Joshua Jegaraj
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2020-10-05
 startsec: 901

--- a/_data/videos/88E4W5xetZw_0.yml
+++ b/_data/videos/88E4W5xetZw_0.yml
@@ -1,7 +1,7 @@
 title: "fast-carpenter: turning trees into tables"
 speaker: Benjamin Krikler
 focus-area: as
-projects:
+project:
 date: 2019-03-04
 startsec: 0
 url: https://www.youtube.com/embed/88E4W5xetZw

--- a/_data/videos/88E4W5xetZw_0.yml
+++ b/_data/videos/88E4W5xetZw_0.yml
@@ -1,6 +1,6 @@
 title: "fast-carpenter: turning trees into tables"
 speaker: Benjamin Krikler
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-03-04
 startsec: 0

--- a/_data/videos/88E4W5xetZw_1.yml
+++ b/_data/videos/88E4W5xetZw_1.yml
@@ -1,7 +1,7 @@
 title: "scikit-validate: automating analysis validation"
 speaker: Lukasz Kreczko
 focus-area: as
-projects:
+project:
 date: 2019-03-04
 startsec: 2430
 url: https://www.youtube.com/embed/88E4W5xetZw

--- a/_data/videos/88E4W5xetZw_1.yml
+++ b/_data/videos/88E4W5xetZw_1.yml
@@ -1,6 +1,6 @@
 title: "scikit-validate: automating analysis validation"
 speaker: Lukasz Kreczko
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-03-04
 startsec: 2430

--- a/_data/videos/BlMl4SGkVnY_0.yml
+++ b/_data/videos/BlMl4SGkVnY_0.yml
@@ -1,7 +1,7 @@
 title: "mpl-hep"
 speaker: Nick Smith
 focus-area: as
-projects:
+project:
 date: 2019-04-15
 startsec: 0
 url: https://www.youtube.com/embed/BlMl4SGkVnY

--- a/_data/videos/BlMl4SGkVnY_0.yml
+++ b/_data/videos/BlMl4SGkVnY_0.yml
@@ -1,6 +1,6 @@
 title: "mpl-hep"
 speaker: Nick Smith
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-04-15
 startsec: 0

--- a/_data/videos/BlMl4SGkVnY_1.yml
+++ b/_data/videos/BlMl4SGkVnY_1.yml
@@ -1,7 +1,7 @@
 title: "boost-histogram and hist"
 speaker: Henry Schreiner
 focus-area: as
-projects:
+project:
 date: 2019-04-15
 startsec: 1280
 url: https://www.youtube.com/embed/BlMl4SGkVnY

--- a/_data/videos/BlMl4SGkVnY_1.yml
+++ b/_data/videos/BlMl4SGkVnY_1.yml
@@ -1,6 +1,6 @@
 title: "boost-histogram and hist"
 speaker: Henry Schreiner
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-04-15
 startsec: 1280

--- a/_data/videos/BlMl4SGkVnY_2.yml
+++ b/_data/videos/BlMl4SGkVnY_2.yml
@@ -1,6 +1,6 @@
 title: "Aghast"
 speaker: Jim Pivarski
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-04-15
 startsec: 2953

--- a/_data/videos/BlMl4SGkVnY_2.yml
+++ b/_data/videos/BlMl4SGkVnY_2.yml
@@ -1,7 +1,7 @@
 title: "Aghast"
 speaker: Jim Pivarski
 focus-area: as
-projects:
+project:
 date: 2019-04-15
 startsec: 2953
 url: https://www.youtube.com/embed/BlMl4SGkVnY

--- a/_data/videos/CAZtQIZ1-wE_0.yml
+++ b/_data/videos/CAZtQIZ1-wE_0.yml
@@ -1,6 +1,6 @@
 title: "Ambiguity Resolution in ACTS"
 speaker: Irina Ene
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2020-09-02
 startsec: 34

--- a/_data/videos/CAZtQIZ1-wE_0.yml
+++ b/_data/videos/CAZtQIZ1-wE_0.yml
@@ -1,7 +1,7 @@
 title: "Ambiguity Resolution in ACTS"
 speaker: Irina Ene
 focus-area: ia
-projects:
+project:
 date: 2020-09-02
 startsec: 34
 url: https://www.youtube.com/embed/CAZtQIZ1-wE

--- a/_data/videos/CAZtQIZ1-wE_1.yml
+++ b/_data/videos/CAZtQIZ1-wE_1.yml
@@ -1,7 +1,7 @@
 title: "Modernizing Boost in CMSSW"
 speaker: Lucas Camolez
 focus-area: ia
-projects:
+project:
 date: 2020-09-02
 startsec: 1891
 url: https://www.youtube.com/embed/CAZtQIZ1-wE

--- a/_data/videos/CAZtQIZ1-wE_1.yml
+++ b/_data/videos/CAZtQIZ1-wE_1.yml
@@ -1,6 +1,6 @@
 title: "Modernizing Boost in CMSSW"
 speaker: Lucas Camolez
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2020-09-02
 startsec: 1891

--- a/_data/videos/Hr0bq2Q31Zc_0.yml
+++ b/_data/videos/Hr0bq2Q31Zc_0.yml
@@ -1,6 +1,6 @@
 title: "Allen project @ LHCb"
 speaker: Daniel Craik
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2020-01-27
 startsec: 0

--- a/_data/videos/Hr0bq2Q31Zc_0.yml
+++ b/_data/videos/Hr0bq2Q31Zc_0.yml
@@ -1,7 +1,7 @@
 title: "Allen project @ LHCb"
 speaker: Daniel Craik
 focus-area: ia
-projects:
+project:
 date: 2020-01-27
 startsec: 0
 url: https://www.youtube.com/embed/Hr0bq2Q31Zc

--- a/_data/videos/K17B-TZC6-Q_0.yml
+++ b/_data/videos/K17B-TZC6-Q_0.yml
@@ -1,6 +1,6 @@
 title: "Initial Studies of ACTS tracking on GPUs"
 speaker: Xiaocong Ai
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2020-08-26
 startsec: 0

--- a/_data/videos/K17B-TZC6-Q_0.yml
+++ b/_data/videos/K17B-TZC6-Q_0.yml
@@ -1,7 +1,7 @@
 title: "Initial Studies of ACTS tracking on GPUs"
 speaker: Xiaocong Ai
 focus-area: ia
-projects:
+project:
 date: 2020-08-26
 startsec: 0
 url: https://www.youtube.com/embed/K17B-TZC6-Q

--- a/_data/videos/NJHEPV4Etmg_0.yml
+++ b/_data/videos/NJHEPV4Etmg_0.yml
@@ -1,7 +1,7 @@
 title: "Extending JAX with CUDA"
 speaker: Daniel Foreman-Mackey
 focus-area: as
-projects:
+project:
 date: 2021-02-01
 startsec: 0
 url: https://www.youtube.com/embed/NJHEPV4Etmg

--- a/_data/videos/NJHEPV4Etmg_0.yml
+++ b/_data/videos/NJHEPV4Etmg_0.yml
@@ -1,6 +1,6 @@
 title: "Extending JAX with CUDA"
 speaker: Daniel Foreman-Mackey
-focus_areas: as
+focus-area: as
 projects:
 date: 2021-02-01
 startsec: 0

--- a/_data/videos/QNqxuuz3pE8_0.yml
+++ b/_data/videos/QNqxuuz3pE8_0.yml
@@ -1,7 +1,7 @@
 title: "Analysis Description Languages"
 speaker: Harrison Prosper
 focus-area: as
-projects:
+project:
 date: 2019-02-25
 startsec: 0
 url: https://www.youtube.com/embed/QNqxuuz3pE8

--- a/_data/videos/QNqxuuz3pE8_0.yml
+++ b/_data/videos/QNqxuuz3pE8_0.yml
@@ -1,6 +1,6 @@
 title: "Analysis Description Languages"
 speaker: Harrison Prosper
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-02-25
 startsec: 0

--- a/_data/videos/QNqxuuz3pE8_1.yml
+++ b/_data/videos/QNqxuuz3pE8_1.yml
@@ -1,7 +1,7 @@
 title: "Declarative analysis with LINQ"
 speaker: Gordon Watts
 focus-area: as
-projects:
+project:
 date: 2019-02-25
 startsec: 2606
 url: https://www.youtube.com/embed/QNqxuuz3pE8

--- a/_data/videos/QNqxuuz3pE8_1.yml
+++ b/_data/videos/QNqxuuz3pE8_1.yml
@@ -1,6 +1,6 @@
 title: "Declarative analysis with LINQ"
 speaker: Gordon Watts
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-02-25
 startsec: 2606

--- a/_data/videos/SFYAIzDFta8_0.yml
+++ b/_data/videos/SFYAIzDFta8_0.yml
@@ -1,7 +1,7 @@
 title: "Integration of C++ Modules into CMSSW"
 speaker: Yuka Takahashi
 focus-area:
-projects:
+project:
 date: 2019-02-18
 startsec: 0
 url: https://www.youtube.com/embed/SFYAIzDFta8

--- a/_data/videos/SFYAIzDFta8_0.yml
+++ b/_data/videos/SFYAIzDFta8_0.yml
@@ -1,6 +1,6 @@
 title: "Integration of C++ Modules into CMSSW"
 speaker: Yuka Takahashi
-focus_areas:
+focus-area:
 projects:
 date: 2019-02-18
 startsec: 0

--- a/_data/videos/Tpy6AR-lTlg_0.yml
+++ b/_data/videos/Tpy6AR-lTlg_0.yml
@@ -1,6 +1,6 @@
 title: "Graph Neural Networks Architectures"
 speaker: Markus Atkinson
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2020-10-21
 startsec: 0

--- a/_data/videos/Tpy6AR-lTlg_0.yml
+++ b/_data/videos/Tpy6AR-lTlg_0.yml
@@ -1,7 +1,7 @@
 title: "Graph Neural Networks Architectures"
 speaker: Markus Atkinson
 focus-area: ia
-projects:
+project:
 date: 2020-10-21
 startsec: 0
 url: https://www.youtube.com/embed/Tpy6AR-lTlg

--- a/_data/videos/Tpy6AR-lTlg_1.yml
+++ b/_data/videos/Tpy6AR-lTlg_1.yml
@@ -1,6 +1,6 @@
 title: "Tracking with GNNs on FPGAs"
 speaker: Javier Duarte
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2020-10-21
 startsec: 1589

--- a/_data/videos/Tpy6AR-lTlg_1.yml
+++ b/_data/videos/Tpy6AR-lTlg_1.yml
@@ -1,7 +1,7 @@
 title: "Tracking with GNNs on FPGAs"
 speaker: Javier Duarte
 focus-area: ia
-projects:
+project:
 date: 2020-10-21
 startsec: 1589
 url: https://www.youtube.com/embed/Tpy6AR-lTlg

--- a/_data/videos/XaCn2Gk2-eg_0.yml
+++ b/_data/videos/XaCn2Gk2-eg_0.yml
@@ -1,6 +1,6 @@
 title: "Hyperparameter Optimisation service at ATLAS"
 speaker: Rui Zhang
-focus_areas:
+focus-area:
 projects:
 date: 2021-03-03
 startsec: 0

--- a/_data/videos/XaCn2Gk2-eg_0.yml
+++ b/_data/videos/XaCn2Gk2-eg_0.yml
@@ -1,7 +1,7 @@
 title: "Hyperparameter Optimisation service at ATLAS"
 speaker: Rui Zhang
 focus-area:
-projects:
+project:
 date: 2021-03-03
 startsec: 0
 url: https://www.youtube.com/embed/XaCn2Gk2-eg

--- a/_data/videos/XaCn2Gk2-eg_1.yml
+++ b/_data/videos/XaCn2Gk2-eg_1.yml
@@ -1,6 +1,6 @@
 title: "Towards cross-platform performance portability of random number generation in SYCL"
 speaker: Vincent Pascuzzi
-focus_areas:
+focus-area:
 projects:
 date: 2021-03-03
 startsec: 2203

--- a/_data/videos/XaCn2Gk2-eg_1.yml
+++ b/_data/videos/XaCn2Gk2-eg_1.yml
@@ -1,7 +1,7 @@
 title: "Towards cross-platform performance portability of random number generation in SYCL"
 speaker: Vincent Pascuzzi
 focus-area:
-projects:
+project:
 date: 2021-03-03
 startsec: 2203
 url: https://www.youtube.com/embed/XaCn2Gk2-eg

--- a/_data/videos/_fB2aUbQwV8_0.yml
+++ b/_data/videos/_fB2aUbQwV8_0.yml
@@ -1,7 +1,7 @@
 title: "intelligent Data Delivery Service"
 speaker: Wen Guan
 focus-area:
-projects:
+project:
 date: 2021-03-29
 startsec: 0
 url: https://www.youtube.com/embed/_fB2aUbQwV8

--- a/_data/videos/_fB2aUbQwV8_0.yml
+++ b/_data/videos/_fB2aUbQwV8_0.yml
@@ -1,6 +1,6 @@
 title: "intelligent Data Delivery Service"
 speaker: Wen Guan
-focus_areas:
+focus-area:
 projects:
 date: 2021-03-29
 startsec: 0

--- a/_data/videos/a4N_iY5fhmw_0.yml
+++ b/_data/videos/a4N_iY5fhmw_0.yml
@@ -1,6 +1,6 @@
 title: "ATLAS Fast Calorimeter Simulation"
 speaker: Jana Schaarschmidt
-focus_areas:
+focus-area:
 projects:
 date: 2021-03-31
 startsec: 0

--- a/_data/videos/a4N_iY5fhmw_0.yml
+++ b/_data/videos/a4N_iY5fhmw_0.yml
@@ -1,7 +1,7 @@
 title: "ATLAS Fast Calorimeter Simulation"
 speaker: Jana Schaarschmidt
 focus-area:
-projects:
+project:
 date: 2021-03-31
 startsec: 0
 url: https://www.youtube.com/embed/a4N_iY5fhmw

--- a/_data/videos/a4N_iY5fhmw_1.yml
+++ b/_data/videos/a4N_iY5fhmw_1.yml
@@ -1,7 +1,7 @@
 title: "Accelerating End-To-End DL Reconstruction for CMS"
 speaker: Davide Di Croce
 focus-area:
-projects:
+project:
 date: 2021-03-31
 startsec: 1477
 url: https://www.youtube.com/embed/a4N_iY5fhmw

--- a/_data/videos/a4N_iY5fhmw_1.yml
+++ b/_data/videos/a4N_iY5fhmw_1.yml
@@ -1,6 +1,6 @@
 title: "Accelerating End-To-End DL Reconstruction for CMS"
 speaker: Davide Di Croce
-focus_areas:
+focus-area:
 projects:
 date: 2021-03-31
 startsec: 1477

--- a/_data/videos/ajcqHESGAQY_0.yml
+++ b/_data/videos/ajcqHESGAQY_0.yml
@@ -1,7 +1,7 @@
 title: "Accelerating Graph Neural Networks on CPU + FPGA co-processors for scalable track reconstruction tasks"
 speaker: Aneesh Heintz
 focus-area: ia
-projects:
+project:
 date: 2020-10-14
 startsec: 0
 url: https://www.youtube.com/embed/ajcqHESGAQY

--- a/_data/videos/ajcqHESGAQY_0.yml
+++ b/_data/videos/ajcqHESGAQY_0.yml
@@ -1,6 +1,6 @@
 title: "Accelerating Graph Neural Networks on CPU + FPGA co-processors for scalable track reconstruction tasks"
 speaker: Aneesh Heintz
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2020-10-14
 startsec: 0

--- a/_data/videos/ajcqHESGAQY_1.yml
+++ b/_data/videos/ajcqHESGAQY_1.yml
@@ -1,6 +1,6 @@
 title: "SkyhookDM projection-only pushdown and Arrow dataset integration into Skyhook objects"
 speaker: Xiongfeng Song
-focus_areas:
+focus-area:
 projects:
 date: 2020-10-14
 startsec: 1180

--- a/_data/videos/ajcqHESGAQY_1.yml
+++ b/_data/videos/ajcqHESGAQY_1.yml
@@ -1,7 +1,7 @@
 title: "SkyhookDM projection-only pushdown and Arrow dataset integration into Skyhook objects"
 speaker: Xiongfeng Song
 focus-area:
-projects:
+project:
 date: 2020-10-14
 startsec: 1180
 url: https://www.youtube.com/embed/ajcqHESGAQY

--- a/_data/videos/b2z8d2tWqcE_0.yml
+++ b/_data/videos/b2z8d2tWqcE_0.yml
@@ -1,7 +1,7 @@
 title: "Particles and decays in the Scikit-HEP project"
 speaker: Eduardo Rodrigues
 focus-area: as
-projects:
+project:
 date: 2019-05-13
 startsec: 0
 url: https://www.youtube.com/embed/b2z8d2tWqcE

--- a/_data/videos/b2z8d2tWqcE_0.yml
+++ b/_data/videos/b2z8d2tWqcE_0.yml
@@ -1,6 +1,6 @@
 title: "Particles and decays in the Scikit-HEP project"
 speaker: Eduardo Rodrigues
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-05-13
 startsec: 0

--- a/_data/videos/b4iMNk2m-Dc_0.yml
+++ b/_data/videos/b4iMNk2m-Dc_0.yml
@@ -1,6 +1,6 @@
 title: "Particle decay classifiers for the LHCb Run 3 first"
 speaker: Sean Condon
-focus_areas:
+focus-area:
 projects:
 date: 2020-09-28
 startsec: 0

--- a/_data/videos/b4iMNk2m-Dc_0.yml
+++ b/_data/videos/b4iMNk2m-Dc_0.yml
@@ -1,7 +1,7 @@
 title: "Particle decay classifiers for the LHCb Run 3 first"
 speaker: Sean Condon
 focus-area:
-projects:
+project:
 date: 2020-09-28
 startsec: 0
 url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/b4iMNk2m-Dc_1.yml
+++ b/_data/videos/b4iMNk2m-Dc_1.yml
@@ -1,7 +1,7 @@
 title: "Graph Neural Networks for Particle Tracking in FPGAs with hls4m"
 speaker: Vesal Razavimaleki
 focus-area: ia
-projects:
+project:
 date: 2020-09-28
 startsec: 845
 url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/b4iMNk2m-Dc_1.yml
+++ b/_data/videos/b4iMNk2m-Dc_1.yml
@@ -1,6 +1,6 @@
 title: "Graph Neural Networks for Particle Tracking in FPGAs with hls4m"
 speaker: Vesal Razavimaleki
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2020-09-28
 startsec: 845

--- a/_data/videos/b4iMNk2m-Dc_2.yml
+++ b/_data/videos/b4iMNk2m-Dc_2.yml
@@ -1,6 +1,6 @@
 title: "Proactive Site Monitoring"
 speaker: Suhaib Shaikh
-focus_areas:
+focus-area:
 projects:
 date: 2020-09-28
 startsec: 2097

--- a/_data/videos/b4iMNk2m-Dc_2.yml
+++ b/_data/videos/b4iMNk2m-Dc_2.yml
@@ -1,7 +1,7 @@
 title: "Proactive Site Monitoring"
 speaker: Suhaib Shaikh
 focus-area:
-projects:
+project:
 date: 2020-09-28
 startsec: 2097
 url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/b4iMNk2m-Dc_3.yml
+++ b/_data/videos/b4iMNk2m-Dc_3.yml
@@ -1,7 +1,7 @@
 title: "Anomaly Detection using VAEs, Normalizing Flows for New Physics Searches"
 speaker: Pratik Jawahar
 focus-area:
-projects:
+project:
 date: 2020-09-28
 startsec: 2849
 url: https://www.youtube.com/embed/b4iMNk2m-Dc

--- a/_data/videos/b4iMNk2m-Dc_3.yml
+++ b/_data/videos/b4iMNk2m-Dc_3.yml
@@ -1,6 +1,6 @@
 title: "Anomaly Detection using VAEs, Normalizing Flows for New Physics Searches"
 speaker: Pratik Jawahar
-focus_areas:
+focus-area:
 projects:
 date: 2020-09-28
 startsec: 2849

--- a/_data/videos/c8FEyWP0dWc_0.yml
+++ b/_data/videos/c8FEyWP0dWc_0.yml
@@ -1,7 +1,7 @@
 title: "Introduction to modern CDN Architectures"
 speaker: John Dilley
 focus-area:
-projects:
+project:
 date: 2019-03-25
 startsec: 0
 url: https://www.youtube.com/embed/c8FEyWP0dWc

--- a/_data/videos/c8FEyWP0dWc_0.yml
+++ b/_data/videos/c8FEyWP0dWc_0.yml
@@ -1,6 +1,6 @@
 title: "Introduction to modern CDN Architectures"
 speaker: John Dilley
-focus_areas:
+focus-area:
 projects:
 date: 2019-03-25
 startsec: 0

--- a/_data/videos/dbUQZbtfNfk_0.yml
+++ b/_data/videos/dbUQZbtfNfk_0.yml
@@ -1,7 +1,7 @@
 title: "Rumble"
 speaker: Ghislain Fourny and Ingo Mueller
 focus-area:
-projects:
+project:
 date: 2020-05-04
 startsec: 0
 url: https://www.youtube.com/embed/dbUQZbtfNfk

--- a/_data/videos/dbUQZbtfNfk_0.yml
+++ b/_data/videos/dbUQZbtfNfk_0.yml
@@ -1,6 +1,6 @@
 title: "Rumble"
 speaker: Ghislain Fourny and Ingo Mueller
-focus_areas:
+focus-area:
 projects:
 date: 2020-05-04
 startsec: 0

--- a/_data/videos/gOVg4qvyw0w_0.yml
+++ b/_data/videos/gOVg4qvyw0w_0.yml
@@ -1,7 +1,7 @@
 title: "Graph Networks for Tracking"
 speaker: Savannah Thais
 focus-area: ia
-projects:
+project:
 date: 2021-03-01
 startsec: 0
 url: https://www.youtube.com/embed/gOVg4qvyw0w

--- a/_data/videos/gOVg4qvyw0w_0.yml
+++ b/_data/videos/gOVg4qvyw0w_0.yml
@@ -1,6 +1,6 @@
 title: "Graph Networks for Tracking"
 speaker: Savannah Thais
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2021-03-01
 startsec: 0

--- a/_data/videos/gOVg4qvyw0w_1.yml
+++ b/_data/videos/gOVg4qvyw0w_1.yml
@@ -1,6 +1,6 @@
 title: "Sherpa performence study - Glibc"
 speaker: Rui Wang
-focus_areas:
+focus-area:
 projects:
 date: 2021-03-01
 startsec: 1927

--- a/_data/videos/gOVg4qvyw0w_1.yml
+++ b/_data/videos/gOVg4qvyw0w_1.yml
@@ -1,7 +1,7 @@
 title: "Sherpa performence study - Glibc"
 speaker: Rui Wang
 focus-area:
-projects:
+project:
 date: 2021-03-01
 startsec: 1927
 url: https://www.youtube.com/embed/gOVg4qvyw0w

--- a/_data/videos/hIiEu7XFu5Y_0.yml
+++ b/_data/videos/hIiEu7XFu5Y_0.yml
@@ -1,7 +1,7 @@
 title: "Testing Bitshuffle compression algorithm preconditioner in ROOT I/O"
 speaker: Keisuke Kamahori
 focus-area:
-projects:
+project:
 date: 2020-09-08
 startsec: 0
 url: https://www.youtube.com/embed/hIiEu7XFu5Y

--- a/_data/videos/hIiEu7XFu5Y_0.yml
+++ b/_data/videos/hIiEu7XFu5Y_0.yml
@@ -1,6 +1,6 @@
 title: "Testing Bitshuffle compression algorithm preconditioner in ROOT I/O"
 speaker: Keisuke Kamahori
-focus_areas:
+focus-area:
 projects:
 date: 2020-09-08
 startsec: 0

--- a/_data/videos/hIiEu7XFu5Y_1.yml
+++ b/_data/videos/hIiEu7XFu5Y_1.yml
@@ -1,7 +1,7 @@
 title: "Enabling C++ Modules For ROOT on Windows"
 speaker: Vaibhav Garg
 focus-area:
-projects:
+project:
 date: 2020-09-08
 startsec: 1054
 url: https://www.youtube.com/embed/hIiEu7XFu5Y

--- a/_data/videos/hIiEu7XFu5Y_1.yml
+++ b/_data/videos/hIiEu7XFu5Y_1.yml
@@ -1,6 +1,6 @@
 title: "Enabling C++ Modules For ROOT on Windows"
 speaker: Vaibhav Garg
-focus_areas:
+focus-area:
 projects:
 date: 2020-09-08
 startsec: 1054

--- a/_data/videos/hIiEu7XFu5Y_2.yml
+++ b/_data/videos/hIiEu7XFu5Y_2.yml
@@ -1,6 +1,6 @@
 title: "Hist: histogramming for analysis powered by boost-histogram"
 speaker: Shuo Liu
-focus_areas: as
+focus-area: as
 projects:
 date: 2020-09-08
 startsec: 2040

--- a/_data/videos/hIiEu7XFu5Y_2.yml
+++ b/_data/videos/hIiEu7XFu5Y_2.yml
@@ -1,7 +1,7 @@
 title: "Hist: histogramming for analysis powered by boost-histogram"
 speaker: Shuo Liu
 focus-area: as
-projects:
+project:
 date: 2020-09-08
 startsec: 2040
 url: https://www.youtube.com/embed/hIiEu7XFu5Y

--- a/_data/videos/q9bPLxZ9xY4_0.yml
+++ b/_data/videos/q9bPLxZ9xY4_0.yml
@@ -1,7 +1,7 @@
 title: "Parallelized Kalman-Filter-Based Reconstruction of Particle Tracks on Many-Core Architectures"
 speaker: Allison Reinsvold Hall
 focus-area: ia
-projects:
+project:
 date: 2019-04-10
 startsec: 0
 url: https://www.youtube.com/embed/q9bPLxZ9xY4

--- a/_data/videos/q9bPLxZ9xY4_0.yml
+++ b/_data/videos/q9bPLxZ9xY4_0.yml
@@ -1,6 +1,6 @@
 title: "Parallelized Kalman-Filter-Based Reconstruction of Particle Tracks on Many-Core Architectures"
 speaker: Allison Reinsvold Hall
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2019-04-10
 startsec: 0

--- a/_data/videos/qFgQQgMDxMo_0.yml
+++ b/_data/videos/qFgQQgMDxMo_0.yml
@@ -1,6 +1,6 @@
 title: "Fast Calorimeter Simulation on GPU"
 speaker: Ke Li
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2021-03-24
 startsec: 0

--- a/_data/videos/qFgQQgMDxMo_0.yml
+++ b/_data/videos/qFgQQgMDxMo_0.yml
@@ -1,7 +1,7 @@
 title: "Fast Calorimeter Simulation on GPU"
 speaker: Ke Li
 focus-area: ia
-projects:
+project:
 date: 2021-03-24
 startsec: 0
 url: https://www.youtube.com/embed/qFgQQgMDxMo

--- a/_data/videos/qFgQQgMDxMo_1.yml
+++ b/_data/videos/qFgQQgMDxMo_1.yml
@@ -1,7 +1,7 @@
 title: "Track Seed Finding in ACTS"
 speaker: Tomohiro Yamazaki
 focus-area: ia
-projects:
+project:
 date: 2021-03-24
 startsec: 1564
 url: https://www.youtube.com/embed/qFgQQgMDxMo

--- a/_data/videos/qFgQQgMDxMo_1.yml
+++ b/_data/videos/qFgQQgMDxMo_1.yml
@@ -1,6 +1,6 @@
 title: "Track Seed Finding in ACTS"
 speaker: Tomohiro Yamazaki
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2021-03-24
 startsec: 1564

--- a/_data/videos/qrFOC7FvN7Q_0.yml
+++ b/_data/videos/qrFOC7FvN7Q_0.yml
@@ -1,6 +1,6 @@
 title: "FAIR Framework for Physics-Inspired AI in HEP"
 speaker: Javier Duarte
-focus_areas:
+focus-area:
 projects:
 date: 2021-04-21
 startsec: 0

--- a/_data/videos/qrFOC7FvN7Q_0.yml
+++ b/_data/videos/qrFOC7FvN7Q_0.yml
@@ -1,7 +1,7 @@
 title: "FAIR Framework for Physics-Inspired AI in HEP"
 speaker: Javier Duarte
 focus-area:
-projects:
+project:
 date: 2021-04-21
 startsec: 0
 url: https://www.youtube.com/embed/qrFOC7FvN7Q

--- a/_data/videos/qrFOC7FvN7Q_1.yml
+++ b/_data/videos/qrFOC7FvN7Q_1.yml
@@ -1,6 +1,6 @@
 title: "ILC Software & Computing"
 speaker: Jan Strube
-focus_areas:
+focus-area:
 projects:
 date: 2021-04-21
 startsec: 2007

--- a/_data/videos/qrFOC7FvN7Q_1.yml
+++ b/_data/videos/qrFOC7FvN7Q_1.yml
@@ -1,7 +1,7 @@
 title: "ILC Software & Computing"
 speaker: Jan Strube
 focus-area:
-projects:
+project:
 date: 2021-04-21
 startsec: 2007
 url: https://www.youtube.com/embed/qrFOC7FvN7Q

--- a/_data/videos/sATu_MJo8L4_0.yml
+++ b/_data/videos/sATu_MJo8L4_0.yml
@@ -1,6 +1,6 @@
 title: "zfp compression on a CMS NanoAOD"
 speaker: Erik Wallin
-focus_areas: as
+focus-area: as
 projects:
 date: 2020-09-21
 startsec: 0

--- a/_data/videos/sATu_MJo8L4_0.yml
+++ b/_data/videos/sATu_MJo8L4_0.yml
@@ -1,7 +1,7 @@
 title: "zfp compression on a CMS NanoAOD"
 speaker: Erik Wallin
 focus-area: as
-projects:
+project:
 date: 2020-09-21
 startsec: 0
 url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/sATu_MJo8L4_1.yml
+++ b/_data/videos/sATu_MJo8L4_1.yml
@@ -1,6 +1,6 @@
 title: "Recast"
 speaker: Vladimir Ovechkin
-focus_areas: as
+focus-area: as
 projects:
 date: 2020-09-21
 startsec: 1016

--- a/_data/videos/sATu_MJo8L4_1.yml
+++ b/_data/videos/sATu_MJo8L4_1.yml
@@ -1,7 +1,7 @@
 title: "Recast"
 speaker: Vladimir Ovechkin
 focus-area: as
-projects:
+project:
 date: 2020-09-21
 startsec: 1016
 url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/sATu_MJo8L4_2.yml
+++ b/_data/videos/sATu_MJo8L4_2.yml
@@ -1,7 +1,7 @@
 title: "Improving the OSG"
 speaker: Tommy Shearer
 focus-area: osg
-projects:
+project:
 date: 2020-09-21
 startsec: 1782
 url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/sATu_MJo8L4_2.yml
+++ b/_data/videos/sATu_MJo8L4_2.yml
@@ -1,6 +1,6 @@
 title: "Improving the OSG"
 speaker: Tommy Shearer
-focus_areas: osg
+focus-area: osg
 projects:
 date: 2020-09-21
 startsec: 1782

--- a/_data/videos/sATu_MJo8L4_3.yml
+++ b/_data/videos/sATu_MJo8L4_3.yml
@@ -1,7 +1,7 @@
 title: "ServiceX: Backend Tests"
 speaker: David Liu
 focus-area:
-projects:
+project:
 date: 2020-09-21
 startsec: 2789
 url: https://www.youtube.com/embed/sATu_MJo8L4

--- a/_data/videos/sATu_MJo8L4_3.yml
+++ b/_data/videos/sATu_MJo8L4_3.yml
@@ -1,6 +1,6 @@
 title: "ServiceX: Backend Tests"
 speaker: David Liu
-focus_areas:
+focus-area:
 projects:
 date: 2020-09-21
 startsec: 2789

--- a/_data/videos/tpjp6lhU7Us_0.yml
+++ b/_data/videos/tpjp6lhU7Us_0.yml
@@ -1,6 +1,6 @@
 title: "ACTS - A Common Track Software"
 speaker: Paul Gessinger
-focus_areas: ia
+focus-area: ia
 projects:
 date: 2019-07-31
 startsec: 0

--- a/_data/videos/tpjp6lhU7Us_0.yml
+++ b/_data/videos/tpjp6lhU7Us_0.yml
@@ -1,7 +1,7 @@
 title: "ACTS - A Common Track Software"
 speaker: Paul Gessinger
 focus-area: ia
-projects:
+project:
 date: 2019-07-31
 startsec: 0
 url: https://www.youtube.com/embed/tpjp6lhU7Us

--- a/_data/videos/uJNFaDsIByY_0.yml
+++ b/_data/videos/uJNFaDsIByY_0.yml
@@ -1,6 +1,6 @@
 title: "Awkward Array: Numba"
 speaker: Jim Pivarski
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-04-17
 startsec: 0

--- a/_data/videos/uJNFaDsIByY_0.yml
+++ b/_data/videos/uJNFaDsIByY_0.yml
@@ -1,7 +1,7 @@
 title: "Awkward Array: Numba"
 speaker: Jim Pivarski
 focus-area: as
-projects:
+project:
 date: 2019-04-17
 startsec: 0
 url: https://www.youtube.com/embed/uJNFaDsIByY

--- a/_data/videos/uJNFaDsIByY_1.yml
+++ b/_data/videos/uJNFaDsIByY_1.yml
@@ -1,7 +1,7 @@
 title: "Awkward Array: Pandas"
 speaker: Michael Hedges
 focus-area: as
-projects:
+project:
 date: 2019-04-17
 startsec: 1611
 url: https://www.youtube.com/embed/uJNFaDsIByY

--- a/_data/videos/uJNFaDsIByY_1.yml
+++ b/_data/videos/uJNFaDsIByY_1.yml
@@ -1,6 +1,6 @@
 title: "Awkward Array: Pandas"
 speaker: Michael Hedges
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-04-17
 startsec: 1611

--- a/_data/videos/uJNFaDsIByY_2.yml
+++ b/_data/videos/uJNFaDsIByY_2.yml
@@ -1,7 +1,7 @@
 title: "FCAT: Coffea"
 speaker: Lindsey Gray
 focus-area: as
-projects:
+project:
 date: 2019-04-17
 startsec: 2843
 url: https://www.youtube.com/embed/uJNFaDsIByY

--- a/_data/videos/uJNFaDsIByY_2.yml
+++ b/_data/videos/uJNFaDsIByY_2.yml
@@ -1,6 +1,6 @@
 title: "FCAT: Coffea"
 speaker: Lindsey Gray
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-04-17
 startsec: 2843

--- a/_data/videos/wPpy08ZjdNY_0.yml
+++ b/_data/videos/wPpy08ZjdNY_0.yml
@@ -1,7 +1,7 @@
 title: "Enhancements to ROOT performance benchmarking"
 speaker: Lilit Harutyunyan
 focus-area:
-projects:
+project:
 date: 2019-08-19
 startsec: 0
 url: https://www.youtube.com/embed/wPpy08ZjdNY

--- a/_data/videos/wPpy08ZjdNY_0.yml
+++ b/_data/videos/wPpy08ZjdNY_0.yml
@@ -1,6 +1,6 @@
 title: "Enhancements to ROOT performance benchmarking"
 speaker: Lilit Harutyunyan
-focus_areas:
+focus-area:
 projects:
 date: 2019-08-19
 startsec: 0

--- a/_data/videos/wPpy08ZjdNY_1.yml
+++ b/_data/videos/wPpy08ZjdNY_1.yml
@@ -1,7 +1,7 @@
 title: "Integration of ZSTD compression algorithm into ROOT"
 speaker: Alfonso Castano
 focus-area:
-projects:
+project:
 date: 2019-08-19
 startsec: 977
 url: https://www.youtube.com/embed/wPpy08ZjdNY

--- a/_data/videos/wPpy08ZjdNY_1.yml
+++ b/_data/videos/wPpy08ZjdNY_1.yml
@@ -1,6 +1,6 @@
 title: "Integration of ZSTD compression algorithm into ROOT"
 speaker: Alfonso Castano
-focus_areas:
+focus-area:
 projects:
 date: 2019-08-19
 startsec: 977

--- a/_data/videos/wPpy08ZjdNY_2.yml
+++ b/_data/videos/wPpy08ZjdNY_2.yml
@@ -1,7 +1,7 @@
 title: "AwkwardCpp"
 speaker: Charles Escott
 focus-area: as
-projects:
+project:
 date: 2019-08-19
 startsec: 2390
 url: https://www.youtube.com/embed/wPpy08ZjdNY

--- a/_data/videos/wPpy08ZjdNY_2.yml
+++ b/_data/videos/wPpy08ZjdNY_2.yml
@@ -1,6 +1,6 @@
 title: "AwkwardCpp"
 speaker: Charles Escott
-focus_areas: as
+focus-area: as
 projects:
 date: 2019-08-19
 startsec: 2390

--- a/_data/videos/wzN_rT-l1S0_0.yml
+++ b/_data/videos/wzN_rT-l1S0_0.yml
@@ -1,6 +1,6 @@
 title: "CLAD"
 speaker: Jack Qiu
-focus_areas:
+focus-area:
 projects:
 date: 2019-08-21
 startsec: 0

--- a/_data/videos/wzN_rT-l1S0_0.yml
+++ b/_data/videos/wzN_rT-l1S0_0.yml
@@ -1,7 +1,7 @@
 title: "CLAD"
 speaker: Jack Qiu
 focus-area:
-projects:
+project:
 date: 2019-08-21
 startsec: 0
 url: https://www.youtube.com/embed/wzN_rT-l1S0

--- a/_data/videos/wzN_rT-l1S0_1.yml
+++ b/_data/videos/wzN_rT-l1S0_1.yml
@@ -1,6 +1,6 @@
 title: "ROOT modules"
 speaker: Arpitha Raghunandan
-focus_areas:
+focus-area:
 projects:
 date: 2019-08-21
 startsec: 1146

--- a/_data/videos/wzN_rT-l1S0_1.yml
+++ b/_data/videos/wzN_rT-l1S0_1.yml
@@ -1,7 +1,7 @@
 title: "ROOT modules"
 speaker: Arpitha Raghunandan
 focus-area:
-projects:
+project:
 date: 2019-08-21
 startsec: 1146
 url: https://www.youtube.com/embed/wzN_rT-l1S0

--- a/_data/videos/wzN_rT-l1S0_2.yml
+++ b/_data/videos/wzN_rT-l1S0_2.yml
@@ -1,6 +1,6 @@
 title: "Fast HGCAL Simulation with Graph Networks"
 speaker: Raghav Kansal
-focus_areas:
+focus-area:
 projects:
 date: 2019-08-21
 startsec: 2614

--- a/_data/videos/wzN_rT-l1S0_2.yml
+++ b/_data/videos/wzN_rT-l1S0_2.yml
@@ -1,7 +1,7 @@
 title: "Fast HGCAL Simulation with Graph Networks"
 speaker: Raghav Kansal
 focus-area:
-projects:
+project:
 date: 2019-08-21
 startsec: 2614
 url: https://www.youtube.com/embed/wzN_rT-l1S0

--- a/_data/videos/y9eTBaVy43M_0.yml
+++ b/_data/videos/y9eTBaVy43M_0.yml
@@ -1,6 +1,6 @@
 title: "Accelerating Raw Data Analysis with ACCORDA"
 speaker: Chen Zou
-focus_areas:
+focus-area:
 projects:
 date: 2020-05-11
 startsec: 0

--- a/_data/videos/y9eTBaVy43M_0.yml
+++ b/_data/videos/y9eTBaVy43M_0.yml
@@ -1,7 +1,7 @@
 title: "Accelerating Raw Data Analysis with ACCORDA"
 speaker: Chen Zou
 focus-area:
-projects:
+project:
 date: 2020-05-11
 startsec: 0
 url: https://www.youtube.com/embed/y9eTBaVy43M

--- a/_data/videos/yjlzO5oXb1w_0.yml
+++ b/_data/videos/yjlzO5oXb1w_0.yml
@@ -1,7 +1,7 @@
 title: "pyhf Hardware Acceleration Benchmarking with CPUs and GPUs"
 speaker: Bo Zheng
 focus-area: as
-projects:
+project:
 date: 2020-08-31
 startsec: 0
 url: https://www.youtube.com/embed/yjlzO5oXb1w

--- a/_data/videos/yjlzO5oXb1w_0.yml
+++ b/_data/videos/yjlzO5oXb1w_0.yml
@@ -1,6 +1,6 @@
 title: "pyhf Hardware Acceleration Benchmarking with CPUs and GPUs"
 speaker: Bo Zheng
-focus_areas: as
+focus-area: as
 projects:
 date: 2020-08-31
 startsec: 0

--- a/_data/videos/yjlzO5oXb1w_1.yml
+++ b/_data/videos/yjlzO5oXb1w_1.yml
@@ -1,7 +1,7 @@
 title: "Track Seeding Example for ACTS"
 speaker: Peter Chatain
 focus-area: ia
-projects: acts
+project: acts
 date: 2020-08-31
 startsec: 610
 url: https://www.youtube.com/embed/yjlzO5oXb1w

--- a/_data/videos/yjlzO5oXb1w_1.yml
+++ b/_data/videos/yjlzO5oXb1w_1.yml
@@ -1,6 +1,6 @@
 title: "Track Seeding Example for ACTS"
 speaker: Peter Chatain
-focus_areas: ia
+focus-area: ia
 projects: acts
 date: 2020-08-31
 startsec: 610

--- a/_data/videos/yjlzO5oXb1w_2.yml
+++ b/_data/videos/yjlzO5oXb1w_2.yml
@@ -1,7 +1,7 @@
 title: "Language Transformations for the Awkward Array Library"
 speaker: Pratyush (Reik) Das
 focus-area:
-projects:
+project:
 date: 2020-08-31
 startsec: 1351
 url: https://www.youtube.com/embed/yjlzO5oXb1w

--- a/_data/videos/yjlzO5oXb1w_2.yml
+++ b/_data/videos/yjlzO5oXb1w_2.yml
@@ -1,6 +1,6 @@
 title: "Language Transformations for the Awkward Array Library"
 speaker: Pratyush (Reik) Das
-focus_areas:
+focus-area:
 projects:
 date: 2020-08-31
 startsec: 1351

--- a/_data/videos/yjlzO5oXb1w_3.yml
+++ b/_data/videos/yjlzO5oXb1w_3.yml
@@ -1,7 +1,7 @@
 title: "Creating an infrastructure for a CUDA backend for Awkward Arrays"
 speaker: Anish Biswas
 focus-area: as
-projects:
+project:
 date: 2020-08-31
 startsec: 2385
 url: https://www.youtube.com/embed/yjlzO5oXb1w

--- a/_data/videos/yjlzO5oXb1w_3.yml
+++ b/_data/videos/yjlzO5oXb1w_3.yml
@@ -1,6 +1,6 @@
 title: "Creating an infrastructure for a CUDA backend for Awkward Arrays"
 speaker: Anish Biswas
-focus_areas: as
+focus-area: as
 projects:
 date: 2020-08-31
 startsec: 2385

--- a/_data/videos/zNLZhlfXUNg_0.yml
+++ b/_data/videos/zNLZhlfXUNg_0.yml
@@ -1,7 +1,7 @@
 title: "Skyhook: Programmable Object Storage for Analysis"
 speaker: Jeff Lefevre
 focus-area:
-projects:
+project:
 date: 2019-04-24
 startsec: 0
 url: https://www.youtube.com/embed/zNLZhlfXUNg

--- a/_data/videos/zNLZhlfXUNg_0.yml
+++ b/_data/videos/zNLZhlfXUNg_0.yml
@@ -1,6 +1,6 @@
 title: "Skyhook: Programmable Object Storage for Analysis"
 speaker: Jeff Lefevre
-focus_areas:
+focus-area:
 projects:
 date: 2019-04-24
 startsec: 0

--- a/_data/videos/zNLZhlfXUNg_1.yml
+++ b/_data/videos/zNLZhlfXUNg_1.yml
@@ -1,7 +1,7 @@
 title: "Skyhook for query systems"
 speaker: Jim Pivarski
 focus-area:
-projects:
+project:
 date: 2019-04-24
 startsec: 1282
 url: https://www.youtube.com/embed/zNLZhlfXUNg

--- a/_data/videos/zNLZhlfXUNg_1.yml
+++ b/_data/videos/zNLZhlfXUNg_1.yml
@@ -1,6 +1,6 @@
 title: "Skyhook for query systems"
 speaker: Jim Pivarski
-focus_areas:
+focus-area:
 projects:
 date: 2019-04-24
 startsec: 1282

--- a/_includes/list_videos.html
+++ b/_includes/list_videos.html
@@ -17,7 +17,7 @@
 
 {% assign f_areas = include.focus_areas | ensure_array %}
 {% if f_areas.size > 0 %}
-  {% assign videos = all_videos | where_overlap: "focus_areas", f_areas %}
+  {% assign videos = all_videos | where_overlap: "focus-area", f_areas %}
   {% assign selected_videos = selected_videos | concat: videos %}
 {% endif %}
 

--- a/_includes/list_videos.html
+++ b/_includes/list_videos.html
@@ -5,7 +5,7 @@
 
 {% assign projects = include.projects | ensure_array %}
 {% if projects.size > 0 %}
-  {% assign videos = all_videos | where_overlap: "projects", projects %}
+  {% assign videos = all_videos | where_overlap: "project", projects %}
   {% assign selected_videos = selected_videos | concat: videos %}
 {% endif %}
 


### PR DESCRIPTION
One could argue that we should have used focus-areas and projects everywhere, but we should be consistent. (And it does allow a single item or a list, with the single item being much more common)