### PR TITLE
Add label concept to presentations

### DIFF
--- a/_data/people/SebastianMacaluso.yml
+++ b/_data/people/SebastianMacaluso.yml
@@ -18,6 +18,8 @@ presentations:
   location: Fermilab, Illinois, USA
   focus-area: ia
   project: ml4jets
+  labels:
+  - conference
 - title: 'SCAILFIN: Reproducible Open Benchmarks'
   date: 2019-06-19
   url: https://indico.cern.ch/event/822074/contributions/3471463/
@@ -36,6 +38,8 @@ presentations:
   location: Massachusetts Institute of Technology (MIT)
   focus-area: ia
   project: ml4jets
+  labels:
+  - conference
 - title: Looking into Jets with Machine Learning
   date: 2019-09-24
   url: https://phy.princeton.edu/events/pheno-vino-seminar-sebastian-macaluso-nyu-looking-jets-machine-learning-jadwin-303
@@ -92,6 +96,8 @@ presentations:
   location: Instituto de Fisica La Plata, La Plata, Argentina
   focus-area: ia
   project: ml4jets
+  labels:
+  - conference
 - title: Reframing Jet Physics in Probabilistic Terms
   date: 2021-03-01
   url: https://github.com/SebastianMacaluso/TalksSlides/blob/master/BrownBag_March2021.pdf

--- a/_data/people/beiwang2003.yml
+++ b/_data/people/beiwang2003.yml
@@ -17,6 +17,8 @@ presentations:
   location: Virtual
   focus-area: ia
   project: mkfit
+  labels:
+  - conference
 - title: Floating Point Arithmetic Is Not Real
   date: 2019-07-24
   url: https://indico.cern.ch/event/814979/contributions/3401175/attachments/1831476/3107964/FloatingPointArithmetic.pdf

--- a/_data/people/cranmer.yml
+++ b/_data/people/cranmer.yml
@@ -127,6 +127,8 @@ presentations:
   focus-area:
   - as
   - ia
+  labels:
+  - conference
 - title: The interplay between physically motivated simulations and machine learning
   date: 2019-09-09
   url: http://www.ipam.ucla.edu/programs/workshops/machine-learning-for-physics-and-the-physics-of-learning-tutorials/?tab=speaker-list
@@ -146,6 +148,8 @@ presentations:
   focus-area:
   - as
   - ia
+  labels:
+  - conference
 - title: What does the Revolution in Artificial Intelligence Mean for Physics?
   date: 2019-09-30
   url: https://ai2019.ethz.ch/program.html
@@ -164,6 +168,8 @@ presentations:
   focus-area:
   - as
   - ia
+  labels:
+  - conference
 - title: Simulation-based inference, interpretability, and experimental design
   date: 2019-10-17
   url: http://www.ipam.ucla.edu/abstract/?tid=15943&pcode=MLPWS2
@@ -174,6 +180,8 @@ presentations:
   focus-area:
   - as
   - ia
+  labels:
+  - conference
 - title: Flows three ways
   date: 2019-11-19
   url: http://pcts.princeton.edu/programs/current/deep-learning-for-physics-seminar-series/121
@@ -203,6 +211,8 @@ presentations:
   - as
   - ia
   - core
+  labels:
+  - conference
 - title: Machine Learning and Physics
   date: 2020-03-05
   url: https://indico.desy.de/indico/event/25451/
@@ -305,6 +315,8 @@ presentations:
   focus-area:
   - as
   - ia
+  labels:
+  - conference
 - title: 'Panel Discussion: A community perspective on Equity in HEP'
   date: 2020-07-09
   url: https://science.osti.gov/hep/hepap/Meetings/202007
@@ -322,6 +334,8 @@ presentations:
   focus-area:
   - as
   - ia
+  labels:
+  - conference
 - title: 'Graphs, Trees, and Sets: structured data in physics'
   date: 2020-07-17
   url: https://grlplus.github.io/schedule/
@@ -331,6 +345,8 @@ presentations:
   focus-area:
   - as
   - ia
+  labels:
+  - conference
 - title: How machine learning can help us get the most out of our highest fidelity
     physical models
   date: 2020-07-21
@@ -341,6 +357,8 @@ presentations:
   focus-area:
   - as
   - ia
+  labels:
+  - conference
 - title: Lectures on Statistics
   date: 2020-08-10
   url: https://indico.fnal.gov/event/22840/
@@ -425,6 +443,8 @@ presentations:
   focus-area:
   - as
   - ia
+  labels:
+  - conference
 - title: Some fun examples from the intersection of machine learning and physics
   date: 2020-12-18
   url: https://virtual-event.mlinpl.org
@@ -434,6 +454,8 @@ presentations:
   focus-area:
   - as
   - ia
+  labels:
+  - conference
 - title: 'MadMiner: Machine learning–based inference for particle physics'
   date: 2021-01-11
   url: https://indico.cern.ch/event/971725/#5-madminer-machine-learning-ba
@@ -457,6 +479,8 @@ presentations:
   meetingurl: http://www.ipam.ucla.edu/programs/workshops/deep-learning-and-combinatorial-optimization/?tab=overview
   location: Institute Pure and Applied Mathematics (IPAM) (virtual)
   focus-area: ia
+  labels:
+  - conference
 - title: Machine Learning for Precision Measurements
   date: 2021-03-02
   url: https://indico.tlabs.ac.za/event/100/contributions/1727/
@@ -487,6 +511,8 @@ presentations:
   meetingurl: https://aistats.org/aistats2021/
   location: "(Virtual)"
   focus-area: as
+  labels:
+  - conference
 - title: Towards a white paper on public likelihoods
   date: 2021-04-22
   url: https://indico.cern.ch/event/1015891/attachments/2231688/3781529/Likelihood-whitepaper-RAMP-2021.pdf
@@ -503,6 +529,8 @@ presentations:
   focus-area:
   - as
   - ia
+  labels:
+  - conference
 - title: Analysis Systems Overview
   date: 2021-04-27
   url: https://indico.cern.ch/event/957103/contributions/4330981/

--- a/_data/people/davidlange6.yml
+++ b/_data/people/davidlange6.yml
@@ -44,6 +44,8 @@ presentations:
   meetingurl: https://indico.cern.ch/event/831165/
   focus-area: ia
   project:
+  labels:
+  - conference
 - title: Innovative Algorithms - Years 3, and 4+5
   meeting: IRIS-HEP team retreat
   url: https://indico.cern.ch/event/896167/contributions/3870074/attachments/2044699/3426314/IA_retreat_day1_6.pdf

--- a/_data/people/dcraik.yml
+++ b/_data/people/dcraik.yml
@@ -24,6 +24,8 @@ presentations:
   location: Madison, WI
   focus-area: ia
   project: allen
+  labels:
+  - conference
 - title: The Allen Project
   date: 2020-01-27
   meeting: IRIS-HEP Topical Meeting
@@ -46,3 +48,5 @@ presentations:
   url: https://slideslive.com/38926198/autoencoders-for-compression-and-simulation-in-particle-physics
   focus-area: ia
   project: allen
+  labels:
+  - conference

--- a/_data/people/heather-gray.yml
+++ b/_data/people/heather-gray.yml
@@ -15,6 +15,8 @@ presentations:
   url: https://indico.cern.ch/event/948465/
   focus-area: ia
   project: acts
+  labels:
+  - conference
 - title: 'IRIS-HEP Report: Innovative Algorithms'
   date: 2020-08-11
   meeting: Snowmass Computational Frontier Workshop
@@ -30,6 +32,8 @@ presentations:
   url: https://www.ml4science.org/agenda-physics-in-ml
   focus-area: ia
   project:
+  labels:
+  - conference
 - title: IRIS-HEP Innovative Algorithms
   date: 2019-02-06
   url: https://indico.cern.ch/event/790759/contributions/3284633/subcontributions/271529/attachments/1791453/2919650/Innovative_Algorithms_3.pdf
@@ -44,6 +48,8 @@ presentations:
   meetingurl: http://www.icepp.s.u-tokyo.ac.jp/symposium/25/timetable.html
   focus-area: ia
   project:
+  labels:
+  - conference
 - title: Ambiguity Resolution Studies with ACTS
   date: 2019-01-13
   url: https://indico.physics.lbl.gov/indico/event/712/contributions/3021/attachments/1761/2138/go

--- a/_data/people/heikomuller.yml
+++ b/_data/people/heikomuller.yml
@@ -34,3 +34,5 @@ presentations:
   focus-area:
   - ia
   - core
+  labels:
+  - conference

--- a/_data/people/henryiii.yml
+++ b/_data/people/henryiii.yml
@@ -36,6 +36,8 @@ presentations:
   location: Valencia, Spain
   focus-area: ia
   project: pv-finder
+  labels:
+  - conference
 - title: 'Conda: a complete reproducible ROOT environment in under 5 minutes'
   date: 2019-03-21
   url: https://indico.cern.ch/event/759388/contributions/3306849/
@@ -52,6 +54,8 @@ presentations:
   location: Jefferson Lab
   focus-area: ia
   project: pv-finder
+  labels:
+  - conference
 - title: A hybrid deep learning approach to vertexing
   date: 2019-03-11
   url: https://indico.cern.ch/event/708041/contributions/3269692/attachments/1809272/2954230/PvFinder_ACAT2019.pdf

--- a/_data/people/marianstahl.yml
+++ b/_data/people/marianstahl.yml
@@ -24,3 +24,5 @@ presentations:
   date: 2020-04-20
   focus-area: ia
   project: pv-finder
+  labels:
+  - conference

--- a/_data/people/slava77.yml
+++ b/_data/people/slava77.yml
@@ -24,6 +24,8 @@ presentations:
   location: Mexico City, Mexico
   focus-area: ia
   project: mkfit
+  labels:
+  - conference
 - title: Update on mkFit developments
   date: 2019-12-16
   url: https://indico.cern.ch/event/869552/contributions/3669454

--- a/_data/people/xiaocong-ai.yml
+++ b/_data/people/xiaocong-ai.yml
@@ -49,6 +49,8 @@ presentations:
   meetingurl: https://indico.cern.ch/event/831165/
   focus-area: ia
   project: acts
+  labels:
+  - conference
 - title: Track fitting/finding with ACTS
   date: 2020-02-19
   url: https://indico.cern.ch/event/889047/contributions/3749030/attachments/1990315/3319040/IRIS_HEP_topical_meeting_Xiaocong.pdf


### PR DESCRIPTION
I want to automate a IA metric computation, which needs to separate talks at conferences from talks in other venues (eg, collaboration meetings). So far this information is not used except in a script; but it could be used as a flexible system for adding attributes.