### PR TITLE
add strawman for fellow pictures/project links on focus area pages

### DIFF
--- a/_layouts/focus-area.html
+++ b/_layouts/focus-area.html
@@ -36,6 +36,24 @@
 </div>
 {% endif %}
 
+{% assign fa_fellows = site.pages | sort_natural: 'title' | where_exp: "item", "item.pagetype == 'fellow'" | where_exp: "item", "item.focus-area contains page_focus_area" %}
+{% if fa_fellows.size > 0 %}
+<h2 class="alt-h2 text-center mb-3 mt-lg-6" id="pres">Current and Previous {{page.short_title | upcase }} Fellows</h2>
+
+<div class="container-fluid">
+  <div class="row">
+    {% for person in fa_fellows %}
+    <div class="card" style="font-size:10px;width: 87px;height: 135px;margin-bottom:-15px;">
+      <img style="width: 85px;height: 85px; object-fit:cover;" src="{{person.photo}}"  alt="Card image cap">
+        <a href="{{person.permalink}}">{{ person.fellow-name }}</a>
+      </div>
+    {% endfor %}
+  </div>
+  <br>
+</div>
+{% endif %}
+
+
 {% if sorted.size > 0 %}
 <div class="container-fluid projects">
   <h2 class="alt-h2 text-center mb-3 mt-lg-6" id="projects">{{ page.short_title | upcase }} Projects</h2><br>

--- a/_layouts/focus-area.html
+++ b/_layouts/focus-area.html
@@ -36,7 +36,7 @@
 </div>
 {% endif %}
 
-{% assign fa_fellows = site.pages | sort_natural: 'title' | where_exp: "item", "item.pagetype == 'fellow'" | where_exp: "item", "item.focus-area contains page_focus_area" %}
+{% assign fa_fellows = site.pages | sort_natural: 'title' | where_exp: "item", "item.pagetype == 'fellow' and item.focus-area contains page_focus_area" %}
 {% if fa_fellows.size > 0 %}
 <h2 class="alt-h2 text-center mb-3 mt-lg-6" id="pres">Current and Previous {{page.short_title | upcase }} Fellows</h2>
 
@@ -137,5 +137,4 @@
   {% include_cached layout_analytics.html %}
   </body>
 </html>
-
 

--- a/pages/fellows/Abdelrahman-Elabd.md
+++ b/pages/fellows/Abdelrahman-Elabd.md
@@ -13,6 +13,7 @@ photo: /assets/images/team/Abdelrahman-Elabd.jpg
 institution: University of Pennsylvania
 e-mail: aelabd@sas.upenn.edu
 project_title: Creating a Python Front-End for HLS Implementation of GNNs on FPGA
+focus-area: ia
 project_goal: >
    FPGA-implementation of GNN particle-tracking algorithms can reduce latency to the speeds necessary for tracking at the LHC, but the catch is that FPGA/HLS design is time and effort intensive. This hinders the speed with which we can implement and test new GNN structures and training paradigms. This project proposes to develop a Python front-end which converts trained pytorch.geometric GNN models into identical HLS representations, and to integrate this functionality into the hls4ml toolkit. This functionality will allow us to keep up with new developments in GNNs such as quantization-aware training, which may further reduce latency and resource usage while providing less lossiness than post-training quantization.
 mentors:

--- a/pages/fellows/AlanAneethJegaraj.md
+++ b/pages/fellows/AlanAneethJegaraj.md
@@ -7,6 +7,7 @@ title: Alan Aneeth Jegaraj - IRIS-HEP Fellow
 fellow-name: Alan Aneeth Jegaraj
 shortname: Alan
 project_title: Matrix Factorization for Primary Vertex Reconstruction in LHCb
+focus-area: ia
 dates:
   start: 2020-06-01
   end: 2020-08-31

--- a/pages/fellows/Ali-Hariri.md
+++ b/pages/fellows/Ali-Hariri.md
@@ -13,6 +13,7 @@ photo: /assets/images/team/Ali_Hariri.jpg
 institution: University of Alabama
 e-mail: hariri.ali961@gmail.com
 project_title: Graph Generative Models For Fast Detector Simulations in Particle Physics
+focus-area:
 project_goal: >
   The Large Hadron Collider (LHC) at CERN is the world’s highest energy particle accelerator,
   delivering the highest energy proton-proton collisions ever recorded in the

--- a/pages/fellows/AneeshHeintz.md
+++ b/pages/fellows/AneeshHeintz.md
@@ -52,6 +52,7 @@ website:
 e-mail: ah2263@cornell.edu
 
 project_title: Implementation of graph neural networks on CPU + FPGA co-processors for scalable track reconstruction tasks
+focus-area: ia
 
 
 project_goal: >

--- a/pages/fellows/AnishBiswas.md
+++ b/pages/fellows/AnishBiswas.md
@@ -7,6 +7,7 @@ title: Anish Biswas - IRIS-HEP Fellow
 fellow-name: Anish Biswas
 shortname: Anish
 project_title: Enabling auto-differentiation for Awkward Array functions
+focus-area:
 dates:
   start: 2021-01-09
   end: 2021-04-03

--- a/pages/fellows/AryanRoy.md
+++ b/pages/fellows/AryanRoy.md
@@ -7,6 +7,7 @@ title: Aryan Roy - IRIS-HEP Fellow
 fellow-name: Aryan Roy
 shortname: Aryan
 project_title: Modernizing FastJet Interfaces With pybind11 and interfacing with Awkward Arrays
+focus-area:
 dates:
   start: 2021-04-04
   end: 2021-08-30

--- a/pages/fellows/BaidyanathKundu.md
+++ b/pages/fellows/BaidyanathKundu.md
@@ -7,6 +7,7 @@ title: Baidyanath Kundu - IRIS-HEP Fellow
 fellow-name: Baidyanath Kundu
 shortname: Baidyanath
 project_title: Reading CMS Run 1/2 miniAOD files with ServiceX and func_adl
+focus-area:
 dates:
   start: 2021-02-01
   end: 2021-04-30

--- a/pages/fellows/BoZheng.md
+++ b/pages/fellows/BoZheng.md
@@ -7,6 +7,7 @@ title: Bo Zheng - IRIS-HEP Fellow
 fellow-name: Bo Zheng
 shortname: Bo
 project_title: pyhf Hardware Acceleration Benchmarking with GPUs and TPUs
+focus-area:
 dates:
   start: 2020-06-01
   end: 2020-08-31

--- a/pages/fellows/BrianCruz.md
+++ b/pages/fellows/BrianCruz.md
@@ -7,6 +7,7 @@ title: Brian Cruz - IRIS-HEP Fellow
 fellow-name: Brian Cruz
 shortname: Brian
 project_title: Translating analyses into prototype analysis systems
+focus-area:
 dates:
   start: 2021-01-11
   end: 2021-06-11

--- a/pages/fellows/CaitlinPatterson.md
+++ b/pages/fellows/CaitlinPatterson.md
@@ -6,6 +6,7 @@ active: true
 title: Caitlin Patterson - IRIS-HEP Fellow
 fellow-name: Caitlin Patterson
 project_title: Scaling up implementations of GNNs with FPGA co-processors for charged particle track reconstruction
+focus-area: ia
 dates:
   start: 2021-01-01
   end: 2021-06-30

--- a/pages/fellows/EdVanBruggen.md
+++ b/pages/fellows/EdVanBruggen.md
@@ -14,6 +14,7 @@ institution: University of Washington, Seattle
 website: https://edryd.org
 e-mail: edvb@uw.edu
 project_title: Expanding Subworkflow Catalog of RECAST-wf For Event Generators
+focus-area:
 project_goal: >
     RECAST is a framework for reinterpreting LHC analyses using Yadage computational workflows.  These workflows can be run on the researcher’s own computer or through the cloud application REANA RECAST-workflow builds on RECAST in order to run truth-level reinterpretations which achieve much faster results by sacrificing complexity.  It also allows for workflows to be modularized through subworkflows which encapsulate each step (generation, selection, analysis).  The goal of this project is to improve the command line usability and documentation, improve MadGraph integration to support custom models, and add the additional event generators Sherpa and Herwig.
 mentors:

--- a/pages/fellows/ErikWallin.md
+++ b/pages/fellows/ErikWallin.md
@@ -7,6 +7,7 @@ title: Erik Wallin - IRIS-HEP Fellow
 fellow-name: Erik Wallin
 shortname: ewallin
 project_title: zfp Compression for HEP Data
+focus-area:
 dates:
   start: 2020-06-01
   end: 2020-08-31

--- a/pages/fellows/FaroukMokhtar.md
+++ b/pages/fellows/FaroukMokhtar.md
@@ -14,6 +14,7 @@ institution: University of California, San Diego
 website:
 e-mail: fmokhtar@ucsd.edu
 project_title: GPU-accelerated Machine-learned Particle-flow Reconstruction
+focus-area:
 project_goal: >
     An important core software algorithm of the LHC is the particle-flow (PF) reconstruction algorithm, which takes disparate types of tracks and clusters reconstructed from different subdetectors and returns a list of final-state PF candidates. The nature of this task motivates the exploration of highly parallelizable machine learning (ML) models that are easier to accelerate with heterogeneous computing resources, such as GPUs and FPGAs, which gives them an advantage over traditional PF algorithms. This project proposes to apply state-of-the-art ML techniques, mainly graph neural networks (GNNs), which learn from non-Euclidean structured data, to the task of PF reconstruction in CMS and for LHC detectors more generally. Concrete deliverables of the project include providing publicly-available ML models for PF reconstruction and benchmarking their physics and computational performance on open datasets with coprocessing accelerators.
 mentors:

--- a/pages/fellows/GarimaSingh.md
+++ b/pages/fellows/GarimaSingh.md
@@ -7,6 +7,7 @@ title: Garima Singh- IRIS-HEP Fellow
 fellow-name: Garima Singh
 shortname: Garima
 project_title: Floating Point Error Evaluation With Clad
+focus-area: ia
 dates:
   start: 2021-01-11
   end: 2021-05-30

--- a/pages/fellows/JeremyFerguson.md
+++ b/pages/fellows/JeremyFerguson.md
@@ -7,6 +7,7 @@ title: Jeremy Ferguson - IRIS-HEP Fellow
 fellow-name: Jeremy Ferguson
 shortname: Jeremy
 project_title: Graph Methods for Particle Tracking
+focus-area: ia
 dates:
   start: 2021-01-04
   end: 2021-06-19

--- a/pages/fellows/KaitlinSalyer.md
+++ b/pages/fellows/KaitlinSalyer.md
@@ -7,6 +7,7 @@ title: Kaitlin Salyer - IRIS-HEP Fellow
 fellow-name: Kaitlin Salyer
 shortname: Kaitlin
 project_title: AutoDQM A Machine Learning Approach to Data Quality Monitoring at CMS
+focus-area:
 dates:
   start: 2021-06-01
   end: 2021-12-31

--- a/pages/fellows/MaxOrok.md
+++ b/pages/fellows/MaxOrok.md
@@ -7,6 +7,7 @@ title: Max Orok - IRIS-HEP Fellow
 fellow-name: Max Orok
 shortname: Max
 project_title: CMSSW Generating ROOT RNTuple NanoAODs
+focus-area:
 dates:
   start: 2021-01-11
   end: 2021-07-11

--- a/pages/fellows/OmarAlterkait.md
+++ b/pages/fellows/OmarAlterkait.md
@@ -7,6 +7,7 @@ title: Omar Alterkait - IRIS-HEP Fellow
 fellow-name: Omar Alterkait
 shortname: Omar
 project_title: Offline Track Selection
+focus-area: ia
 dates:
   start: 2021-01-04
   end: 2021-06-04

--- a/pages/fellows/OrghoNeogi.md
+++ b/pages/fellows/OrghoNeogi.md
@@ -7,6 +7,7 @@ title: Orgho Neogi - IRIS-HEP Fellow
 fellow-name: Orgho Neogi
 shortname: Orgho
 project_title: Machine Learning inference as a Service optimization in neutrino reconstruction
+focus-area: ia
 dates:
   start: 2021-02-15
   end: 2021-08-14

--- a/pages/fellows/PeterChatain.md
+++ b/pages/fellows/PeterChatain.md
@@ -14,6 +14,7 @@ institution: Stanford University
 website: https://github.com/Pchatain
 e-mail: pchatain@stanford.edu
 project_title: Example Track Seeding Algorithm for ACTS
+focus-area: ia
 project_goal: >
   A Common Tracking Software (ACTS) is an experiment-independent project designed to leverage modern computing architecture to reconstruct particle paths in HEP experiments. My goal is to create an example track seeding algorithm for ACTS. Once that is complete, I will work on testing and implementing track seeding algorithms.
 proposal: /assets/pdf/Project_Proposal_Peter_Chatain.pdf

--- a/pages/fellows/RaghavKansal.md
+++ b/pages/fellows/RaghavKansal.md
@@ -13,6 +13,7 @@ photo: /assets/images/team/Raghav-Kansal.jpg
 institution: University of California, San Diego
 website: https://github.com/raghsthebest/
 e-mail: NoEmailYet
+focus-area: ia
 
 project_goal: >
   High granular calorimeters will be the biggest novelty of the CMS Phase II upgrade and, in general,

--- a/pages/fellows/SammyEdwards.md
+++ b/pages/fellows/SammyEdwards.md
@@ -13,6 +13,7 @@ photo: /assets/images/team/Sammy-Edwards.jpg
 institution: University of Wisconsin - Platteville
 e-mail: sam@reddan.net
 project_title: Analyzing Neutrino Interactions
+focus-area: ia
 project_goal: >
  When neutrinos interact with each other, the result is close to a pixelated image. Once the image comes through it
  can be broken down and analyzed, and then put back together. This project will develop an algorithm to help

--- a/pages/fellows/SantamRC.md
+++ b/pages/fellows/SantamRC.md
@@ -13,6 +13,7 @@ photo: /assets/images/team/Santam-Roy-Choudhury.jpg
 institution: National Institute of Technology, Durgapur
 e-mail: santamdev404@gmail.com
 project_title: Automating Awkward Array Testing
+focus-area:
 project_goal: >
     Awkward Array is a popular library for nested, variable-sized data, including
     arbitrary-length lists, records, mixed types, and missing data, using NumPy-like idioms.

--- a/pages/fellows/SeanCondon.md
+++ b/pages/fellows/SeanCondon.md
@@ -7,6 +7,7 @@ title: Sean Condon - IRIS-HEP Fellow
 fellow-name: Sean Condon
 shortname: Sean
 project_title: Developing selection algorithms to reduce output data rate from the Large Hadron Collider
+focus-area: ia
 dates:
   start: 2020-06-01
   end: 2020-08-31

--- a/pages/fellows/ShravanChaudhari.md
+++ b/pages/fellows/ShravanChaudhari.md
@@ -13,6 +13,7 @@ photo: /assets/images/team/Shravan-Chaudhari.jpg
 institution: Birla Institute of Technology and Science Pilani
 e-mail: f20170736@goa.bits-pilani.ac.in
 project_title: Accelerating End-to-End Deep Learning Reconstruction using Graph Neural Networks.
+focus-area:
 project_goal: >
    Currently, most of the machine learning based particle identification techniques developed by the CMS and ATLAS experiments rely on the inputs provided by the Particle Flow (PF) algorithms to convert detector level information to physics objects. Despite the very high reconstruction efficiency of PF algorithms, some physics objects fail to be reconstructed, reconstruct imperfectly or they exist as fakes. The end-to-end deep learning technique combines deep learning algorithms and low level detector representation of collision events. This project aims to implement graph neural network (GNN) based deep learning approaches to perform end-to-end tau identification. Furthermore, the developed GNN algorithm will be integrated with the existing CMS Software (CMSSW) based end-to-end deep learning framework (E2EFW).
 mentors:

--- a/pages/fellows/SuhaibShaikh.md
+++ b/pages/fellows/SuhaibShaikh.md
@@ -14,6 +14,7 @@ institution: University of Nebraska - Lincoln
 website:
 e-mail:
 project_title: Proactive Site Monitoring
+focus-area:
 project_goal: "Researchers using the OSG rely on the stability of resources in order to accomplish their science.  The OSG’s GRACC accounting service collects usage information for all sites contributing to and all jobs that run on the OSG.  The accounting service is a large source of information on the OSG.  The accounting data is stored within an ElasticSearch database at UNL.  Monitoring using this accounting service exists that will alert when a site completely fails, but there is no alerting on a decrease in functionality of a site. My project would be to develop proactive site monitoring to alert on site issues detected from the GRACC accounting system.  The alert would run periodically on OSG resources."
 mentors:
   - djw8605

--- a/pages/fellows/ThomasShearer.md
+++ b/pages/fellows/ThomasShearer.md
@@ -7,6 +7,7 @@ title: Thomas Shearer - IRIS-HEP Fellow
 fellow-name: Thomas Shearer
 shortname: Tommy
 project_title: Improving the User Interface to OSG-LHC Network Metrics
+focus-area:
 dates:
   start: 2020-05-01
   end: 2020-08-31

--- a/pages/fellows/VarunSreenivasan16.md
+++ b/pages/fellows/VarunSreenivasan16.md
@@ -13,6 +13,7 @@ photo: /assets/images/team/Varun-Sreenivasan.jpg
 institution: University of Wisconsin-Madison
 e-mail: vsreenivasan@wisc.edu
 project_title: Graph Methods for Particle Tracking
+focus-area: ia
 project_goal: >
     Use Machine Learning and domain knowledge to adapt Nearest Neighbors algorithm for efficient graph construction. Developing this solution will pave the way for achieving enhancements in the particle track reconstruction process.
 mentors:

--- a/pages/fellows/VesalRazavimaleki.md
+++ b/pages/fellows/VesalRazavimaleki.md
@@ -14,6 +14,7 @@ institution: University of California, San Diego
 website:
 e-mail: vrazavim@ucsd.edu
 project_title: Adapting GNN Tracking for FPGAs with hls4ml
+focus-area: ia
 project_goal: >
     Graph neural networks (GNNs) have demonstrated promise for pattern recognition problems like particle tracking. To meet the demands of the planned HL-LHC, there has been increased interest in accelerating large machine learning (ML) models with FPGA coprocessors for integration into the L1 trigger. Deployment of neural networks on FPGAs has been studied with the hls4ml compiler package which uses high-level synthesis to convert ML models to FPGA firmware. This project proposes to expand the hls4ml toolkit to support GNNs for particle tracking, allowing them to be implemented in FPGA coprocessor applications possibly including the L1 trigger.
 mentors:

--- a/pages/fellows/XiongfengSong.md
+++ b/pages/fellows/XiongfengSong.md
@@ -7,6 +7,7 @@ title: Xiongfeng Song - IRIS-HEP Fellow
 fellow-name: Xiongfeng Song
 shortname: Xiongfeng
 project_title: Implement Skyhook row index filter operation, Awkward list in-storage operations and Coffea processor/executor
+focus-area:
 dates:
   start: 2020-06-01
   end: 2020-08-31

--- a/pages/fellows/dwliu.md
+++ b/pages/fellows/dwliu.md
@@ -7,6 +7,7 @@ title: David Liu - IRIS-HEP Fellow
 fellow-name: David Liu
 shortname: dwliu
 project_title: Verification of the Fidelity of ServiceX Data Set Extractions Using Python and C++
+focus-area:
 dates:
   start: 2020-05-01
   end: 2020-09-30

--- a/pages/fellows/etsai.md
+++ b/pages/fellows/etsai.md
@@ -6,6 +6,7 @@ active: true
 title: Emily Tsai - IRIS-HEP Fellow
 fellow-name: Emily Tsai
 project_title: OpenCL based implementation of graph neural networks on FPGA
+focus-area: ia
 dates:
   start: 2021-01-11
   end: 2021-05-28

--- a/pages/fellows/nupuroza.md
+++ b/pages/fellows/nupuroza.md
@@ -13,6 +13,7 @@ photo: /assets/images/team/Nupur-Oza.JPG
 institution: University of Pennsylvania
 e-mail: nupoza@sas.upenn.edu
 project_title: Implementation of ML algorithms for ambiguity resolution in ACTS track reconstruction
+focus-area:
 project_goal: >
     The high-pileup of collisions associated with the upgrade of the HL-LHC will offer serious computational limitations to particle tracking. ACTS, an experiment independent tool for track reconstruction, is especially CPU-expensive in its ambiguity solving step. To mitigate this, this project seeks to implement ML-based algorithms for ambiguity solving and final track resolution within ACTS.
 mentors:

--- a/pages/fellows/rfarkas.md
+++ b/pages/fellows/rfarkas.md
@@ -14,6 +14,7 @@ institution: Universität Bonn (Germany)
 website:
 e-mail: ralf.farkas@uni-bonn.de
 project_title: Combinatorial Kalman Filter for the ACTS tracking software
+focus-area: ia
 project_goal: >
   The reconstruction of trajectories of charged particles is a crucial task for most HEP experiments. The ACTS (A Common Tracking Software) aims to provide an experiment-independent suite of tools that enable future high-energy particle physics experiments to implement their full track reconstruction chain. I will be working on the implementation and validation of a Combinatorial Kalman Filter (CKF) in the ACTS framework.
 mentors:

--- a/pages/fellows/shuoliu.md
+++ b/pages/fellows/shuoliu.md
@@ -14,6 +14,7 @@ institution: Columbia University in the City of New York
 website:
 e-mail: sl4921@columbia.edu
 project_title: Histograms Using Numba
+focus-area:
 project_goal: >
     Recent developments in Scikit-HEP libraries have enabled efficient histogramming powered by boost-histogram and fitting into a larger ecosystem of users. Numba is a high-performance Python compiler that uses the industry-standard LLVM compiler library. To enable a fully Numba-enabled event loop for analyses, histogramming step needs to be implemented. In this summer, I will investigate ways to enable boost-histogram’s histogramming fill from inside the LLVM Numba loop without stepping through Python.
 mentors:

--- a/pages/fellows/toyamaza.md
+++ b/pages/fellows/toyamaza.md
@@ -14,6 +14,7 @@ institution: University of California, Berkeley
 website:
 e-mail: tomohiro.yamazaki@cern.ch
 project_title: ACTS integration into the ATLAS reconstruction software
+focus-area: ia
 project_goal: >
   The track reconstruction is the most time-consuming part of the ATLAS reconstruction software, and the HL-LHC upgrade requires significant innovation to perform tracking in the high pile-up environment. A Common Tracking Software (ACTS) is an open-source project developing an experiment-independent set of track reconstruction tools. This project aims to integrate ACTS into the ATLAS reconstruction software and evaluate the ACTS (Combined) Kalman Filter tracking performance with the ATLAS ITk detector layout.
 mentors:

--- a/pages/fellows/trivm963.md
+++ b/pages/fellows/trivm963.md
@@ -14,6 +14,7 @@ institution: University of Michigan, Ann Arbor
 website:
 e-mail: trivm@umich.edu
 project_title: Creating a User Interface to Analyse Network Topology
+focus-area:
 project_goal: >
     The LHC-OSG Network Monitoring Area gathers and makes accessible various network metrics related to network performance in order to debug complex network  problems more effectively. This is a unique dataset with continuous measurements of thousands of research and education network paths. It can be challenging to identify network problems and, more importantly, their location. The goal of my project is to create a network topology analysis web interface to aid with debugging and localizing network performance issues. This will be mostly focussed on path analysis: finding commonalities between paths, finding paths that contain a given address, correlating paths with other network metrics, and the degree of path symmetry.
 mentors:

--- a/pages/fellows/vovechkin.md
+++ b/pages/fellows/vovechkin.md
@@ -14,6 +14,7 @@ institution: University of Washington, Seattle
 website: http://vladov3000.com/
 e-mail: vladov@uw.edu
 project_title: Integrating MadAnalysis and pyhf into Recast-workflow
+focus-area:
 project_goal: >
     Recast-workflow is able to quickly construct new truth-level reinterpretations to determine which regions of phase space would be interesting for a full reinterpretation that is much more computationally expensive and difficult to make. It accomplishes this by simplyifing the process to 3 steps: generation, selection, and analysis. Recast-cli (command line interface for Recast-workflow) has been previously developed to provide a user interface for creating and executing new workflows compromised of several different combinations of options for each step. In RECAST-workflow’s current state, the workflows only run on the user’s local machine using RECAST-cli. The goal of this project is three fold: add new options for the selection step of RECAST-workflow besides Rivet (e.g. MadAnalsyis), add alternative statistical tools (e.g. pyhf), and to run the workflows in REANA on the cloud.
 mentors:

--- a/pages/fellows/zche.md
+++ b/pages/fellows/zche.md
@@ -7,6 +7,7 @@ title: Zora Che - IRIS-HEP Fellow
 fellow-name: Zora Che
 shortname: Zora
 project_title: Scaling Coffea-Casa Analysis Facility
+focus-area:
 dates:
   start: 2021-01-01
   end: 2021-05-31


### PR DESCRIPTION
I added a focus-area attribute to fellows, and filled it in for the IA fellows. (I can do others but would need a mapping..)

After this PR, the IA page looks like this (the links point to the fellow page)
![image](https://user-images.githubusercontent.com/5042883/117696299-708c9d00-b1c1-11eb-8d8f-b8187351174c.png)
