### PR TITLE
fix: filter on active

### DIFF
--- a/_layouts/focus-area.html
+++ b/_layouts/focus-area.html
@@ -16,7 +16,7 @@
 {% assign page_focus_area = page.name | basename %}
 {% assign sorted = site.pages | where: "pagetype", "project" | where_exp: "item", "item.focus-area contains page_focus_area" | smart_title_sort %}
 
-{% assign fa_team = site.data.people | where_exp: "item", "item.focus-area contains page_focus_area and item.active" | last_name_sort: "name" %}
+{% assign fa_team = site.data.people | where_exp: "item", "item.focus-area contains page_focus_area and item.active and item.hidden != true" | last_name_sort: "name" %}
 
 {% if fa_team.size > 0 %}
 <div class="container-fluid">

--- a/_layouts/focus-area.html
+++ b/_layouts/focus-area.html
@@ -16,7 +16,7 @@
 {% assign page_focus_area = page.name | basename %}
 {% assign sorted = site.pages | where: "pagetype", "project" | where_exp: "item", "item.focus-area contains page_focus_area" | smart_title_sort %}
 
-{% assign fa_team = site.data.people | where_exp: "item", "item.focus-area contains page_focus_area" %}
+{% assign fa_team = site.data.people | where_exp: "item", "item.focus-area contains page_focus_area and item.active" | last_name_sort: "name" %}
 
 {% if fa_team.size > 0 %}
 <div class="container-fluid">

--- a/_plugins/checkusers.rb
+++ b/_plugins/checkusers.rb
@@ -29,11 +29,11 @@ module Checks
         person.print_warnings
 
         if person_hash['hidden']
-          msg = "#{name} is listed in a university and hidden is True"
-          raise StandardError, msg if people_in_inst.include? person_hash['shortname']
+          msg = 'is listed in a university and hidden is True'
+          person.raise_err msg if people_in_inst.include? person_hash['shortname']
         else
-          msg = "#{name} is not listed in a university and hidden is not True"
-          raise StandardError, msg unless people_in_inst.include? person_hash['shortname']
+          msg = 'is not listed in a university and hidden is not True'
+          person.raise_err msg unless people_in_inst.include? person_hash['shortname']
         end
       end
     end

--- a/_plugins/filters.rb
+++ b/_plugins/filters.rb
@@ -54,6 +54,14 @@ module IrisHep
       input.select { |v| ensure_array(v[key]).to_set.intersect? values.to_set }
     end
 
+    # Sort "First ..., Last" by "last, first, ..."
+    def last_name_sort(input, key)
+      input.sort_by do |v|
+        vals = v[key].downcase.split
+        vals[-1..-1] + vals[0..-2]
+      end
+    end
+
     # Print to console
     def puts(input, msg = '')
       print "#{msg} #{input}\n"

--- a/pages/about/team.md
+++ b/pages/about/team.md
@@ -5,32 +5,17 @@ title: Institute Team
 ---
 
 {% include institution_list.html %}
+{% assign univs = institution_list | hash_fetch: site.data.universities %}
 
 <h1>Full Team</h1><br>
 
 <div class="container-fluid">
   <div class="row">
-    {% for uniindex in institution_list %}
-      {%- assign univ = site.data.universities[uniindex] -%}
+    {% for univ in univs %}
+      {% assign members = univ.personnel | hash_fetch: site.data.people | where_exp:"item", "item.active" | last_name_sort: "name" %}
 
-      {%- assign sorted_mapping = "" | split:"," -%}
-      {%- for memberid in univ.personnel -%}
-        {%- assign member = site.data.people[memberid] -%}
-        {%- assign sortable_name = member.name | split:" " | reverse | join:" " -%}
-        {%- capture item -%}
-          {{sortable_name}};{{memberid}}
-        {%- endcapture -%}
-        {%- assign sorted_mapping = sorted_mapping | push: item -%}
-      {%- endfor -%}
-      {%- assign sorted_people = sorted_mapping | sort -%}
-
-      {% for member in sorted_people %}
-           {%- assign item = member | split:";" -%}
-           {%- assign item = item[1] -%}
-           {% assign person = site.data.people[item] %}
-           {% if person.active %}
-           {% include standard_person_card.md person=person %}
-           {% endif %}
+      {% for person in members %}
+        {% include standard_person_card.md person=person %}
       {% endfor %}
     {% endfor %}
   </div>
@@ -41,28 +26,11 @@ title: Institute Team
 
 <div class="container-fluid">
   <div class="row">
-    {% for uniindex in institution_list %}
-      {%- assign univ = site.data.universities[uniindex] -%}
+    {% for univ in univs %}
+      {% assign members = univ.personnel | hash_fetch: site.data.people | where_exp: "item", "item.active == nil or item.active == false" | last_name_sort: "name" %}
 
-      {%- assign sorted_mapping = "" | split:"," -%}
-      {%- for memberid in univ.personnel -%}
-        {%- assign member = site.data.people[memberid] -%}
-        {%- assign sortable_name = member.name | split:" " | reverse | join:" " -%}
-        {%- capture item -%}
-          {{sortable_name}};{{memberid}}
-        {%- endcapture -%}
-        {%- assign sorted_mapping = sorted_mapping | push: item -%}
-      {%- endfor -%}
-      {%- assign sorted_people = sorted_mapping | sort -%}
-
-      {% for member in sorted_people %}
-           {%- assign item = member | split:";" -%}
-           {%- assign item = item[1] -%}
-           {% assign person = site.data.people[item] %}
-           {% if person.active and person.active == true %}
-           {% else %}
-           {% include standard_person_card.md person=person %}
-           {% endif %}
+      {% for person in members %}
+        {% include standard_person_card.md person=person %}
       {% endfor %}
     {% endfor %}
   </div>

--- a/pages/about/team.md
+++ b/pages/about/team.md
@@ -12,7 +12,7 @@ title: Institute Team
 <div class="container-fluid">
   <div class="row">
     {% for univ in univs %}
-      {% assign members = univ.personnel | hash_fetch: site.data.people | where_exp:"item", "item.active" | last_name_sort: "name" %}
+      {% assign members = univ.personnel | hash_fetch: site.data.people | where_exp:"item", "item.active and item.hidden != true" | last_name_sort: "name" %}
 
       {% for person in members %}
         {% include standard_person_card.md person=person %}
@@ -27,7 +27,7 @@ title: Institute Team
 <div class="container-fluid">
   <div class="row">
     {% for univ in univs %}
-      {% assign members = univ.personnel | hash_fetch: site.data.people | where_exp: "item", "item.active == nil or item.active == false" | last_name_sort: "name" %}
+      {% assign members = univ.personnel | hash_fetch: site.data.people | where_exp: "item", "item.active == nil or item.active == false and item.hidden != true" | last_name_sort: "name" %}
 
       {% for person in members %}
         {% include standard_person_card.md person=person %}

--- a/pages/about/team.md
+++ b/pages/about/team.md
@@ -12,7 +12,9 @@ title: Institute Team
 <div class="container-fluid">
   <div class="row">
     {% for univ in univs %}
-      {% assign members = univ.personnel | hash_fetch: site.data.people | where_exp:"item", "item.active and item.hidden != true" | last_name_sort: "name" %}
+      {% assign members = univ.personnel | hash_fetch: site.data.people
+                                         | where_exp:"item", "item.active and item.hidden != true"
+                                         | last_name_sort: "name" %}
 
       {% for person in members %}
         {% include standard_person_card.md person=person %}
@@ -27,7 +29,9 @@ title: Institute Team
 <div class="container-fluid">
   <div class="row">
     {% for univ in univs %}
-      {% assign members = univ.personnel | hash_fetch: site.data.people | where_exp: "item", "item.active == nil or item.active == false and item.hidden != true" | last_name_sort: "name" %}
+      {% assign members = univ.personnel | hash_fetch: site.data.people
+                                         | where_exp: "item", "item.active == nil or item.active == false and item.hidden != true"
+                                         | last_name_sort: "name" %}
 
       {% for person in members %}
         {% include standard_person_card.md person=person %}

--- a/pages/about/team_alphabetical.md
+++ b/pages/about/team_alphabetical.md
@@ -5,38 +5,17 @@ title: Institute Team
 ---
 
 {% include institution_list.html %}
+{% assign members = site.data.people | values
+                                     | where_exp:"item", "item.active and item.hidden != true"
+                                     | last_name_sort: "name" %}
 
-
-{%- assign valid_people_ids = "" | split: "," -%}
-{%- for uniindex in institution_list -%}
-  {%- assign univ = site.data.universities[uniindex] -%}
-  {%- for memberid in univ.personnel -%}
-    {%- assign valid_people_ids = valid_people_ids | push: memberid -%}
-  {%- endfor -%}
-{%- endfor -%}
-
-
-{%- assign sorted_mapping = "," | split:"," -%}
-{%- for member in site.data.people -%}
-  {%- assign sortable_name = member[1].name | split:" " | reverse | join:" " -%}
-  {%- capture item -%}
-    {{sortable_name}};{{member[0]}}
-  {%- endcapture -%}
-  {%- assign sorted_mapping = sorted_mapping | push: item -%}
-{%- endfor -%}
-{%- assign sorted_people = sorted_mapping | sort -%}
 
 <h1>Full Team</h1><br>
 
 <div class="container-fluid">
 <div class="row">
-{% for member in sorted_people %}
-  {%- assign pair = member | split:";" -%}
-  {%- assign memberid = pair[1] -%}
-  {%- if valid_people_ids contains memberid -%}
-    {% assign person = site.data.people[memberid] %}
+{% for person in members %}
     {% include standard_person_card.md person=person %}
-  {% endif %}
 {% endfor %}
 </div>
 </div>


### PR DESCRIPTION
Working on filtering.

This should close #865 and close #870. `hidden` and `active` status now accounted for and loops removed from team, alphabetical team, and focus area pages. Standardized last name sort, too.