### PR TITLE
refactor: month lists

### DIFF
--- a/_plugins/blocks.rb
+++ b/_plugins/blocks.rb
@@ -11,11 +11,10 @@ module IrisHep
 
     def render(context)
       results = context[@variable].map do |item|
-        content = context.stack do
+        context.stack do
           context['expandable'] = item
-          super
+          "<li>#{super}</li>"
         end
-        "<li>#{content}</li>"
       end
 
       return '' if results.empty?
@@ -27,6 +26,31 @@ module IrisHep
       output + "<p>[expand]</p>\n<ul>#{results[@number..-1].join("\n")}</ul>\n<p>[/expand]</p>\n"
     end
   end
+
+  # Display a grouped-by-month listing
+  class DisplayByMonth < Liquid::Block
+    def initialize(tage_name, markup, tokens)
+      @variable, @key = markup.split
+      super
+    end
+
+    def render(context)
+      groups = context[@variable].group_by { |item| item[@key].strftime('%B, %Y') }
+
+      results = groups.map do |month_year, items|
+        listing = items.map do |item|
+          context.stack do 
+            context['display_by_month'] = item
+             "<li>#{super}</li>"
+          end
+        end
+        block = listing.join "\n"
+        "<h5>#{month_year}</h5>\n<ul>\n#{block}\n</ul>"
+      end
+      results.join("\n\n")
+    end
+  end
 end
 
 Liquid::Template.register_tag('expandable', IrisHep::ExpandableList)
+Liquid::Template.register_tag('display_by_month', IrisHep::DisplayByMonth)

--- a/_plugins/blocks.rb
+++ b/_plugins/blocks.rb
@@ -26,31 +26,6 @@ module IrisHep
       output + "<p>[expand]</p>\n<ul>#{results[@number..-1].join("\n")}</ul>\n<p>[/expand]</p>\n"
     end
   end
-
-  # Display a grouped-by-month listing
-  class DisplayByMonth < Liquid::Block
-    def initialize(tage_name, markup, tokens)
-      @variable, @key = markup.split
-      super
-    end
-
-    def render(context)
-      groups = context[@variable].group_by { |item| item[@key].strftime('%B, %Y') }
-
-      results = groups.map do |month_year, items|
-        listing = items.map do |item|
-          context.stack do 
-            context['display_by_month'] = item
-             "<li>#{super}</li>"
-          end
-        end
-        block = listing.join "\n"
-        "<h5>#{month_year}</h5>\n<ul>\n#{block}\n</ul>"
-      end
-      results.join("\n\n")
-    end
-  end
 end
 
 Liquid::Template.register_tag('expandable', IrisHep::ExpandableList)
-Liquid::Template.register_tag('display_by_month', IrisHep::DisplayByMonth)

--- a/pages/docs/webdesign.md
+++ b/pages/docs/webdesign.md
@@ -161,9 +161,20 @@ This block will make an expandable list. You give it the number of non-expanded 
 {% raw %}
 ```
 {% expandable my_array 10 %}
-- {{ expandable }}
+  {{ expandable }}
 {% endexpandable%}
 ```
 {% endraw %}
 
+#### `display_by_month` (block)
+
+This block will make a list grouped by month. You give it the array of items and the key to expand (currently an unquoted string), and this will make the list. Inside the block, you have access to the "display_by_month" item, which is the current looping item. The contents will be list items.
+
+{% raw %}
+```
+{% display_by_month my_list date %}
+  {{ display_by_month.name }} at {{ display_by_month.date }}
+{% enddisplay_by_month %}
+```
+{% endraw %}
 

--- a/pages/docs/webdesign.md
+++ b/pages/docs/webdesign.md
@@ -166,15 +166,3 @@ This block will make an expandable list. You give it the number of non-expanded 
 ```
 {% endraw %}
 
-#### `display_by_month` (block)
-
-This block will make a list grouped by month. You give it the array of items and the key to expand (currently an unquoted string), and this will make the list. Inside the block, you have access to the "display_by_month" item, which is the current looping item. The contents will be list items.
-
-{% raw %}
-```
-{% display_by_month my_list date %}
-  {{ display_by_month.name }} at {{ display_by_month.date }}
-{% enddisplay_by_month %}
-```
-{% endraw %}
-

--- a/pages/events.md
+++ b/pages/events.md
@@ -10,7 +10,6 @@ title: IRIS-HEP Events
 <br>
 Events that IRIS-HEP team members are involved in organizing, planning to participate in or otherwise interested in:
 
-<ul>
 {% assign yearlist = "2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016" | split: ", " %}
 {% assign monthlist= "12, 11, 10, 09, 08, 07, 06, 05, 04, 03, 02, 01" | split: ", " %}
 
@@ -21,34 +20,14 @@ chronological order, grouped by months
 
 {%- include get_all_events.html -%}
 
-{% for yearidx in yearlist %}
-{% for monthidx in monthlist %}
- {% assign selected_array = "" | split: "," %}
- {% for event in all_events  %}
-   {% assign eventyear = event.startdate | date: "%Y" %}
-   {% assign eventmonth = event.startdate | date: "%m" %}
-   {% if eventyear == yearidx and eventmonth == monthidx %}
-      {% assign selected_array = selected_array | push: event %}
-   {% endif %}
- {% endfor %}
-
-<ul>
-{% assign hdrprint = true %}
-{% for event in selected_array %}
-  {% if hdrprint == true %}
-    <br><h5>{{event.startdate | date: "%B, %Y"}}</h5>
-    {% assign hdrprint = false %}
-  {% endif %}
-  <li>{{event.startdate | date: "%-d %b" }}{{event.enddate | date: " - %-d %b" }}, {{event.startdate | date: "%Y" }} - <a href="{{event.meetingurl}}">{{event.name}}</a> (<i>{{event.location}}</i>)
-  {% if event.abstractdeadline != null %}
+{% display_by_month all_events startdate %}
+  {% assign event = display_by_month %}
+  {{event.startdate | date: "%-d %b" }}{{event.enddate | date: " - %-d %b" }}, {{event.startdate | date: "%Y" }} - <a href="{{event.meetingurl}}">{{event.name}}</a> (<i>{{event.location}}</i>)
+  {% if event.abstractdeadline != nil %}
     {% assign abs_date = event.abstractdeadline | date_to_long_string %}
     (Abstract deadline: {{abs_date}})
   {% endif %}
-</li>
-{% endfor %}
-</ul>
+{% enddisplay_by_month %}
 
-{% endfor %}
-{% endfor %}
-<br>
+<br/>
 

--- a/pages/events.md
+++ b/pages/events.md
@@ -20,14 +20,19 @@ chronological order, grouped by months
 
 {%- include get_all_events.html -%}
 
-{% display_by_month all_events startdate %}
-  {% assign event = display_by_month %}
-  {{event.startdate | date: "%-d %b" }}{{event.enddate | date: " - %-d %b" }}, {{event.startdate | date: "%Y" }} - <a href="{{event.meetingurl}}">{{event.name}}</a> (<i>{{event.location}}</i>)
-  {% if event.abstractdeadline != nil %}
-    {% assign abs_date = event.abstractdeadline | date_to_long_string %}
-    (Abstract deadline: {{abs_date}})
-  {% endif %}
-{% enddisplay_by_month %}
+{% assign grouping = all_events | group_by_exp: "item", "item.startdate | date: '%B, %Y'"%}
 
-<br/>
+{% for pair in grouping %}
+  <h5>{{ pair.name }}</h5>
+  <ul>
+    {% for event in pair.items %}
+      <li> {{event.startdate | date: "%-d %b" }}{{event.enddate | date: " - %-d %b" }}, {{event.startdate | date: "%Y" }} - <a href="{{event.meetingurl}}">{{event.name}}</a> (<i>{{event.location}}</i>)
+      {% if event.abstractdeadline != nil %}
+        {% assign abs_date = event.abstractdeadline | date_to_long_string %}
+        (Abstract deadline: {{abs_date}})
+      {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+{% endfor %}
 

--- a/pages/presentations/bymonth.md
+++ b/pages/presentations/bymonth.md
@@ -5,34 +5,20 @@ title: Presentations by Month
 redirect_from: "/presentations/all"
 ---
 
-{% assign sorted_presentations = site.data['sorted_presentations'] %}
+{% assign groups = site.data['sorted_presentations'] | group_by_exp: "item", "item.date | date: '%B, %Y'" %}
 
-
-<!--
-  0     1       2      3       4          5           6          7            8
-date | name | title | url | meeting | meetingurl | project | focus_area | institution
--->
 
 <h2>Presentations by the IRIS-HEP team</h2>
-{% assign prescount = 0 %}
 
-<ul>
-{% assign prev_header = "" %}
-{% for talk in sorted_presentations %}
-  {% assign talk_date = talk.date | date: "%B, %Y" %}
-  {% if prev_header != talk_date %}
-</ul>
-<h4> {{ talk_date }} </h4>
-<ul>
-    {% assign prev_header =  talk_date %}
-  {% endif %}
-
-  <li>
-    {%- include print_pres.html talk=talk -%}
-  </li>
-
-  {% assign prescount = prescount | plus: "1" %}
+{% for pair in groups %}
+  <h4> {{ pair.name }} </h4>
+  <ul>
+    {% for talk in pair.items %}
+      <li>
+        {%- include print_pres.html talk=talk -%}
+      </li>
+    {% endfor %}
+  </ul>
 {% endfor %}
-</ul>
 
-Total presentations: {{ prescount }}.
+Total presentations: {{ site.data['sorted_presentations'].size }}.

--- a/pages/topical.md
+++ b/pages/topical.md
@@ -21,14 +21,16 @@ chronological order, grouped by months
 {% endcomment %}
 
 {% include get_indico_list.html %}
-{% assign selected_array = indico_list | reverse %}
+{% assign grouping = indico_list | reverse | group_by_exp: "item", "item.startdate | date: '%B, %Y'"%}
 
-{% display_by_month selected_array startdate %}
-  {% assign event = display_by_month %}
-  {{event.startdate | date: "%-d %b" }}{{event.enddate | date: " - %-d %b" }}, {{event.startdate | date: "%Y" }} - <a href="{{event.meetingurl}}">{{event.name}}</a>
-  {% if event.youtube.size > 4 %}
-  - (<a href="{{event.youtube}}">Watch the meeting recording</a>)
-  {% endif %}
-{% enddisplay_by_month %}
-
+{% for pair in grouping %}
+  <h5>{{ pair.name }}</h5>
+  <ul>
+  {% for event in pair.items %}
+    <li> {{event.startdate | date: "%-d %b" }}{{event.enddate | date: " - %-d %b" }}, {{event.startdate | date: "%Y" }} - <a href="{{event.meetingurl}}">{{event.name}}</a>
+    {%- if event.youtube.size > 4 %} - (<a href="{{event.youtube}}">Watch the meeting recording</a>){%- endif -%}
+    </li>
+  {% endfor %}
+  </ul>
+{% endfor %}
 

--- a/pages/topical.md
+++ b/pages/topical.md
@@ -14,7 +14,6 @@ typically held Mondays 17:30 GVA and Wednesdays 18:00 GVA. Vidyo
 connections are always available and meetings are usually recorded.
 Find all topical meeting agendas
 [here](https://indico.cern.ch/category/10570/).
-<ul>
 
 {% comment %}
 Go through the list and produce a breakdown of the events in reverse
@@ -24,25 +23,12 @@ chronological order, grouped by months
 {% include get_indico_list.html %}
 {% assign selected_array = indico_list | reverse %}
 
-{% assign hdrprint = "" %}
-{% for event in selected_array %}
-  {% assign eventyear = event.startdate | date: "%Y" %}
-  {% assign eventmonth = event.startdate | date: "%m" %}
-  {% assign newprint = event.startdate | date: "%B, %Y"%}
-  {% if hdrprint != newprint %}
-    {% if hdrprint != "" %}
-      </ul>
-    {% endif %}
-    <br><h5>{{newprint}}</h5>
-    <ul>
-    {% assign hdrprint = newprint %}
-  {% endif %}
-  <li>{{event.startdate | date: "%-d %b" }}{{event.enddate | date: " - %-d %b" }}, {{event.startdate | date: "%Y" }} - <a href="{{event.meetingurl}}">{{event.name}}</a>
+{% display_by_month selected_array startdate %}
+  {% assign event = display_by_month %}
+  {{event.startdate | date: "%-d %b" }}{{event.enddate | date: " - %-d %b" }}, {{event.startdate | date: "%Y" }} - <a href="{{event.meetingurl}}">{{event.name}}</a>
   {% if event.youtube.size > 4 %}
   - (<a href="{{event.youtube}}">Watch the meeting recording</a>)
   {% endif %}
-  </li>
-{% endfor %}
-</ul>
-<br>
+{% enddisplay_by_month %}
+
 


### PR DESCRIPTION
Using `group_by_exp` instead of manually hacking in html tags and such. Found a bug with topical meetings, but already pushed that, so this is just the refactoring.