### PR TITLE
fix: protect figure class properly on pages

### DIFF
--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -5,9 +5,9 @@
 {%- endif -%}
 
 {%- if include.caption -%}
-<figure class="{{include.class | default: "right"}} caption" style="{{include.figure-style}}">
+<figure class="{{include.class | default: "right"}} caption iris-figure" style="{{include.figure-style}}">
 {%- else -%}
-<figure class="{{include.class | default: "right"}}" style="{{include.figure-style}}">
+<figure class="{{include.class | default: "right"}} iris-figure" style="{{include.figure-style}}">
 {%- endif -%}
 <a href="{{url}}">
   <img alt="{{include.alt}}" src="{{include.file}}" style="{{include.img-style}}">

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -521,11 +521,11 @@ main {
     padding-bottom: 20px;
   }
 
-  figure a img {
+  figure.iris-figure a img {
     width: 100%;
   }
 
-  figure.right {
+  figure.iris-figure.right {
     margin-left: auto;
     margin-right: auto;
     width: 90%;
@@ -536,7 +536,7 @@ main {
     }
   }
 
-  figure.center {
+  figure.iris-figure.center {
     margin-left: auto;
     margin-right: auto;
     width: 90%;
@@ -545,7 +545,7 @@ main {
     }
   }
 
-  figure.caption {
+  figure.iris-figure.caption {
     @media only screen and (min-width: 991px), only print {
       padding: 6px;
       background-color: scale-color($iris-100, $lightness:60%);
@@ -561,9 +561,6 @@ main {
       }
       margin-bottom: 6px;
     }
-  }
-  a img {
-    width: 100%;
   }
 }
 


### PR DESCRIPTION
Sadly, I finally achieved perfect badges properly highlighting their true importance, but it seems not everyone liked them! Have no idea why.

<img width="1230" alt="Screen Shot 2021-05-13 at 5 00 07 PM" src="https://user-images.githubusercontent.com/4616906/118188187-0288e580-b40e-11eb-8a32-8cb3f1d2a7f0.png">
