### PR TITLE
Add default image (logo) for twitter posts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/add_news_story.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_news_story.md
@@ -3,9 +3,9 @@
 ### Complete the checklist
 
 - [ ] Have you read [the guidelines](https://iris-hep.org/docs/add_news)?
-- [ ] Did you add `layout: irispost`, `title:`, and `postimage` (not too large, please)?
+- [ ] Did you add `layout: irispost`, `title:`, and `image` (not too large, please)?
 - [ ] Did you add `author:` (if needed)?
-- [ ] Did you add `postimage-caption:` (recommended for accessibility)?
+- [ ] Did you add `image-caption:` (recommended for accessibility)?
 - [ ] Did you add `<!--break-->` after the first paragraph or so, or add `summary:` to the front matter?
 
 You can also add a very wide image with `postbanner:` (optional). There is also a custom figure environment you can use in your article for more images.

--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ url: "http://iris-hep.org" # the base hostname & protocol for your site, e.g. ht
 twitter_username: iris_hep
 github_username:  iris-hep
 excerpt_separator: <!--more-->
+twitter-img: /assets/logos/Iris-hep-5-just-graphic.png
 
 # Build settings
 markdown: kramdown

--- a/_config.yml
+++ b/_config.yml
@@ -19,10 +19,17 @@ description: >- # this means to ignore newlines until "baseurl:"
   The Institute for Research and Innovation in Software for High Energy Physics (IRIS-HEP) has been established to meet the software and computing challenges of the planned upgrades to the Large Hadron Collider, the world's most powerful particle accelerator.  IRIS-HEP pursues R&D for the software needed to acquire, manage, process and analyze the torrent of data that will be produced by the upgrade accelerator and its detectors as part of the search for discoveries beyond the Standard Model of Particle Physics.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://iris-hep.org" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: iris_hep
+twitter:
+  username: iris_hep
 github_username:  iris-hep
 excerpt_separator: <!--more-->
-twitter-img: /assets/logos/Iris-hep-5-just-graphic.png
+logo: /assets/logos/Iris-hep-5-just-graphic.png
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      image: /assets/logos/Iris-hep-5-just-graphic.png
 
 # Build settings
 markdown: kramdown

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,6 +11,10 @@
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
 
+    {% if site.twitter-img %}
+       <meta name="twitter:image" content="{{site.url}}{{site.baseurl}}{{ site.twitter-img }}" />
+    {% endif %}
+
 {% seo %}
 
     <meta name="viewport" content="width=device-width">
@@ -35,4 +39,3 @@
   gtag('config', 'UA-127196353-1');
 </script>
 </head>
-

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,10 +11,6 @@
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
 
-    {% if site.twitter-img %}
-       <meta name="twitter:image" content="{{site.url}}{{site.baseurl}}{{ site.twitter-img }}" />
-    {% endif %}
-
 {% seo %}
 
     <meta name="viewport" content="width=device-width">

--- a/_layouts/irispost.html
+++ b/_layouts/irispost.html
@@ -19,11 +19,11 @@ layout: default
         • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author }}</span></span>
       {%- endif -%}</p>
   </header>
-  {%- if page.postimage and page.postimage != "/assets/images/default-card.png" -%}
-    {%- if page.postimage-caption -%}
-      {% include figure.html file=page.postimage alt="Post primary image" caption=page.postimage-caption %}
+  {%- if page.image and page.image != "/assets/images/default-card.png" -%}
+    {%- if page.image-caption -%}
+      {% include figure.html file=page.image alt="Post primary image" caption=page.image-caption %}
     {%- else -%}
-      {% include figure.html file=page.postimage alt="Post primary image" %}
+      {% include figure.html file=page.image alt="Post primary image" %}
     {%- endif -%}
   {%- endif -%}
 

--- a/_layouts/irispost.html
+++ b/_layouts/irispost.html
@@ -19,7 +19,7 @@ layout: default
         • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author }}</span></span>
       {%- endif -%}</p>
   </header>
-  {%- if page.postimage -%}
+  {%- if page.postimage and page.postimage != "/assets/images/default-card.png" -%}
     {%- if page.postimage-caption -%}
       {% include figure.html file=page.postimage alt="Post primary image" caption=page.postimage-caption %}
     {%- else -%}

--- a/_posts/2018-09-04-iris-hep-project-funded.md
+++ b/_posts/2018-09-04-iris-hep-project-funded.md
@@ -1,7 +1,7 @@
 ---
 layout: irispost
 title: NSF funds IRIS-HEP project to address the massive data demands from the upgraded Large Hadron Collider
-postimage: /assets/images/Tprime-200pu-PhaseII-black-arctic-main-image.jpg
+image: /assets/images/Tprime-200pu-PhaseII-black-arctic-main-image.jpg
 ---
 
 The National Science Foundation (NSF) has [launched](https://www.nsf.gov/news/news_summ.jsp?cntn_id=296456&org=NSF&from=news) the Institute

--- a/_posts/2019-04-26-uprm-ml-hackathon.md
+++ b/_posts/2019-04-26-uprm-ml-hackathon.md
@@ -1,7 +1,7 @@
 ---
 layout: irispost
 title: ML Hackathon at the University of Puerto Rico at Mayaguez
-postimage: /assets/images/posts/2019-04-26-uprm-ml-hackathon-main.jpg
+image: /assets/images/posts/2019-04-26-uprm-ml-hackathon-main.jpg
 ---
 
 The very first Machine Learning Hackathon at the Physics Department

--- a/_posts/2019-07-26-codas-hep-2019.md
+++ b/_posts/2019-07-26-codas-hep-2019.md
@@ -1,7 +1,7 @@
 ---
 layout: irispost
 title: CoDaS-HEP 2019 at Princeton University
-postimage: /assets/images/posts/2019-07-26-codas-hep-2019-main.jpg
+image: /assets/images/posts/2019-07-26-codas-hep-2019-main.jpg
 ---
 
 For the third consecutive summer, high energy physics graduate students, postdocs and instructors from across the United States, as well as from India, Italy and Switzerland, gathered at Princeton University to attend the school on Tools, Techniques and Methods for Computational and Data Science for High Energy Physics or CoDaS-HEP, held this year from July 22 to 26.

--- a/_posts/2019-08-23-usatlas-bootcamp.md
+++ b/_posts/2019-08-23-usatlas-bootcamp.md
@@ -2,8 +2,8 @@
 layout: irispost
 title: First USATLAS Bootcamp held in coordination with Software Carpentries and IRIS-HEP/FIRST-HEP
 author: Henry Schreiner
-postimage: /assets/images/posts/2019-08-23-usatlas-bootcamp-main.jpg
-postimage-caption: Teachers and students pose outside at LBNL.
+image: /assets/images/posts/2019-08-23-usatlas-bootcamp-main.jpg
+image-caption: Teachers and students pose outside at LBNL.
 postbanner: /assets/images/posts/2019-08-23-usatlas-bootcamp-class.jpg
 summary: The first USATLAS Bootcamp was a huge success. 31 students and more than 8 instructors met at the Lawrence Berkeley National Laboratory to cover four topics from both a general and experiment specific viewpoint.
 ---

--- a/_posts/2019-09-11-fastml-blueprint.md
+++ b/_posts/2019-09-11-fastml-blueprint.md
@@ -2,8 +2,8 @@
 layout: irispost
 title: Workshop on Accelerated Machine Learning and Inference (FastML)
 author: Melissa Moss and Peter Elmer
-postimage: /assets/images/20190911-fastml-georgia-karagiorgi.jpg
-postimage-caption: "Georgia Karagiorgi (Columbia University) describes the opportunities for fast machine learning for the neutrino physics program. Photo Credit: Marguerite Tonjes (FNAL)."
+image: /assets/images/20190911-fastml-georgia-karagiorgi.jpg
+image-caption: "Georgia Karagiorgi (Columbia University) describes the opportunities for fast machine learning for the neutrino physics program. Photo Credit: Marguerite Tonjes (FNAL)."
 postbanner: /assets/images/20190911-fastml-workshop-19-0152-01.jpg
 summary: "From September 10-11 at Fermi National Accelerator Laboratory (Fermilab), over 200 scientists gathered for a workshop to explore ultrafast deep learning algorithms and inference technologies, as well as the strategies driving cutting-edge ML for high energy physics."
 ---

--- a/_posts/2020-01-17-ml4jets-workshop.md
+++ b/_posts/2020-01-17-ml4jets-workshop.md
@@ -2,8 +2,8 @@
 layout: irispost
 title: Machine Learning for Jet Physics Workshop (ML4Jets)
 author: Kyle Cranmer and Robert Tuck
-postimage: /assets/images/posts/20200117-ml4jets-workshop-group-photo.jpeg
-postimage-caption: "Participants in ML4Jets Workshop. Photo Credit: Kyle Cranmer"
+image: /assets/images/posts/20200117-ml4jets-workshop-group-photo.jpeg
+image-caption: "Participants in ML4Jets Workshop. Photo Credit: Kyle Cranmer"
 postbanner: /assets/images/posts/20200117-ml4jets-workshop-room.png
 summary: "NYU Hosted the third in a series of workshops focusing on Machine Learning for Jet Physics from January 15-17, 2020. The [event](https://indico.cern.ch/event/809820/overview)
 drew more than 100 participants including experimental physicists, theoretical physicists, computer scientists, and applied mathematicians. IRIS-HEP members Kyle Cranmer and Sebastian Macaluso were the local organizers."

--- a/_posts/2020-02-17-analysis-preservation.md
+++ b/_posts/2020-02-17-analysis-preservation.md
@@ -2,8 +2,8 @@
 layout: irispost
 title: Analysis Preservation Bootcamp
 author: Lukas Heinrich and Kyle Cranmer
-postimage: /assets/images/posts/2020-02-17-preservation-reproduced-plots.jpeg
-postimage-caption: "Participants in [Analysis Preservation Bootcamp](https://indico.cern.ch/event/awesome) showing off their ability to reproduce an LHC analysis. Photo Credit: Samuel Meehan"
+image: /assets/images/posts/2020-02-17-preservation-reproduced-plots.jpeg
+image-caption: "Participants in [Analysis Preservation Bootcamp](https://indico.cern.ch/event/awesome) showing off their ability to reproduce an LHC analysis. Photo Credit: Samuel Meehan"
 postbanner: /assets/images/posts/2020-02-17-preservation-thumbs-up.jpeg
 summary: "The first [Analysis Preservation Bootcamp](https://indico.cern.ch/event/awesome) was held at CERN from February 17-19, 2020. Thirty graduate students and postdocs learned these new technologies aimed at ensuring reproducibility, streamlining onboarding, and extending the impact of LHC analyses through reuse."
 ---

--- a/_posts/2020-02-27-iris-hep-posters-2020.md
+++ b/_posts/2020-02-27-iris-hep-posters-2020.md
@@ -2,8 +2,8 @@
 layout: irispost
 title: IRIS-HEP Poster Session 2020 at Princeton University
 author: Robert Tuck
-postimage: /assets/images/posts/2020-02-27-iris-hep-posters-2020-main.jpg
-postimage-caption: "Irina Espejo, a graduate student at NYU, with the poster for Scalable Cyberinfrastructure Applications Photo Credit: Kyle Cranmer"
+image: /assets/images/posts/2020-02-27-iris-hep-posters-2020-main.jpg
+image-caption: "Irina Espejo, a graduate student at NYU, with the poster for Scalable Cyberinfrastructure Applications Photo Credit: Kyle Cranmer"
 postbanner: /assets/images/posts/20200227-iris-hep-posters-2020-banner.jpg
 summary: "IRIS-HEP held a Poster Session at Princeton University on February 27, 2020, to highlight the work of members from the first 18 months of IRIS-HEP."
 ---

--- a/_posts/2020-05-07-bei-wang-rse.md
+++ b/_posts/2020-05-07-bei-wang-rse.md
@@ -2,8 +2,8 @@
 layout: irispost
 title: Preparing the Large Hadron Collider for a Data Deluge
 author: Bennett McIntosh
-postimage: /assets/images/posts/2020-05-07-bei-wang-rse-wang-das-nabili.jpg
-postimage-caption: >
+image: /assets/images/posts/2020-05-07-bei-wang-rse-wang-das-nabili.jpg
+image-caption: >
     Bei Wang with Pratyush Das, IRIS-HEP Fellow and Sara Nabili, a graduate
     student from University of Maryland at the 2019 Computational and Data
     Science Training for High Energy Physics Summer School at Princeton

--- a/_posts/2020-09-17-fellows.md
+++ b/_posts/2020-09-17-fellows.md
@@ -2,8 +2,8 @@
 layout: irispost
 title: IRIS-HEP Fellows Thrive During a Remote Summer
 author: Bennett McIntosh
-postimage: /assets/images/posts/2020-09-17-fellows-watts-liu.jpg
-postimage-caption: >
+image: /assets/images/posts/2020-09-17-fellows-watts-liu.jpg
+image-caption: >
     Gordon Watts, a professor at University of Washington, meets virtually with David Liu, IRIS-HEP Fellow Photo Credit: Gordon Watts, University of Washington.
 postbanner: /assets/images/posts/2020-09-17-fellows-watts-liu-banner.png
 summary: >

--- a/_posts/2020-10-12-snowmass-loi.md
+++ b/_posts/2020-10-12-snowmass-loi.md
@@ -2,8 +2,8 @@
 layout: irispost
 title: Snowmass Letters Of Interest submitted by IRIS-HEP Members
 author: Gordon Watts and Rob Tuck
-postimage: /assets/images/posts/2020-10-12-snowmass-loi.jpg
-postimage-caption: >
+image: /assets/images/posts/2020-10-12-snowmass-loi.jpg
+image-caption: >
     Snowmass Mountain Photo Credit: Nelsestu at English Wikipedia -
     Self-photographed, Public Domain,
     [https://commons.wikimedia.org/w/index.php?curid=80947852]

--- a/_posts/2020-10-14-sust-sw-blueprint.md
+++ b/_posts/2020-10-14-sust-sw-blueprint.md
@@ -2,9 +2,9 @@
 layout: irispost
 title: Software Sustainability & High Energy Physics Blueprint Workshop
 author: Daniel S. Katz
-postimage: /assets/images/blueprint-process.png
-postimage-whole: true
-postimage-caption: "This workshop was part of the Blueprint process, which is designed to inform the development and evolution of the IRIS-HEP strategic vision, in this case regarding sustainable software."
+image: /assets/images/blueprint-process.png
+image-whole: true
+image-caption: "This workshop was part of the Blueprint process, which is designed to inform the development and evolution of the IRIS-HEP strategic vision, in this case regarding sustainable software."
 summary: "On July 22, about 80 researchers interested in both sustainable software and high energy physics gathered virtually to talk about how the high energy physics community could make its software more sustainable, wanting it to be easier to develop and maintain so that it remains available in the future on new platforms, meets new needs, and is as reusable as possible."
 ---
 

--- a/_posts/2020-11-30-training-online.md
+++ b/_posts/2020-11-30-training-online.md
@@ -3,9 +3,9 @@ layout: irispost
 title: >
     In the future, it will all be online: IRIS-HEP adapts training and outreach for the pandemic
 author: Bennett McIntosh
-postimage: /assets/images/posts/20201130-small-zoom.png
-postimage-whole: true
-postimage-caption: |
+image: /assets/images/posts/20201130-small-zoom.png
+image-whole: true
+image-caption: |
     A screenshot showing participants of the remote workshop entitled "Data
     Analysis for STEM teachers" on July 15-16, 2020 at UPRM, Mayaguez, Puerto
     Rico.

--- a/_posts/2021-04-10-exabyte-era.md
+++ b/_posts/2021-04-10-exabyte-era.md
@@ -2,9 +2,9 @@
 layout: irispost
 title: High-energy physics opens its doors to the exabyte era
 author: Eoin O'Carroll
-postimage: /assets/images/posts/20210410-Oksana-Shadura-CERN.jpg
-postimage-whole: true
-postimage-caption: |
+image: /assets/images/posts/20210410-Oksana-Shadura-CERN.jpg
+image-whole: true
+image-caption: |
     Oksana Shadura, a software developer at University of Nebraska-Lincoln based at CERN, Switzerland, is creating an interactive analysis facility for the high-energy physics community. Working with IRIS-HEP’s Data Organization, Management and Access team (DOMA@IRIS-HEP), Dr. Shadura helps physicists work with the wider Python ecosystem and other novel programming paradigms. Credit: CERN
 summary: |
     As the high-energy physics community prepares for the High-Luminosity LHC, new data science challenges await.

--- a/_posts/2021-05-12-career-path-rse.md
+++ b/_posts/2021-05-12-career-path-rse.md
@@ -2,9 +2,9 @@
 layout: irispost
 title: Building a career path for research software engineers
 author: Eoin O'Carroll
-postimage: /assets/images/posts/20210512-Ianna-Osborne-CERN.jpg
-postimage-whole: true
-postimage-caption: |
+image: /assets/images/posts/20210512-Ianna-Osborne-CERN.jpg
+image-whole: true
+image-caption: |
     Ianna Osborne in the cavern with CMS detector and in the control room at CERN expecting first collisions. Credit: Ianna Osborne; CERN; and collage by PICSciE staff.
 summary: |
     Software is now fundamental to scientific research. Until recently, the people who build it have lacked recognition.

--- a/pages/docs/add_news.md
+++ b/pages/docs/add_news.md
@@ -22,14 +22,14 @@ Your news item will start with front matter. You should at least have:
 ---
 layout: irispost
 title: <title here>
-postimage: /assets/images/posts/<main image here>
+image: /assets/images/posts/<main image here>
 ---
 ```
 
 There are several optional fields as well:
 
 * `author`: The post author (your name, however you would like it displayed)
-* `postimage-caption`: A caption string for the main post image. Will be added to the main image on the post page. Recommended for accessibility, if nothing else.
+* `image-caption`: A caption string for the main post image. Will be added to the main image on the post page. Recommended for accessibility, if nothing else.
 * `postbanner`: A very wide image to use as a banner across the top of the post.
 * `summary`: Will replace the auto-summary with an explicit one for the IRIS-HEP main page, so the beginning text does not have to match.
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -27,7 +27,7 @@ IRIS-HEP is a software institute funded by the National Science Foundation. It a
     {% for post in site.posts limit:4 %}
        <div class="card news">
           <a href="{{post.url}}">
-            <img class="card-img-top" src="{{post.postimage}}" {% if post.postimage-whole -%} style="object-fit:scale-down;" {% endif -%} alt="Card image cap">
+            <img class="card-img-top" src="{{post.image}}" {% if post.image-whole -%} style="object-fit:scale-down;" {% endif -%} alt="Card image cap">
           </a>
           <div class="card-body d-flex flex-column">
             <div class="card-text card-title">

--- a/pages/news.md
+++ b/pages/news.md
@@ -9,8 +9,8 @@ title: "News, Featured Stories and Links"
   <div>
     <h4><a href="{{ post.url }}">{{ post.title }}</a></h4>
     <h6><i>{{ post.date | date_to_long_string }}</i></h6>
-    {% if post.postimage %}
-    <img src="{{post.postimage}}" style="float:left; margin-left: 10px; margin-right: 10px; width: 35%; max-width: 200px;">
+    {% if post.image %}
+    <img src="{{post.image}}" style="float:left; margin-left: 10px; margin-right: 10px; width: 35%; max-width: 200px;">
     {% else %}
     <img src="/assets/images/Tprime-200pu-PhaseII-black-arctic-main-image-small.jpg" style="float:left; margin-left: 10px; margin-right: 10px; width: 10%">
     {% endif %}


### PR DESCRIPTION
As of now, twitter links to iris-hep.org content don't have a default image and look like this:

![image](https://user-images.githubusercontent.com/5824618/119186258-d4c32280-ba45-11eb-8ac6-1517e00d70bc.png)

Instead of the grey image, it would be nice to have the IRIS-HEP logo.  

This PR adds a top level site variable in _config.yml to set the default image. For now I have it set to be /assets/logos/Iris-hep-5-just-graphic.png,  but that is easily changed. 

It doesn't break anything when I test locally, but it will need to be tested live with:  https://cards-dev.twitter.com/validator