### PR TITLE
Fix the collaboration 'short name'.

### DIFF
--- a/_data/collaborations/distributed.yml
+++ b/_data/collaborations/distributed.yml
@@ -27,7 +27,8 @@
   awards:
     - type: OAC
       number: 2114989
-- name: Event Workflow Management Service (EWMS)
+- name: Event Workflow Management Service
+  short: EWMS
   url: https://www.nsf.gov/awardsearch/showAward?AWD_ID=2103963
   description: "Working to manage extremely large numbers of independent computational tasks - represented as 'events' - as part of a manaager-worker paraadigm"
   awards:

--- a/pages/collaborations.md
+++ b/pages/collaborations.md
@@ -15,8 +15,8 @@ include:
 #### {{ collab.name }}
 {%    for proj in site.data.collaborations[collab.id] %}
 * [{{ proj.name }}]({{ proj.url }})
-      {%- if proj.shortname -%}
-          ({{ proj.shortname }})
+      {%- if proj.short -%}
+          ({{ proj.short }})
       {%- endif -%}
       {%- if proj.description -%}
         : {{ proj.description }}

--- a/pages/index.html
+++ b/pages/index.html
@@ -190,7 +190,11 @@ ongoing events don't get prematurely flagged as recent.
 {%- for cat in site.data.collabcats -%}
   {%- for proj in site.data.collaborations[cat.id] -%}
     {%- capture projtxt -%}
-      [{{ proj.name }}]({{ proj.url }})
+      {%- if proj.short %}
+          [{{ proj.short }}]({{ proj.url }})
+      {% else %}
+          [{{ proj.name }}]({{ proj.url }})
+      {%- endif -%}
     {%- endcapture -%}
     {%- assign projlist = projlist | push: projtxt -%}
   {%- endfor -%}


### PR DESCRIPTION
It appears this never functioned -- all the collaborations used the key 'short' and the rendering looked for the 'shortname' key.

Whoops.