### PR TITLE
fix: Madminer project badge URLs

### DIFF
--- a/pages/projects/madminer.md
+++ b/pages/projects/madminer.md
@@ -40,10 +40,9 @@ to be very valuable for inference.
 [![GitHub](https://img.shields.io/badge/GitHub-555555.svg)](https://github.com/diana-hep/madminer)
 [![PyPI version](https://badge.fury.io/py/madminer.svg)](https://badge.fury.io/py/madminer)
 [![Documentation Status](https://readthedocs.org/projects/madminer/badge/?version=latest)](https://madminer.readthedocs.io/en/latest/?badge=latest)
-[![Build Status](https://travis-ci.com/johannbrehmer/madminer.svg?branch=master)](https://travis-ci.com/johannbrehmer/madminer)
+[![CI Status](https://github.com/diana-hep/madminer/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/diana-hep/madminer/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Docker pulls](https://img.shields.io/docker/pulls/madminertool/docker-madminer.svg)](https://hub.docker.com/r/madminertool/docker-madminer)
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/johannbrehmer/madminer/master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1489147.svg)](https://doi.org/10.5281/zenodo.1489147)
-

--- a/pages/projects/madminer.md
+++ b/pages/projects/madminer.md
@@ -42,7 +42,7 @@ to be very valuable for inference.
 [![Documentation Status](https://readthedocs.org/projects/madminer/badge/?version=latest)](https://madminer.readthedocs.io/en/latest/?badge=latest)
 [![CI Status](https://github.com/diana-hep/madminer/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/diana-hep/madminer/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Docker pulls](https://img.shields.io/docker/pulls/madminertool/docker-madminer.svg)](https://hub.docker.com/r/madminertool/docker-madminer)
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/johannbrehmer/madminer/master)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/diana-hep/madminer/master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1489147.svg)](https://doi.org/10.5281/zenodo.1489147)


### PR DESCRIPTION
This PR updates the badges of the [Madminer project entry](https://iris-hep.org/projects/madminer.html).

- The CI badge is now pointing to GitHub Actions (instead of Travis), after the merge of [this PR](https://github.com/diana-hep/madminer/pull/457).
- The Binder badge is now pointing to the _official_ repository (instead of Johann's fork).