### PR TITLE
talk: Add pyhf PyHEP Module of the Month tutorial

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -194,3 +194,13 @@ presentations:
   location: Virtual
   focus-area: as
   project: pyhf
+
+
+- title: 'Distributed statistical inference with pyhf enabled through funcX'
+  date: 2021-05-20
+  url: https://indico.cern.ch/event/948465/contributions/4324013/
+  meeting: vCHEP 2021 Conference
+  meetingurl: https://indico.cern.ch/event/948465/
+  location: Virtual
+  focus-area: as
+  project: pyhf

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -189,7 +189,7 @@ presentations:
 - title: 'PyHEP pyhf Tutorial'
   date: 2021-04-07
   url: https://indico.cern.ch/event/985425/
-  meeting: PyHEP Python Module of the Month, April 2021
+  meeting: PyHEP Python Module of the Month (April 2021)
   meetingurl: https://indico.cern.ch/event/985425/
   location: Virtual
   focus-area: as

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -186,11 +186,11 @@ presentations:
   focus-area: as
   project: pyhf
 
-- title: 'Distributed statistical inference with pyhf enabled through funcX'
-  date: 2021-05-20
-  url: https://indico.cern.ch/event/948465/contributions/4324013/
-  meeting: vCHEP 2021 Conference
-  meetingurl: https://indico.cern.ch/event/948465/
+- title: 'PyHEP pyhf Tutorial'
+  date: 2021-04-07
+  url: https://indico.cern.ch/event/985425/
+  meeting: PyHEP Python Module of the Month, April 2021
+  meetingurl: https://indico.cern.ch/event/985425/
   location: Virtual
   focus-area: as
   project: pyhf

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -195,7 +195,6 @@ presentations:
   focus-area: as
   project: pyhf
 
-
 - title: 'Distributed statistical inference with pyhf enabled through funcX'
   date: 2021-05-20
   url: https://indico.cern.ch/event/948465/contributions/4324013/


### PR DESCRIPTION
Add `pyhf` tutorial given at the April 2021 PyHEP Python Module of the Month workshop series.

```
* Add pyhf tutorial given at the April 2021 PyHEP Python Module of the Month workshop series
   - c.f. https://indico.cern.ch/event/985425/
```