### PR TITLE
talk: Add pyhf PyHEP 2021 talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -203,3 +203,13 @@ presentations:
   location: Virtual
   focus-area: as
   project: pyhf
+
+
+- title: 'Distributed statistical inference with pyhf enabled through funcX'
+  date: 2021-05-20
+  url: https://indico.cern.ch/event/948465/contributions/4324013/
+  meeting: vCHEP 2021 Conference
+  meetingurl: https://indico.cern.ch/event/948465/
+  location: Virtual
+  focus-area: as
+  project: pyhf

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -204,12 +204,11 @@ presentations:
   focus-area: as
   project: pyhf
 
-
-- title: 'Distributed statistical inference with pyhf enabled through funcX'
-  date: 2021-05-20
-  url: https://indico.cern.ch/event/948465/contributions/4324013/
-  meeting: vCHEP 2021 Conference
-  meetingurl: https://indico.cern.ch/event/948465/
+- title: 'Distributed statistical inference with pyhf'
+  date: 2021-07-06
+  url: https://indico.cern.ch/event/1019958/contributions/4418598/
+  meeting: PyHEP 2021 Workshop
+  meetingurl: https://indico.cern.ch/event/1019958/
   location: Virtual
   focus-area: as
   project: pyhf


### PR DESCRIPTION
Add talk given at PyHEP 2021 on [Distributed statistical inference with pyhf](https://indico.cern.ch/event/1019958/contributions/4418598/) presented on behalf of @matthewfeickert, @lukasheinrich, and @kratsg.

```
* c.f. https://indico.cern.ch/event/1019958/contributions/4418598/
* Presented on behalf of Matthew Feickert, Lukas Heinrich, Giordon Stark
```