### PR TITLE
Offboard Mike Stanfield, reactivate Susan Sons

### DIFF
--- a/_data/people/HedgeMage.yml
+++ b/_data/people/HedgeMage.yml
@@ -1,4 +1,4 @@
-active: false
+active: true
 institution: Indiana University
 name: Susan Sons
 photo: "/assets/images/team/Susan-Sons.jpg"

--- a/_data/people/mtstanfield.yml
+++ b/_data/people/mtstanfield.yml
@@ -1,4 +1,4 @@
-active: true
+active: false
 focus-area:
 - osglhc
 institution: Indiana University

--- a/_data/universities/indiana.yml
+++ b/_data/universities/indiana.yml
@@ -1,6 +1,5 @@
 name: Indiana University
 personnel:
-  - mtstanfield
   - HedgeMage
   - zsshah
   - jcdrake

--- a/_data/universities/indiana.yml
+++ b/_data/universities/indiana.yml
@@ -4,3 +4,4 @@ personnel:
   - zsshah
   - jcdrake
   - adciu
+  - mtstanfield

--- a/pages/projects/osg-security.md
+++ b/pages/projects/osg-security.md
@@ -12,7 +12,7 @@ team:
 - adciu
 - jcdrake
 - zsshah
-- mtstanfield
+- HedgeMage
 ---
 
 The OSG Security team works on supporting operational security for OSG infrastructure, software security,


### PR DESCRIPTION
Make changes to people yml files for mtstanfield and HedgeMage to deactivate Mike Stanfield and re-add Susan Sons to OSG security.  

Edited osg-security.md on project page to reflect changes

Removed mtstanfield from Indiana.yml