### PR TITLE
talk: Add Feickert SciPy 2021 talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -221,3 +221,4 @@ presentations:
   location: Virtual
   focus-area: as
   project: pyhf
+  comment: Proceedings for slides not yet published

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -212,3 +212,13 @@ presentations:
   location: Virtual
   focus-area: as
   project: pyhf
+
+
+- title: 'Distributed statistical inference with pyhf'
+  date: 2021-07-015
+  url: https://indico.cern.ch/event/1019958/contributions/4418598/
+  meeting: 20th Python in Science Conference (SciPy 2021)
+  meetingurl: https://conference.scipy.org/proceedings/scipy2020/slides.html
+  location: Virtual
+  focus-area: as
+  project: pyhf

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -213,12 +213,11 @@ presentations:
   focus-area: as
   project: pyhf
 
-
-- title: 'Distributed statistical inference with pyhf'
-  date: 2021-07-015
-  url: https://indico.cern.ch/event/1019958/contributions/4418598/
+- title: 'Distributed statistical inference with pyhf powered by funcX'
+  date: 2021-07-15
+  url: https://github.com/matthewfeickert/talk-scipy-2021
   meeting: 20th Python in Science Conference (SciPy 2021)
-  meetingurl: https://conference.scipy.org/proceedings/scipy2020/slides.html
+  meetingurl: https://conference.scipy.org/proceedings/scipy2021/slides.html
   location: Virtual
   focus-area: as
   project: pyhf


### PR DESCRIPTION
Add [`pyhf` and `funcX` talk given at SciPy 2021](https://matthewfeickert.github.io/talk-scipy-2021/).

Note that this PR will be amended by a follow up PR once the [SciPy 2021 proceedings for talks are released](https://github.com/scipy-conference/scipy_proceedings/pull/658).

```
* Add pyhf and funcX talk presented at SciPy 2021 by Matthew Feickert
   - c.f. https://matthewfeickert.github.io/talk-scipy-2021/
   - SciPy 2021 proceedings are in the process of being published
```