### PR TITLE
feat: add talk video icons

### DIFF
--- a/_data/people/henryiii.yml
+++ b/_data/people/henryiii.yml
@@ -215,7 +215,7 @@ presentations:
   meeting: PyHEP 2020 Workshop
   meetingurl: https://indico.cern.ch/PyHEP2020
   focus-area: ssc
-  project: 
+  project:
   location: Virtual
   video: https://youtu.be/kKroC93_jyg
 - title: 'High-performance Python: CPUs'
@@ -269,7 +269,7 @@ presentations:
   date: 2021-07-05
   url: https://indico.cern.ch/event/1019958/contributions/4430355/
   meeting: PyHEP 2021 Workshop
-  meetingurl: https://indico.cern.ch/e/PyHEP2021 
+  meetingurl: https://indico.cern.ch/e/PyHEP2021
   focus-area: ssc
   project:
   location: Virtual
@@ -278,7 +278,7 @@ presentations:
   date: 2021-07-06
   url: https://indico.cern.ch/event/1019958/contributions/4430422/
   meeting: PyHEP 2021 Workshop
-  meetingurl: https://indico.cern.ch/e/PyHEP2021 
+  meetingurl: https://indico.cern.ch/e/PyHEP2021
   focus-area: ssc
   project:
   location: Virtual
@@ -287,7 +287,7 @@ presentations:
   date: 2021-07-07
   url: https://indico.cern.ch/event/1019958/contributions/4430375/
   meeting: PyHEP 2021 Workshop
-  meetingurl: https://indico.cern.ch/e/PyHEP2021 
+  meetingurl: https://indico.cern.ch/e/PyHEP2021
   focus-area: as
   project: histogram
   location: Virtual
@@ -296,7 +296,7 @@ presentations:
   date: 2021-07-08
   url: https://indico.cern.ch/event/1019958/contributions/4418546/
   meeting: PyHEP 2021 Workshop
-  meetingurl: https://indico.cern.ch/e/PyHEP2021 
+  meetingurl: https://indico.cern.ch/e/PyHEP2021
   focus-area: as
   project:
   location: Virtual

--- a/_data/people/henryiii.yml
+++ b/_data/people/henryiii.yml
@@ -199,14 +199,25 @@ presentations:
   focus-area: as
   project: histogram
   location: Virtual
+  video: https://youtu.be/ERraTfHkPd0
 - title: The boost-histogram package
   date: 2020-07-17
   url: https://zenodo.org/record/4147611
   meeting: PyHEP 2020 Workshop
-  meetingurl: https://indico.cern.ch/event/882824/
+  meetingurl: https://indico.cern.ch/PyHEP2020
   focus-area: as
   project: histogram
   location: Virtual
+  video: https://youtu.be/-g0mxopCJT8
+- title: High-performance Python
+  date: 2020-07-15
+  url: https://indico.cern.ch/event/882824/contributions/3931295/
+  meeting: PyHEP 2020 Workshop
+  meetingurl: https://indico.cern.ch/PyHEP2020
+  focus-area: ssc
+  project: 
+  location: Virtual
+  video: https://youtu.be/kKroC93_jyg
 - title: 'High-performance Python: CPUs'
   date: 2020-11-04
   url: https://researchcomputing.princeton.edu/events/high-performance-python-cpus-1
@@ -253,4 +264,48 @@ presentations:
   meeting: Software & Computing Round Table
   focus-area: ssc
   project:
+  location: Virtual
+- title: Level Up Your Python (Part I)
+  date: 2021-07-05
+  url: https://indico.cern.ch/event/1019958/contributions/4430355/
+  meeting: PyHEP 2021 Workshop
+  meetingurl: https://indico.cern.ch/e/PyHEP2021 
+  focus-area: ssc
+  project:
+  location: Virtual
+  video: https://youtu.be/qW6DA52cpv4
+- title: Level Up Your Python (Part II)
+  date: 2021-07-06
+  url: https://indico.cern.ch/event/1019958/contributions/4430422/
+  meeting: PyHEP 2021 Workshop
+  meetingurl: https://indico.cern.ch/e/PyHEP2021 
+  focus-area: ssc
+  project:
+  location: Virtual
+  video: https://youtu.be/Kfspje3s1y8
+- title: High-Performance Histogramming for HEP Analysis
+  date: 2021-07-07
+  url: https://indico.cern.ch/event/1019958/contributions/4430375/
+  meeting: PyHEP 2021 Workshop
+  meetingurl: https://indico.cern.ch/e/PyHEP2021 
+  focus-area: as
+  project: histogram
+  location: Virtual
+  video: https://youtu.be/tmBA4zwpiO0
+- title: Powerful Python Packaging for Scientific Codes
+  date: 2021-07-08
+  url: https://indico.cern.ch/event/1019958/contributions/4418546/
+  meeting: PyHEP 2021 Workshop
+  meetingurl: https://indico.cern.ch/e/PyHEP2021 
+  focus-area: as
+  project:
+  location: Virtual
+  video: https://youtu.be/jewb5q6_Rpk
+- title: pybind11
+  date: 2021-07-16
+  url: https://na.eventscloud.com/ehome/index.php?eventid=604197&tabid=1110004
+  meeting: SciPy 2021
+  meetingurl: https://www.scipy2021.scipy.org
+  focus-area: as
+  project: histogram
   location: Virtual

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,16 +21,16 @@
         <div class="footer-vertical-center">
           <div class="footer-buttons">
             <button type="button" class="btn btn-outline-secondary btn-sm">
-              <a href="https://twitter.com/iris_hep"><i class="fa fa-twitter"></i></a>
+              <a href="https://twitter.com/iris_hep"><i class="fab fa-twitter"></i></a>
             </button>
             <button type="button" class="btn btn-outline-secondary btn-sm">
-              <a href="https://www.youtube.com/channel/UC8Dmx4MYjp6RQ9ngc58Ujmg?view_as=subscriber"> <i class="fa fa-youtube"></i></a>
+              <a href="https://www.youtube.com/channel/UC8Dmx4MYjp6RQ9ngc58Ujmg?view_as=subscriber"> <i class="fab fa-youtube"></i></a>
             </button>
             <button type="button" class="btn btn-outline-secondary btn-sm">
-              <a href="https://github.com/iris-hep/"> <span class="fa fa-github"></span></a>
+              <a href="https://github.com/iris-hep/"> <span class="fab fa-github"></span></a>
             </button>
             <button type="button" class="btn btn-outline-secondary btn-sm">
-              <a href="https://groups.google.com/a/iris-hep.org/forum/#!forum/announcements"> <span class="fa fa-google"></span></a>
+              <a href="https://groups.google.com/a/iris-hep.org/forum/#!forum/announcements"> <span class="fab fa-google"></span></a>
             </button>
             </div>
           </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,8 +18,7 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="/assets/css/bootstrap.css" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-    <!-- Desired link from https://www.bootstrapcdn.com/fontawesome/ as of 2019-04-23 -->
-    <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
     <script src="/assets/js/jquery-3.2.1.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
     <script src="/assets/js/popper.min.js" integrity="sha384-L2pyEeut/H3mtgCBaUNw7KWzp5n9+4pDQiExs933/5QfaTh8YStYFFkOzSoXjlTb" crossorigin="anonymous"></script>

--- a/_includes/print_pres.html
+++ b/_includes/print_pres.html
@@ -19,6 +19,11 @@
   {%- else -%}
     "{{ talk.title }}"
   {%- endif -%}
+  {%- if talk.video -%}
+  {{ " " }}<a href="{{ talk.video }}" aria-label="Video">
+      <i aria-hidden="true" class="fas fa-video" title="Video"></i>
+    </a>
+  {%- endif -%}
 {%- endcapture -%}
 
 {{ prettydate }} - {{ title }}, {{ talk-member }}, {{ meeting }}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -375,9 +375,9 @@ div#container {
   }
 
   .footer-buttons {
-    width:33px;
+    width:35px;
     @media only screen and (min-width: 991px) {
-      width:66px;
+      width:70px;
     }
     @media only print {
       display: none;


### PR DESCRIPTION
As requested in #1048, also adding my talks and adding a few video links. Updating fontawesome to version 5, which has a nicer YouTube image (the logo rather than the words), and has the video icon I'm using here. Link from https://cdnjs.com/libraries/font-awesome .

<img width="676" alt="Screen Shot 2021-07-23 at 3 26 22 PM" src="https://user-images.githubusercontent.com/4616906/126833588-c05783a7-2017-4495-8b08-55ef69d241a8.png">
