### PR TITLE
pyhf: Add Zenodo DOI to Feickert SciPy 2021 talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -220,11 +220,10 @@ presentations:
 
 - title: 'Distributed statistical inference with pyhf powered by funcX'
   date: 2021-07-15
-  url: https://github.com/matthewfeickert/talk-scipy-2021
+  url: https://doi.org/10.25080/majora-1b6fd038-023
   video: https://youtu.be/rwaxVDWZS8A
   meeting: 20th Python in Science Conference (SciPy 2021)
   meetingurl: https://conference.scipy.org/proceedings/scipy2021/slides.html
   location: Virtual
   focus-area: as
   project: pyhf
-  comment: Proceedings for slides not yet published

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -221,6 +221,7 @@ presentations:
 - title: 'Distributed statistical inference with pyhf powered by funcX'
   date: 2021-07-15
   url: https://github.com/matthewfeickert/talk-scipy-2021
+  video: https://youtu.be/rwaxVDWZS8A
   meeting: 20th Python in Science Conference (SciPy 2021)
   meetingurl: https://conference.scipy.org/proceedings/scipy2021/slides.html
   location: Virtual


### PR DESCRIPTION
Now that the [SciPy 2021 proceedings](http://conference.scipy.org/proceedings/scipy2021/) are published (huge thanks to the amazing @deniederhut for once again doing a heroic job to get them done!), add the Zenodo DOI URL to the talk entry and link to the [video on YouTube](https://youtu.be/rwaxVDWZS8A).

[![DOI](https://zenodo.org/badge/DOI/10.25080/majora-1b6fd038-023.svg)](https://doi.org/10.25080/majora-1b6fd038-023)

```
* Add Zenodo DOI URL from SciPy 2021 proceedings
   - c.f. https://doi.org/10.25080/majora-1b6fd038-023
* Add link to talk video recording on YouTube
   - c.f. https://youtu.be/rwaxVDWZS8A
```