### PR TITLE
fix: Update CI status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Github Actions badge](https://github.com/iris-hep/iris-hep.github.io-source/workflows/CI/badge.svg)](https://github.com/iris-hep/iris-hep.github.io-source/actions)
+[![CI](https://github.com/iris-hep/iris-hep.github.io-source/actions/workflows/ci.yml/badge.svg)](https://github.com/iris-hep/iris-hep.github.io-source/actions/workflows/ci.yml)
 
 Is this badge red? Click on it to find whats wrong with the repository...
 


### PR DESCRIPTION
The current status badge is reporting that the CI is failing though it is passing

[![Github Actions badge](https://github.com/iris-hep/iris-hep.github.io-source/workflows/CI/badge.svg)](https://github.com/iris-hep/iris-hep.github.io-source/actions)

If we replace it with the status badge URL that is generated from the "Create status badge" drop down option in the Actions panel

[![CI](https://github.com/iris-hep/iris-hep.github.io-source/actions/workflows/ci.yml/badge.svg)](https://github.com/iris-hep/iris-hep.github.io-source/actions/workflows/ci.yml)

then it properly displays the CI status again.
