### PR TITLE
Nov 2021 update for Alexander Held

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -18,6 +18,7 @@ presentations:
   location: NYU
   focus-area: as
   project: cabinetry
+
 - title: Harmonizing statistics tools - ideas
   date: 2019-10-29
   url: https://indico.cern.ch/event/859742/contributions/3620507/
@@ -26,6 +27,7 @@ presentations:
   location: CERN
   focus-area: as
   project: cabinetry
+
 - title: Constraining effective field theories with machine learning
   date: 2019-11-07
   url: https://indico.cern.ch/event/773049/contributions/3476179/
@@ -34,6 +36,7 @@ presentations:
   location: Adelaide, Australia
   focus-area: as
   project: madminer
+
 - title: Rethinking final analysis stages (poster)
   date: 2020-02-27
   url: https://indico.cern.ch/event/894127/attachments/1996570/3331188/18_-_AS_Final_analysis_stages.pdf
@@ -42,6 +45,7 @@ presentations:
   location: Princeton, USA
   focus-area: as
   project: cabinetry
+
 - title: pyhf and thoughts about analysis workflow
   date: 2020-03-12
   url: https://indico.cern.ch/event/897232/contributions/3784156/
@@ -50,6 +54,7 @@ presentations:
   location: CERN
   focus-area: as
   project: cabinetry
+
 - title: Cabinetry introduction
   date: 2020-05-27
   url: https://indico.cern.ch/event/896167/contributions/3880230/
@@ -58,6 +63,7 @@ presentations:
   location: "(Virtual)"
   focus-area: as
   project: cabinetry
+
 - title: Differentiable physics analyses
   date: 2020-08-11
   url: https://indico.fnal.gov/event/43829/contributions/193761/
@@ -66,6 +72,7 @@ presentations:
   location: "(Virtual)"
   focus-area: as
   project:
+
 - title: 'Template-based Fitting: cabinetry'
   date: 2020-10-26
   url: https://indico.cern.ch/event/960587/contributions/4070322/
@@ -74,6 +81,7 @@ presentations:
   location: "(Virtual)"
   focus-area: as
   project: cabinetry
+
 - title: The cabinetry library
   date: 2021-02-25
   url: https://indico.cern.ch/event/1005890/contributions/4222699/
@@ -82,6 +90,7 @@ presentations:
   location: "(Virtual)"
   focus-area: as
   project: cabinetry
+
 - title: Building and steering template fits with cabinetry
   date: 2021-05-19
   url: https://indico.cern.ch/event/948465/contributions/4324154/
@@ -90,6 +99,7 @@ presentations:
   location: "(Virtual)"
   focus-area: as
   project: cabinetry
+
 - title: Binned template fits with cabinetry
   date: 2021-07-06
   url: https://indico.cern.ch/event/1019958/contributions/4421868/
@@ -98,3 +108,29 @@ presentations:
   location: "(Virtual)"
   focus-area: as
   project: cabinetry
+
+- title: pyhf and cabinetry
+  date: 2021-09-21
+  url: https://indico.cern.ch/event/1056428/contributions/4523825/
+  meeting: ATLAS SUSY Workshop 2021
+  meetingurl: https://indico.cern.ch/event/1056428/
+  location: "(Virtual)"
+  focus-area: as
+  project:
+    - cabinetry
+    - pyhf
+
+- title: "From data delivery to statistical inference: ServiceX, coffea, cabinetry & pyhf"
+  date: 2021-11-03
+  url: https://indico.cern.ch/event/1076231/contributions/4560405/
+  meeting: IRIS-HEP AGC Tools 2021 Workshop
+  meetingurl: https://indico.cern.ch/event/1076231/
+  location: "(Virtual)"
+  focus-area:
+    - as
+    - doma
+  project:
+    - servicex
+    - func-adl
+    - cabinetry
+    - pyhf

--- a/_data/publications/1911802.yml
+++ b/_data/publications/1911802.yml
@@ -1,0 +1,4 @@
+inspire-id: 1911802
+focus-area: as
+project:
+  - cabinetry

--- a/_data/publications/cabinetry-vchep2021.yml
+++ b/_data/publications/cabinetry-vchep2021.yml
@@ -1,8 +1,0 @@
-title: "Building and steering template fits with cabinetry"
-link: https://doi.org/10.5281/zenodo.4627038
-date: 2021-03-22
-citation: |
-  K. Cranmer, A. Held
-  DOI: 10.5281/zenodo.4627038
-focus-area: as
-project: cabinetry


### PR DESCRIPTION
Adding two talks, and slightly re-formatting the list of talks to be more readable with empty lines between list items. Also replacing the Zenodo link to the `cabinetry` vCHEP proceedings with the published version.

This is ready for review / merge.