### PR TITLE
fix: date for cabinetry proceedings

### DIFF
--- a/_data/publications/1911802.yml
+++ b/_data/publications/1911802.yml
@@ -1,4 +1,5 @@
 inspire-id: 1911802
 focus-area: as
+date: 2021-08-23
 project:
   - cabinetry


### PR DESCRIPTION
#1143 added cabinetry proceedings, but the date for them on INSPIRE just shows up as "2021", which seems to be interpreted as January 1st for the purpose of sorting on the IRIS-HEP website. This adds an explicit date to them, which is the date of online publication on [EPJ Web of Conferences](https://doi.org/10.1051/epjconf/202125103067).

This is ready for review / merge.