### PR TITLE
talk: Add pyhf talk at CMS Analysis Tools Task Force meeting

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -236,3 +236,12 @@ presentations:
   location: Virtual
   focus-area: as
   project: pyhf
+
+- title: 'Distributed statistical inference with pyhf powered by funcX'
+  date: 2021-10-27
+  url: https://parsl-project.org/parslfest2021-files/feickert-pyhf.pdf
+  meeting: Parsl & funcX Fest 2021
+  meetingurl: https://parsl-project.org/parslfest2021.html
+  location: Virtual
+  focus-area: as
+  project: pyhf

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -237,11 +237,11 @@ presentations:
   focus-area: as
   project: pyhf
 
-- title: 'Distributed statistical inference with pyhf powered by funcX'
-  date: 2021-10-27
-  url: https://parsl-project.org/parslfest2021-files/feickert-pyhf.pdf
-  meeting: Parsl & funcX Fest 2021
-  meetingurl: https://parsl-project.org/parslfest2021.html
+- title: 'pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation'
+  date: 2021-12-01
+  url: https://indico.cern.ch/event/1100873/contributions/4631656/
+  meeting: CMS Analysis Tools Task Force
+  meetingurl: https://indico.cern.ch/event/1100873/
   location: Virtual
   focus-area: as
   project: pyhf


### PR DESCRIPTION
```
* Add pyhf talk presented at the CMS Analysis Tools Task Force 2021-12-01 meeting by Matthew Feickert
   - c.f. https://indico.cern.ch/event/1100873/contributions/4631656/
```