### PR TITLE
Fellow proposal for AGC benchmarking

### DIFF
--- a/_data/fellow_projects/agc_benchmarking.yml
+++ b/_data/fellow_projects/agc_benchmarking.yml
@@ -1,0 +1,17 @@
+open: yes
+postdate: 2022-01-17
+title: Benchmarking of prototype analysis system components
+description: >
+  The [Analysis Grand Challenge](https://iris-hep.org/grand-challenges.html#analysis-grand-challenge)
+  of IRIS-HEP focuses on performing a high energy physics analysis at scale, including
+  all relevant features encountered by analyzers in this context. It is performed using
+  tools and technologies developed within both IRIS-HEP and the broader community,
+  making use of the Python ecosystem and the required cyberinfrastructure to run at
+  scale. This project will happen after a first preliminary benchmarking has been
+  performed, and it will build on that: the prospective fellow will use pieces of an
+  example physics analysis to study the performance of different system components in
+  more detail. Fellows are expected to have prior Python experience and interest in
+  working with a diverse stack of analysis tools available in the ecosystem.
+contacts:
+- oshadura
+- alexander-held


### PR DESCRIPTION
Adding a proposal for a 2022 fellow working on system component benchmarking in the context of the AGC.

This is ready for review/merge.

cc @oshadura 