### PR TITLE
pyhf: Add use citation form ATLAS UEH MS displaced jet paper

### DIFF
--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -55,6 +55,7 @@ team:
 
 Updating list of citations and use cases of `pyhf`:
 
+- ATLAS Collaboration. Search for events with a pair of displaced vertices from long-lived neutral particles decaying into hadronic jets in the ATLAS muon spectrometer in pp collisions at $\sqrt s=13$ TeV. March 2022. arXiv:2203.00587.
 - Lukas Heinrich and Michael Kagan. Differentiable Matrix Elements with MadJax. Feb 2022. [arXiv:2203.00057](https://arxiv.org/abs/2203.00057).
 - Jim Pivarski, Eduardo Rodrigues, Kevin Pedro, Oksana Shadura, Benjamin Krikler, and Graeme A. Stewart. HL-LHC Computing Review Stage 2, Common Software Projects: Data Science Tools for Analysis. Feb 2022. [arXiv:2202.02194](https://arxiv.org/abs/2202.02194).
 - Florentin Jaffredo. Revisiting mono-τ tails at the LHC. Dec 2021. [arXiv:2112.14604](https://arxiv.org/abs/2112.14604).

--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -55,7 +55,7 @@ team:
 
 Updating list of citations and use cases of `pyhf`:
 
-- ATLAS Collaboration. Search for events with a pair of displaced vertices from long-lived neutral particles decaying into hadronic jets in the ATLAS muon spectrometer in pp collisions at $\sqrt s=13$ TeV. March 2022. arXiv:2203.00587.
+- ATLAS Collaboration. Search for events with a pair of displaced vertices from long-lived neutral particles decaying into hadronic jets in the ATLAS muon spectrometer in pp collisions at s√=13 TeV. March 2022. [arXiv:2203.00587](https://arxiv.org/abs/2203.00587).
 - Lukas Heinrich and Michael Kagan. Differentiable Matrix Elements with MadJax. Feb 2022. [arXiv:2203.00057](https://arxiv.org/abs/2203.00057).
 - Jim Pivarski, Eduardo Rodrigues, Kevin Pedro, Oksana Shadura, Benjamin Krikler, and Graeme A. Stewart. HL-LHC Computing Review Stage 2, Common Software Projects: Data Science Tools for Analysis. Feb 2022. [arXiv:2202.02194](https://arxiv.org/abs/2202.02194).
 - Florentin Jaffredo. Revisiting mono-τ tails at the LHC. Dec 2021. [arXiv:2112.14604](https://arxiv.org/abs/2112.14604).


### PR DESCRIPTION
Add `pyhf` use citation from ATLAS paper [Search for events with a pair of displaced vertices from long-lived neutral particles decaying into hadronic jets in the ATLAS muon spectrometer in pp collisions at \sqrt{s}=13 TeV](https://inspirehep.net/literature/2040545) ([ANA-EXOT-2019-24](https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/EXOT-2019-24/)).

```
* Add pyhf use citation from 'Search for events with a pair of displaced
vertices from long-lived neutral particles decaying into hadronic jets in
the ATLAS muon spectrometer in pp collisions at \sqrt{s}=13 TeV'
   - ATLAS paper: ANA-EXOT-2019-24
   - c.f. https://inspirehep.net/literature/2040545
```