### PR TITLE
paper: Snowmass white paper on ML for event generation and simulation-based inference

### DIFF
--- a/_data/publications/snowmass2021-ML-event-generation.yml
+++ b/_data/publications/snowmass2021-ML-event-generation.yml
@@ -1,0 +1,3 @@
+inspire-id: 2052497
+comment: Contribution to Snowmass 2021
+focus-area: as


### PR DESCRIPTION
Adding the Snowmass white paper "Machine Learning and LHC Event Generation": https://arxiv.org/abs/2203.07460

(following the format of #1291)

This is ready for review/merge.