### PR TITLE
Adding a cabinetry introduction talk

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -134,3 +134,14 @@ presentations:
     - func-adl
     - cabinetry
     - pyhf
+
+- title: Introduction to cabinetry
+  date: 2022-03-15
+  url: https://indico.cern.ch/event/1132859/#2-introduction-to-cabinetry
+  meeting: ATLAS SUSY Background Forum
+  meetingurl: https://indico.cern.ch/event/1132859/
+  location: "CERN"
+  focus-area: as
+  project:
+    - cabinetry
+    - pyhf


### PR DESCRIPTION
Adding a `cabinetry` introduction talk given at the ATLAS SUSY Background Forum (https://indico.cern.ch/event/1132859/, ATLAS-restricted).

This is ready for review/merge.