### PR TITLE
Add AGC tools 2022 workshop event

### DIFF
--- a/_data/events/20220425-agc-tools-2.yml
+++ b/_data/events/20220425-agc-tools-2.yml
@@ -1,0 +1,11 @@
+name: IRIS-HEP AGC Tools 2022 Workshop
+startdate: 2022-04-25
+enddate: 2022-04-26
+location: Virtual
+meetingurl: https://indico.cern.ch/e/agc-tools-2
+image:
+description: >
+  The IRIS-HEP AGC Tools 2022 Workshop is dedicated to showcasing tools and workflows related to the so-called “Analysis Grand Challenge” (AGC) being organized by IRIS-HEP and partners. This workshop is a part of preparations for HSF Analysis Ecosystems Workshop II.
+  The AGC focuses on running a physics analysis at scale, including the handling of systematic uncertainties, binned statistical analysis, reinterpretation, and end-to-end optimization. The AGC makes use of new and advanced analysis tools developed by the community in the Python ecosystem and relies on the development of the required cyberinfrastructure to be executed at scale. A specific goal of the AGC is to demonstrate technologies envisioned for use at the HL-LHC.
+labels:
+- training


### PR DESCRIPTION
Adding an event for the upcoming AGC workshop: https://indico.cern.ch/e/agc-tools-2

~I built the site locally via the Jekyll docker image, but did not actually see the event show up on the generated website. Is there something else needed for this?~
-> everything is fine after rebuilding the site, I am not sure what caused the original issue but it all seems ok now.

This is ready for review / merge.

cc @oshadura 