### PR TITLE
Add AGC talk at HSF AF forum kick-off

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -134,6 +134,7 @@ presentations:
     - func-adl
     - cabinetry
     - pyhf
+    - agc
 
 - title: Introduction to cabinetry
   date: 2022-03-15
@@ -145,3 +146,15 @@ presentations:
   project:
     - cabinetry
     - pyhf
+
+- title: AFs in the context of the IRIS-HEP AGC
+  date: 2022-03-25
+  url: https://indico.cern.ch/event/1132360/contributions/4759781/
+  meeting: Analysis Facilities Forum Kick-off Meeting
+  meetingurl: https://indico.cern.ch/event/1132360/
+  location: "(Virtual)"
+  focus-area:
+    - as
+    - doma
+    - ssl
+  project: agc


### PR DESCRIPTION
This talk was prepared jointly with @oshadura and given at the [HSF AF forum kick-off](https://indico.cern.ch/event/1132360/): https://indico.cern.ch/event/1132360/contributions/4759781/.

Also adding the AGC talk to a former talk that was missing it.

This is ready for review / merge.