### PR TITLE
pyhf: Clarify citations are from use and general reference

### DIFF
--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -53,7 +53,7 @@ team:
 
 ### Citations and Use in Publications
 
-Updating list of citations and use cases of `pyhf`:
+Updating list of citations (from use in analyses and general reference) of `pyhf`:
 
 - ATLAS Collaboration. SimpleAnalysis: Truth-level Analysis Framework. Apr 2022. [https://cds.cern.ch/record/2805991](https://cds.cern.ch/record/2805991).
 - Nathan Simpson and Lukas Heinrich. neos: End-to-End-Optimised Summary Statistics for High Energy Physics. Mar 2022. [arXiv:2203.05570](https://arxiv.org/abs/2203.05570).

--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -51,7 +51,7 @@ team:
 * [`pyhf` tutorial](https://pyhf.github.io/pyhf-tutorial/) (continually updated to use the latest `pyhf` release)
    - Past tutorials (with recordings on YouTube) are listed on the [tutorial GitHub project](https://github.com/pyhf/pyhf-tutorial)
 
-### Use in Publications
+### Citations and Use in Publications
 
 Updating list of citations and use cases of `pyhf`:
 


### PR DESCRIPTION
Indicate that the list of pyhf citations includes both uses of pyhf in physics analyses, as well as general citations of pyhf (the software and the JOSS paper).

```
* Indicate that the list of pyhf citations includes both uses
of pyhf in physics analyses, as well as general citations of
pyhf (the software and the JOSS paper).
```