### PR TITLE
Add AGC workshop pipeline talk

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -158,3 +158,19 @@ presentations:
     - doma
     - ssl
   project: agc
+
+- title: "From data delivery to statistical inference with CMS Open Data"
+  date: 2022-04-25
+  url: https://indico.cern.ch/event/1126109/contributions/4780156/
+  meeting: IRIS-HEP AGC Tools 2022 Workshop
+  meetingurl: https://indico.cern.ch/event/1126109/
+  location: "(Virtual)"
+  focus-area:
+    - as
+    - doma
+  project:
+    - servicex
+    - func-adl
+    - cabinetry
+    - pyhf
+    - agc


### PR DESCRIPTION
Adding a talk: [From data delivery to statistical inference with CMS Open Data](https://indico.cern.ch/event/1126109/contributions/4780156/) from the AGC workshop that just took place.

This is ready for review/merge.