### PR TITLE
talk: Add inference and ATLAS user experience IRIS-HEP AGC Tools 2022 Workshop talks

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -245,3 +245,14 @@ presentations:
   location: Virtual
   focus-area: as
   project: pyhf
+
+- title: 'Statistical inference: pyhf and cabinetry'
+  date: 2022-04-25
+  url: https://indico.cern.ch/event/1126109/contributions/4780155/
+  meeting: IRIS-HEP AGC Tools 2022 Workshop
+  meetingurl: https://indico.cern.ch/event/1126109/
+  location: Virtual
+  focus-area: as
+  project:
+    - cabinetry
+    - pyhf

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -256,3 +256,12 @@ presentations:
   project:
     - cabinetry
     - pyhf
+
+- title: 'Analysis user experience with Python HEP data science tools in ATLAS'
+  date: 2022-04-26
+  url: https://indico.cern.ch/event/1126109/contributions/4780168/
+  meeting: IRIS-HEP AGC Tools 2022 Workshop
+  meetingurl: https://indico.cern.ch/event/1126109/
+  location: Virtual
+  focus-area: as
+  project:


### PR DESCRIPTION

```
* Add tutorial on 'Statistical inference: pyhf and cabinetry'
   - c.f. https://indico.cern.ch/event/1126109/contributions/4780155/
* Add 'Analysis user experience with Python HEP data science tools in ATLAS' summary
   - c.f. https://indico.cern.ch/event/1126109/contributions/4780168/
```