### PR TITLE
fix: expander could break in markdown page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'minima', '~> 2.5'
 group :jekyll_plugins do
   gem 'jekyll-feed', '~> 0.16'
   gem 'jekyll-include-cache'
-  gem 'jekyll-indico', '~> 0.6.0'
+  gem 'jekyll-indico', '~> 0.6.2'
   # gem 'jekyll-indico', github: 'iris-hep/jekyll-indico', branch: 'main'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-indico (0.6.0)
+    jekyll-indico (0.6.2)
       jekyll (>= 3.8, < 5.0)
     jekyll-last-modified-at (1.3.0)
       jekyll (>= 3.7, < 5.0)
@@ -122,7 +122,7 @@ DEPENDENCIES
   jekyll (~> 4.2.0)
   jekyll-feed (~> 0.16)
   jekyll-include-cache
-  jekyll-indico (~> 0.6.0)
+  jekyll-indico (~> 0.6.2)
   jekyll-last-modified-at
   kramdown-parser-gfm
   minima (~> 2.5)

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,4 +31,11 @@
 
   gtag('config', 'UA-127196353-1');
 </script>
+
+<script>
+  function iris_show_hide_button(button) {
+      const visible = button.innerHTML == "Show less &lt;&lt;";
+      button.innerHTML = visible ? "Show more &gt;&gt;" : "Show less &lt;&lt;";
+    }
+</script>
 </head>

--- a/_plugins/blocks.rb
+++ b/_plugins/blocks.rb
@@ -25,24 +25,22 @@ module IrisHep
 
       return output if results.size <= @number
 
-      %(
+      %(<div>
         <div>
           #{output}
         </div>
-        <button class="btn btn-primary #{name}_class collapse.show" type="button" data-bs-toggle="collapse"
-                data-bs-target=".#{name}_class" aria-expanded="false" aria-controls="#{name}">
-          See more
-        </button>
-        <div class="collapse #{name}_class" id="#{name}">
+        <div class="collapse" id="#{name}">
           <ul>
             #{results[@number..].join("\n")}
           </ul>
-          <button class="btn btn-primary #{name}_class" type="button" data-bs-toggle="collapse"
-                data-bs-target=".#{name}_class" aria-expanded="false" aria-controls="#{name}">
-            See less
-          </button>
         </div>
-      )
+        <button class="btn btn-white" type="button" id="#{name}_btn"
+                data-bs-toggle="collapse" data-bs-target="##{name}"
+                aria-expanded="false" aria-controls="#{name}"
+                onClick="iris_show_hide_button(this);">
+          Show more >>
+        </button>
+      </div>)
     end
   end
 end


### PR DESCRIPTION
Closes #1376. Also fixing an issue running `bundle exec rake cache`.


- fix: bump jekyll-indico for cache command
- fix: expander issue when used in markdown
