### PR TITLE
Pin docker image to 3.8 to avoid yaml library issues with dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Alternatively, you can test your changes out using the Jekyll docker image:
 docker run --rm -it \
       --volume="$PWD:/srv/jekyll"  \
       -p 4000:4000 \
-      jekyll/builder:stable jekyll serve --incremental
+      jekyll/builder:3.8 jekyll serve --incremental
 ```
 This will mount your checked out copy of this repo, then build and start the
 jekyll server mapping it to port 4000 on your computer. You can make changes


### PR DESCRIPTION
# Problem
The site doesn't support ruby version 3.1. It throws an exception
```
/usr/local/lib/ruby/3.1.0/psych/class_loader.rb:99:in `find': Tried to load unspecified class: Date (Psych::DisallowedClass)
```

# Approach
In the instructions for running the builder out of docker, pin the image to `3.8` 