### PR TITLE
Add focus area for a handful of fellows.

### DIFF
--- a/pages/fellows/ErikWallin.md
+++ b/pages/fellows/ErikWallin.md
@@ -6,7 +6,7 @@ active: false
 title: Erik Wallin - IRIS-HEP Fellow
 fellow-name: Erik Wallin
 project_title: zfp Compression for HEP Data
-focus-area:
+focus-area: doma
 dates:
   start: 2020-06-01
   end: 2020-08-31

--- a/pages/fellows/MaggieRamsay.md
+++ b/pages/fellows/MaggieRamsay.md
@@ -8,7 +8,7 @@ title: Maggie Ramsay - IRIS-HEP Fellow
 fellow-name: Maggie Ramsay
 project_title: "Continuous Testing of Facility\u2019s Functionality Including Data\
   \ Delivery Services Available in Coffea-Casa Analysis Facility"
-focus-area:
+focus-area: doma
 dates:
   start: 2021-06-01
   end: 2021-08-31

--- a/pages/fellows/ThomasShearer.md
+++ b/pages/fellows/ThomasShearer.md
@@ -6,7 +6,7 @@ active: false
 title: Thomas Shearer - IRIS-HEP Fellow
 fellow-name: Thomas Shearer
 project_title: Improving the User Interface to OSG-LHC Network Metrics
-focus-area:
+focus-area: osglhc
 dates:
   start: 2020-05-01
   end: 2020-08-31

--- a/pages/fellows/zche.md
+++ b/pages/fellows/zche.md
@@ -6,7 +6,7 @@ active: false
 title: Zora Che - IRIS-HEP Fellow
 fellow-name: Zora Che
 project_title: Scaling Coffea-Casa Analysis Facility
-focus-area:
+focus-area: doma
 dates:
   start: 2021-01-01
   end: 2021-05-31


### PR DESCRIPTION
There are less than a dozen remaining unlabeled fellows.  However, I didn't recognize the remainder of the names.

Seems useful to have these labelled as it allows them to pop up in the corresponding area webpages.

@oshadura - please note and let me know if I got these incorrect.