### PR TITLE
pyhf: Add use citation from ATLAS dE/dX long-lived particle paper

### DIFF
--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -66,8 +66,7 @@ team:
 
 Updating list of citations (from use in analyses and general reference) of `pyhf`:
 
-- ATLAS Collaboration. Search for heavy, long-lived, charged particles with large ionisation energy loss in pppp collisions at \sqrt{s} = 13~\text{TeV}
-s =13 TeV using the ATLAS experiment and the full Run 2 dataset. May 2022. [arxiv:2205.06013](https://arxiv.org/abs/2205.06013)
+- ATLAS Collaboration. Search for heavy, long-lived, charged particles with large ionisation energy loss in pp collisions at s√=13 TeV using the ATLAS experiment and the full Run 2 dataset. May 2022. [arxiv:2205.06013](https://arxiv.org/abs/2205.06013)
 - ATLAS Collaboration. SimpleAnalysis: Truth-level Analysis Framework. Apr 2022. [https://cds.cern.ch/record/2805991](https://cds.cern.ch/record/2805991).
 - Tommaso Dorigo et al. Toward the End-to-End Optimization of Particle Physics Instruments with Differentiable Programming: a White Paper. Mar 2022. [arXiv:2203.13818](https://arxiv.org/abs/2203.13818).
 - Alexander Albert et al. Strange quark as a probe for new physics in the Higgs sector. In _2022 Snowmass Summer Study_. Mar 2022. [arXiv:2203.07535](https://arxiv.org/abs/2203.07535).

--- a/pages/projects/pyhf.md
+++ b/pages/projects/pyhf.md
@@ -66,6 +66,8 @@ team:
 
 Updating list of citations (from use in analyses and general reference) of `pyhf`:
 
+- ATLAS Collaboration. Search for heavy, long-lived, charged particles with large ionisation energy loss in pppp collisions at \sqrt{s} = 13~\text{TeV}
+s =13 TeV using the ATLAS experiment and the full Run 2 dataset. May 2022. [arxiv:2205.06013](https://arxiv.org/abs/2205.06013)
 - ATLAS Collaboration. SimpleAnalysis: Truth-level Analysis Framework. Apr 2022. [https://cds.cern.ch/record/2805991](https://cds.cern.ch/record/2805991).
 - Tommaso Dorigo et al. Toward the End-to-End Optimization of Particle Physics Instruments with Differentiable Programming: a White Paper. Mar 2022. [arXiv:2203.13818](https://arxiv.org/abs/2203.13818).
 - Alexander Albert et al. Strange quark as a probe for new physics in the Higgs sector. In _2022 Snowmass Summer Study_. Mar 2022. [arXiv:2203.07535](https://arxiv.org/abs/2203.07535).


### PR DESCRIPTION
Add pyhf use citation from [Search for heavy, long-lived, charged particles with large ionisation energy loss in pp collisions at s√=13 TeV using the ATLAS experiment and the full Run 2 dataset](https://inspirehep.net/literature/2080541). The paper only includes the citation of the Zenodo archive and doesn't cite the pyhf JOSS paper.

```
* Add pyhf use citation from 'Search for heavy, long-lived, charged particles with
large ionisation energy loss in pp collisions at s√=13 TeV using the ATLAS
experiment and the full Run 2 dataset'.
   - ATLAS paper: SUSY-2018-42
   - c.f. https://inspirehep.net/literature/2080541
```