### PR TITLE
Remove borders of small cards included in focus areas

### DIFF
--- a/_layouts/focus-area.html
+++ b/_layouts/focus-area.html
@@ -46,7 +46,7 @@
 <div class="container-fluid">
   <div class="row">
     {% for person in fa_team %}
-    <div class="card" style="font-size:10px;width: 87px;height: 135px;margin-bottom:-15px;">
+    <div class="card" style="font-size:10px;width: 87px;height: 135px;margin-bottom:-15px; border: none; text-align: center;">
       <img style="width: 85px;height: 85px; object-fit:cover;" src="{{person.photo}}"  alt="Card image cap">
       {%- if person.website -%}
         <a href="{{person.website}}">{{ person.name }}</a>


### PR DESCRIPTION
This might be a matter of taste, but I don't like the frames around the small cards in the focus areas ([example](https://iris-hep.org/ssc.html)).

[before](https://iris-hep.org/ssc.html):
![image](https://user-images.githubusercontent.com/13602468/171432198-87026fe2-32a8-4e9c-8da5-9c901bf42db4.png)


after this PR:
![image](https://user-images.githubusercontent.com/13602468/171432129-a66ce52b-8e59-4dee-8d75-e59d072f453f.png)
