### PR TITLE
chore: Update Feickert institute to University of Wisconsin-Madison

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -3,7 +3,7 @@ e-mail: matthew.feickert@cern.ch
 focus-area:
 - as
 - ssc
-institution: University of Illinois at Urbana-Champaign
+institution: University of Wisconsin-Madison
 name: Matthew Feickert
 photo: "/assets/images/team/matthewfeickert.jpeg"
 shortname: matthewfeickert

--- a/_data/universities/uiuc.yml
+++ b/_data/universities/uiuc.yml
@@ -5,4 +5,3 @@ personnel:
   - BenGalewsky
   - MichaelJohnson
   - matkinso
-  - matthewfeickert

--- a/_data/universities/wisconsin.yml
+++ b/_data/universities/wisconsin.yml
@@ -7,3 +7,4 @@ personnel:
   - edquist
   - aaronmoate
   - wguan
+  - matthewfeickert


### PR DESCRIPTION
Matthew Feickert is a postdoc at University of Wisconsin-Madison as of June 2022.