### PR TITLE
chore: Migrate Alexander Held to University of Wisconsin listing

### DIFF
--- a/_data/universities/nyu.yml
+++ b/_data/universities/nyu.yml
@@ -3,7 +3,6 @@ personnel:
   - cranmer
   - johannbrehmer
   - SebastianMacaluso
-  - alexander-held
   - irinaespejo
   - sinclert
   - heikomuller

--- a/_data/universities/wisconsin.yml
+++ b/_data/universities/wisconsin.yml
@@ -7,4 +7,5 @@ personnel:
   - edquist
   - aaronmoate
   - wguan
+  - alexander-held
   - matthewfeickert


### PR DESCRIPTION
@alexander-held's institution was migrated in PR #1377, and this migrates avatar placement on the ['full team' view](https://iris-hep.org/about/team).