### PR TITLE
Add pyhf tutorial talk

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -222,3 +222,14 @@ presentations:
     - as
     - doma
   project: agc
+
+- title: "pyhf tutorial"
+  date: 2022-06-28
+  url: https://indico.cern.ch/event/1159574/contributions/4930681/
+  meeting: Hybrid ATLAS Induction Day + Software Tutorial
+  meetingurl: https://indico.cern.ch/event/1159574/
+  location: "CERN & Virtual"
+  focus-area: as
+  project:
+    - cabinetry
+    - pyhf


### PR DESCRIPTION
Adding a pyhf tutorial talk given at the ATLAS Software tutorial week.

This talk doesn't show up for me when building the website locally through Docker following the command in the README, which has worked in the past. I am not sure why this is the case, but cannot see anything wrong with this entry in particular, so perhaps it is just a glitch on my end.