### PR TITLE
feat: Add Matthew as Analysis Systems Area Lead

### DIFF
--- a/_data/orgs/exec-board.yml
+++ b/_data/orgs/exec-board.yml
@@ -14,3 +14,4 @@ personnel:
   - fkw888
   - alexander-held
   - oshadura
+  - matthewfeickert

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -7,7 +7,7 @@ institution: University of Wisconsin-Madison
 name: Matthew Feickert
 photo: "/assets/images/team/matthewfeickert.jpeg"
 shortname: matthewfeickert
-title: Postdoctoral researcher
+title: Postdoctoral researcher and Analysis Systems Area Lead
 website: https://www.matthewfeickert.com
 presentations:
 - title: 'pyhf: a pure Python implementation of HistFactory with tensors and autograd'


### PR DESCRIPTION
* Matthew has taken over from Kyle as Analysis Systems area lead as of July 2022.
* Add Matthew to Executive Board.