### PR TITLE
talk: Add Feickert SciPy 2022 lightning talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -267,7 +267,7 @@ presentations:
   project:
 
 - title: 'Analysis as Applications: Quick introduction to lockfiles'
-  date: 2022-07-16
+  date: 2022-07-15
   url: https://doi.org/10.25080/majora-212e5952-028
   meeting: 21st Python in Science Conference (SciPy 2022)
   meetingurl: https://conference.scipy.org/proceedings/scipy2022/

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -270,7 +270,7 @@ presentations:
   date: 2022-07-16
   url: https://doi.org/10.25080/majora-212e5952-028
   meeting: 21st Python in Science Conference (SciPy 2022)
-  meetingurl: http://conference.scipy.org/proceedings/scipy2022/
+  meetingurl: https://conference.scipy.org/proceedings/scipy2022/
   location: Austin, Texas
   focus-area: as
   project:

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -266,6 +266,15 @@ presentations:
   focus-area: as
   project:
 
+- title: 'Analysis as Applications: Quick introduction to lockfiles'
+  date: 2022-07-16
+  url: https://doi.org/10.25080/majora-212e5952-028
+  meeting: 21st Python in Science Conference (SciPy 2022)
+  meetingurl: http://conference.scipy.org/proceedings/scipy2022/
+  location: Austin, Texas
+  focus-area: as
+  project:
+
 - title: 'Feedback from Data and Analysis Preservation, Recasting, and Reinterpretation white paper authors'
   date: 2022-07-21
   url: https://indico.fnal.gov/event/22303/contributions/245996/


### PR DESCRIPTION
* Add 'Analysis as Applications: Quick introduction to lockfiles' lightning talk given at SciPy 2022

https://twitter.com/rasbt/status/1548065872807243778