### PR TITLE
talk: Add June 2022 DOEPy talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -268,7 +268,7 @@ presentations:
 
 - title: 'Modern Python analysis ecosystem for High Energy Physics'
   date: 2022-06-29
-  url: https://doi.org/10.25080/
+  url: https://doi.org/10.5281/zenodo.6976007
   video: https://youtu.be/QSlcmZw0rRk
   meeting: The Python Exchange for DOE Employees (DOEPy)
   meetingurl: https://meetup.doepy.org/

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -273,7 +273,7 @@ presentations:
   meeting: The Python Exchange for DOE Employees (DOEPy)
   meetingurl: https://meetup.doepy.org/
   location: Virtual
-  focus-area: as
+  focus-area:
     - as
     - doma
   project:

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -266,6 +266,18 @@ presentations:
   focus-area: as
   project:
 
+- title: 'Modern Python analysis ecosystem for High Energy Physics'
+  date: 2022-06-29
+  url: https://doi.org/10.25080/
+  video: https://youtu.be/QSlcmZw0rRk
+  meeting: The Python Exchange for DOE Employees (DOEPy)
+  meetingurl: https://meetup.doepy.org/
+  location: Virtual
+  focus-area: as
+    - as
+    - doma
+  project:
+
 - title: 'Analysis as Applications: Quick introduction to lockfiles'
   date: 2022-07-15
   url: https://doi.org/10.25080/majora-212e5952-028


### PR DESCRIPTION
Add 'Modern Python analysis ecosystem for High Energy Physics' talk given at the [June 2022 Python Exchange for DOE Employees (DOEPy)](https://youtu.be/QSlcmZw0rRk) by @matthewfeickert, @jpivarski, and @gordonwatts. [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6976007.svg)](https://doi.org/10.5281/zenodo.6976007)

```
* Add 'Modern Python analysis ecosystem for High Energy Physics' talk given
at the June 2022 Python Exchange for DOE Employees (DOEPy).
   - c.f. https://doi.org/10.5281/zenodo.6976007
```