### PR TITLE
fix: Use formatting consistent with rest of Executive Board

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -7,7 +7,7 @@ institution: University of Wisconsin-Madison
 name: Matthew Feickert
 photo: "/assets/images/team/matthewfeickert.jpeg"
 shortname: matthewfeickert
-title: Postdoctoral researcher and Analysis Systems Area Lead
+title: Postdoctoral Researcher and Analysis Systems Area Lead
 website: https://www.matthewfeickert.com
 presentations:
 - title: 'pyhf: a pure Python implementation of HistFactory with tensors and autograd'


### PR DESCRIPTION
* Have all words in title be capitalized.