### PR TITLE
Add AEW2 report to publications

### DIFF
--- a/_data/publications/aew2-report.yml
+++ b/_data/publications/aew2-report.yml
@@ -1,0 +1,9 @@
+title: "HSF IRIS-HEP Second Analysis Ecosystem Workshop Report"
+link: https://doi.org/10.5281/zenodo.7003962
+date: 2022-08-17
+citation: "10.5281/zenodo.7003962"
+focus-area:
+- as
+- doma
+- ssl
+project:


### PR DESCRIPTION
The [Analysis Ecosystem Workshop II](https://indico.cern.ch/e/aew2) report is now up on Zenodo: https://doi.org/10.5281/zenodo.7003962. It includes contributions from many IRIS-HEP members (not cc-ing everyone one by one here). The author list may still change via an opt-in mechanism for participants of the workshop, for now I have not added any authors here. I am unsure whether this would be picked up by INSPIRE-HEP to use that standardized format instead. 