### PR TITLE
talk: Add Feickert ATLAS HDBS 2022 pyhf talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -304,3 +304,12 @@ presentations:
   location: Virtual
   focus-area: as
   project:
+
+- title: 'pyhf and analysis optimization with automatic differentiation'
+  date: 2022-09-06
+  url: https://indico.cern.ch/event/1132691/contributions/4994710/
+  meeting: ATLAS HDBS Workshop 2022
+  meetingurl: https://indico.cern.ch/event/1132691/
+  location: Uppsala University, Sweden
+  focus-area: as
+  project: pyhf


### PR DESCRIPTION
Add '[pyhf and analysis optimization with automatic differentiation](https://indico.cern.ch/event/1132691/contributions/4994710/)' talk given at ATLAS HDBS Workshop 2022.