### PR TITLE
fix: Add focus-area info to past AS Fellow project descriptions

### DIFF
--- a/pages/fellows/BoZheng.md
+++ b/pages/fellows/BoZheng.md
@@ -6,7 +6,7 @@ active: false
 title: Bo Zheng - IRIS-HEP Fellow
 fellow-name: Bo Zheng
 project_title: pyhf Hardware Acceleration Benchmarking with GPUs and TPUs
-focus-area:
+focus-area: as
 dates:
   start: 2020-06-01
   end: 2020-08-31

--- a/pages/fellows/peterridolfi.md
+++ b/pages/fellows/peterridolfi.md
@@ -17,6 +17,7 @@ project_goal: >
     The main goal of this project is to develop a tool that actively identifies and accommodates similarities and nuances between pyhf and CMS Combine models. The tool must be able to convert the given parameters form one type of model to the other type, while maintaining a high degree of accuracy between the actual functionality and predictions that are made by the models. Additionally, the tool should be able to give feedback concerning expected differences in these outputs based on the parameters that are given, and the limitations of the tool itself. Ultimately, the tool will serve as another method for better understanding the models that are created and the predictions that they make.
     <br>
     GitHub url: <a href="https://github.com/peterridolfi/Pyhf-to-Combine-converter.git">https://github.com/peterridolfi/Pyhf-to-Combine-converter.git</a>
+focus-area: as
 mentors:
   - Matthew Feickert (University of Wisconsin-Madison)
   - Alexander Held (University of Wisconsin-Madison)


### PR DESCRIPTION
This is part of Issue #1429.

* Without the focus-area info being added to the project the Fellows do not show up on the AS page as past Fellows.
   - Add 'as' focus-area to Bo Zheng and Peter Ridolfi's projects.