### PR TITLE
fix: Add YouTube recording URLs to Fellow projects

### DIFF
--- a/pages/fellows/peterridolfi.md
+++ b/pages/fellows/peterridolfi.md
@@ -38,7 +38,7 @@ presentations:
   url: https://indico.cern.ch/event/1195271/contributions/5056107/
   meeting: IRIS-HEP Fellows Presentations 2022
   meetingurl: https://indico.cern.ch/event/1195271
-  recordingurl: https://youtu.be/H8mwFxK7sos&t=704s
+  recordingurl: https://youtu.be/H8mwFxK7sos&t=707s
   location: Virtual
   focus-area: as
   project:

--- a/pages/fellows/peterridolfi.md
+++ b/pages/fellows/peterridolfi.md
@@ -38,6 +38,7 @@ presentations:
   url: https://indico.cern.ch/event/1195271/contributions/5056107/
   meeting: IRIS-HEP Fellows Presentations 2022
   meetingurl: https://indico.cern.ch/event/1195271
+  recordingurl: https://youtu.be/H8mwFxK7sos&t=704s
   location: Virtual
   focus-area: as
   project:

--- a/pages/fellows/ptemplem.md
+++ b/pages/fellows/ptemplem.md
@@ -23,7 +23,7 @@ mentors:
 proposal: /assets/pdf/fellows-2022/042-proposal-Philip-Templeman.pdf
 presentations:
   - title: "Prototyping a REANA workflow for MINERvA"
-  - date: "21 September 2022"
+  - date: 2022-09-21
   - meeting: "IRIS-HEP Fellows Presentations 2022"
   - meetingurl: "https://indico.cern.ch/event/1195271/"
   - recordingurl: "https://youtu.be/H8mwFxK7sos"

--- a/pages/fellows/ptemplem.md
+++ b/pages/fellows/ptemplem.md
@@ -23,11 +23,11 @@ mentors:
 proposal: /assets/pdf/fellows-2022/042-proposal-Philip-Templeman.pdf
 presentations:
   - title: "Prototyping a REANA workflow for MINERvA"
-  - date: 2022-09-21
-  - url: https://indico.cern.ch/event/1195271/contributions/5056115/
-  - meeting: IRIS-HEP Fellows Presentations 2022
-  - meetingurl: https://indico.cern.ch/event/1195271/
-  - recordingurl: https://youtu.be/H8mwFxK7sos&t=4327s
+    date: 2022-09-21
+    url: https://indico.cern.ch/event/1195271/contributions/5056115/
+    meeting: IRIS-HEP Fellows Presentations 2022
+    meetingurl: https://indico.cern.ch/event/1195271/
+    recordingurl: https://youtu.be/H8mwFxK7sos&t=4327s
 current_status: >
   A placeholder for status updates
 github-username: ptemplem

--- a/pages/fellows/ptemplem.md
+++ b/pages/fellows/ptemplem.md
@@ -24,9 +24,10 @@ proposal: /assets/pdf/fellows-2022/042-proposal-Philip-Templeman.pdf
 presentations:
   - title: "Prototyping a REANA workflow for MINERvA"
   - date: 2022-09-21
-  - meeting: "IRIS-HEP Fellows Presentations 2022"
-  - meetingurl: "https://indico.cern.ch/event/1195271/"
-  - recordingurl: "https://youtu.be/H8mwFxK7sos&t=4327s"
+  - url: https://indico.cern.ch/event/1195271/contributions/5056115/
+  - meeting: IRIS-HEP Fellows Presentations 2022
+  - meetingurl: https://indico.cern.ch/event/1195271/
+  - recordingurl: https://youtu.be/H8mwFxK7sos&t=4327s
 current_status: >
   A placeholder for status updates
 github-username: ptemplem

--- a/pages/fellows/ptemplem.md
+++ b/pages/fellows/ptemplem.md
@@ -28,6 +28,9 @@ presentations:
     meeting: IRIS-HEP Fellows Presentations 2022
     meetingurl: https://indico.cern.ch/event/1195271/
     recordingurl: https://youtu.be/H8mwFxK7sos&t=4327s
+    location: Virtual
+    focus-area: as
+    project:
 current_status: >
   A placeholder for status updates
 github-username: ptemplem

--- a/pages/fellows/ptemplem.md
+++ b/pages/fellows/ptemplem.md
@@ -26,7 +26,7 @@ presentations:
   - date: 2022-09-21
   - meeting: "IRIS-HEP Fellows Presentations 2022"
   - meetingurl: "https://indico.cern.ch/event/1195271/"
-  - recordingurl: "https://youtu.be/H8mwFxK7sos"
+  - recordingurl: "https://youtu.be/H8mwFxK7sos&t=4327s"
 current_status: >
   A placeholder for status updates
 github-username: ptemplem


### PR DESCRIPTION
```
* Add 'recordingurl' fields with specific timestamps for Peter Ridolfi
and Philip Templeman's IRIS-HEP Fellow summary presentations.
* Correct spec for Philip Templeman's presentation
  - Amends PR #1611
```