### PR TITLE
fix: add focus-area field to fellow template

### DIFF
--- a/pages/docs/fellow.md
+++ b/pages/docs/fellow.md
@@ -41,6 +41,7 @@ dates:
 photo: /assets/images/team/<First name>-<Last name>.jpg
 institution: <Your institution>
 e-mail: <Your email>
+focus-area: <Focus Area - ia,ssl,ssc,doma,as,osglhc>
 project_title: <Project title>
 project_goal: >
     Short description of your project


### PR DESCRIPTION
Add `focus-area` field to fellow template so that fellow profiles are visible under `Current and Previous <Focus Area> Fellows` in the Focus Area page