### PR TITLE
Change of member institutions for publications

### DIFF
--- a/_data/fellow_projects/cling_pytorch.yml
+++ b/_data/fellow_projects/cling_pytorch.yml
@@ -1,5 +1,5 @@
 open: yes
-title: Interactive C++ for ML 
+title: Interactive C++ for ML
 
 description: >
   Cling is an interactive C++ interpreter, built on top of Clang and LLVM compiler infrastructure. Cling realizes the read-eval-print loop (REPL) concept, in order to leverage rapid application development. Implemented as a small extension to LLVM and Clang, the interpreter reuses its strengths such as the praised concise and expressive compiler diagnostics. The LLVM-based C++ interpreter has enabled interactive C++ coding environments, whether in a standalone shell or a Jupyter notebook environment in xeus-cling.

--- a/_data/people/cranmer.yml
+++ b/_data/people/cranmer.yml
@@ -4,6 +4,7 @@ focus-area:
   - as
   - ia
 institution: University of Wisconsin–Madison
+past_institution: {institution: New York University, end_date: 2022-01-01}
 name: Kyle Cranmer
 photo: "/assets/images/team/Kyle-Cranmer.jpg"
 shortname: cranmer

--- a/_data/people/cranmer.yml
+++ b/_data/people/cranmer.yml
@@ -4,7 +4,7 @@ focus-area:
   - as
   - ia
 institution: University of Wisconsin–Madison
-past_institution: {institution: New York University, end_date: 2022-01-01}
+past_institution: { institution: New York University, end_date: 2022-01-01 }
 name: Kyle Cranmer
 photo: "/assets/images/team/Kyle-Cranmer.jpg"
 shortname: cranmer

--- a/pages/presentations/byinstitution.md
+++ b/pages/presentations/byinstitution.md
@@ -20,13 +20,22 @@ date | name | title | url | meeting | meetingurl | project | focus_area | instit
   {% assign uni = site.data.universities[uniindex] %}
 <h4>{{uni.name}}</h4>
 <ul>
+  <script>console.log({{ site.data.people[talk.member] }});</script>
   {% for talk in sorted_presentations %}
-    {% if site.data.people[talk.member].institution contains uni.name %}
+    {% if site.data.people[talk.member].past_institution.institution contains uni.name and talk.date < site.data.people[talk.member].past_institution.end_date%}
       <li>
         {%- include print_pres.html talk=talk -%}
       </li>
 
       {% assign prescount = prescount | plus: "1" %}
+    {% elsif site.data.people[talk.member].institution contains uni.name %}
+      {% unless talk.date < site.data.people[talk.member].past_institution.end_date %}
+        <li>
+          {%- include print_pres.html talk=talk -%}
+        </li>
+
+        {% assign prescount = prescount | plus: "1" %}
+      {% endunless %}
     {% endif %}
   {% endfor %}
 </ul>

--- a/pages/presentations/byinstitution.md
+++ b/pages/presentations/byinstitution.md
@@ -20,7 +20,6 @@ date | name | title | url | meeting | meetingurl | project | focus_area | instit
   {% assign uni = site.data.universities[uniindex] %}
 <h4>{{uni.name}}</h4>
 <ul>
-  <script>console.log({{ site.data.people[talk.member] }});</script>
   {% for talk in sorted_presentations %}
     {% if site.data.people[talk.member].past_institution.institution contains uni.name and talk.date < site.data.people[talk.member].past_institution.end_date%}
       <li>


### PR DESCRIPTION
Attempt to add the ability for a member to display publications by institution based on date.  in response to Kyle's, @cranmer , message on the IRIS-HEP website Slack channel.

Basically adding a past_institution field to the member YML file - with the past_institution name and an end date.  Then filtering in the appropriate place.

@henryiii @davidlange6 Any thoughts?  It seems to work in my limited testing.  I'm certain the logic could be improved.

Please note the end date I picked was arbitrary just to see If I could get the filtering to work.