### PR TITLE
talk: Add Feickert Software Citation best practices talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -329,3 +329,12 @@ presentations:
     location: Virtual
     focus-area: as
     project:
+
+  - title: "Software Citation Tools, Technologies, and Best Practices"
+    date: 2022-11-23
+    url: https://indico.cern.ch/event/1211229/contributions/5120858/
+    meeting: "Software Citation and Recognition in HEP Workshop 2022"
+    meetingurl: https://indico.cern.ch/event/1211229/
+    location: Virtual
+    focus-area: as
+    project:


### PR DESCRIPTION
* Add 'Software Citation Tools, Technologies, and Best Practices' talk given at the Software Citation and Recognition in HEP Workshop 2022.
   - c.f. https://indico.cern.ch/event/1211229/contributions/5120858/