### PR TITLE
docs: add second AGC demo day event

### DIFF
--- a/_data/events/20230224-agc-demo-day.yml
+++ b/_data/events/20230224-agc-demo-day.yml
@@ -1,0 +1,9 @@
+name: IRIS-HEP / AGC Demo day
+startdate: 2023-02-24
+enddate: 2023-02-24
+location: CERN
+meetingurl: https://indico.cern.ch/e/agc-demo-day-2
+image:
+description: >
+  This second IRIS-HEP / AGC "Demo Day" is an informal event to showcase the latest developments with short contributions covering a variety of topics in the Analysis Grand Challenge sphere. Contributions are generally technical in nature, targeting developers and the interested community. Zoom coordinates are provided on the agenda, but feel free to also join us in room 304/1-007 at CERN!
+labels:


### PR DESCRIPTION
Adding the second demo day https://indico.cern.ch/event/1232470/ to the website.

cc @oshadura 