### PR TITLE
ACAT2022: Using a DSL to read ROOT TTrees faster in Uproot

### DIFF
--- a/_data/publications/roy-acat2022-awkwardforth-uproot.yml
+++ b/_data/publications/roy-acat2022-awkwardforth-uproot.yml
@@ -1,0 +1,9 @@
+title: "Using a DSL to read ROOT TTrees faster in Uproot"
+link: https://arxiv.org/abs/2303.02202
+date: 2023-03-03
+inspire-id: 2638609
+focus-area: as
+project:
+  - awkward
+  - uproot
+submitted-to: ACAT 2022


### PR DESCRIPTION
FYI, @aryan26roy (following the example of #1734).