### PR TITLE
talk: Add Feickert pyhf talk at CMS CAT April 2023 meeting

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -367,3 +367,12 @@ presentations:
     location: Virtual
     focus-area: as
     project: pyhf
+
+  - title: "pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation"
+    date: 2023-04-12
+    url: https://matthewfeickert-talks.github.io/talk-pyhf-cms-common-analysis-tools-april-2023/
+    meeting: "CMS Common Analysis Tools General Meeting"
+    meetingurl: https://indico.cern.ch/event/1264029/
+    location: Virtual
+    focus-area: as
+    project: pyhf


### PR DESCRIPTION
* Add pyhf overview talk given at the April 2023 CMS Common Analysis Tools General Meeting.
   - c.f. https://indico.cern.ch/event/1264029/contributions/5308065/