### PR TITLE
Adding jekyll-redirect-from to support redirecting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :jekyll_plugins do
   gem 'jekyll-feed', '~> 0.16'
   gem 'jekyll-include-cache'
   gem 'jekyll-indico', '~> 0.6.2'
+  gem 'jekyll-redirect-from'
   # gem 'jekyll-indico', github: 'iris-hep/jekyll-indico', branch: 'main'
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ theme: minima
 plugins:
   - jekyll-feed
   - jekyll-include-cache
+  - jekyll-redirect-from
 
 strict_front_matter: true
 

--- a/pages/ahm-2023.md
+++ b/pages/ahm-2023.md
@@ -1,0 +1,4 @@
+---
+permalink: /ahm-2023
+redirect_to:  https://indico.cern.ch/event/1288444/
+---


### PR DESCRIPTION
There was a request from @bbockelm  to redirect https://iris-hep.org/ahm-2023 to the Indico link for the upcoming IRIS-HEP All Hands Meeting - https://indico.cern.ch/event/1288444/

This plugin seems to support that.  Are there any objections?  @henryiii 