### PR TITLE
Info about vector dropping Python `3.7` in `v1.1.0`

### DIFF
--- a/pages/projects/vector.md
+++ b/pages/projects/vector.md
@@ -18,7 +18,7 @@ team:
 ---
 
 [Vector](https://github.com/scikit-hep/vector)
-is a Python 3.7+ library for 2D, 3D, and [Lorentz vectors](https://en.wikipedia.org/wiki/Special_relativity#Physics_in_spacetime), especially _arrays of vectors_, to solve common physics problems in a NumPy-like way.
+is a Python 3.8+ library (Python 3.6 and 3.7 supported till `v0.9.0` and `v1.0.0`, respectively) for 2D, 3D, and [Lorentz vectors](https://en.wikipedia.org/wiki/Special_relativity#Physics_in_spacetime), especially _arrays of vectors_, to solve common physics problems in a NumPy-like way.
 
 Main features of Vector:
 


### PR DESCRIPTION
See https://github.com/scikit-hep/vector/releases/tag/v1.1.0