### PR TITLE
talk: Add Feickert PyHEP 2023 and Comp HEP Traineeship Summer School talks

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -412,3 +412,21 @@ presentations:
     location: Norfolk, U.S.A.
     focus-area:
     project:
+
+  - title: "Working Towards Fully Differentiable Analysis"
+    date: 2023-07-25
+    url: https://indico.cern.ch/event/1234156/contributions/5510688/
+    meeting: "PyHEP.dev Workshop 2023"
+    meetingurl: https://indico.cern.ch/event/1234156/
+    location: Princeton, U.S.A.
+    focus-area: as
+    project:
+
+  - title: "pyhf Tutorial and Demonstration"
+    date: 2023-07-26
+    url: https://indico.cern.ch/event/1293313/contributions/5437775/
+    meeting: "Computational HEP Traineeship Summer School 2023"
+    meetingurl: https://indico.cern.ch/event/1293313/
+    location: Princeton, U.S.A.
+    focus-area: as
+    project: pyhf


### PR DESCRIPTION
* Add [intro talk given at the PyHEP.dev Workshop 2023](https://indico.cern.ch/event/1234156/contributions/5510688/).
* Add [pyhf lecture given at 2023 Computational HEP Traineeship Summer School](https://indico.cern.ch/event/1293313/contributions/5437775/ ).