### PR TITLE
fix: Remove 'related-work' tag as IRIS-HEP supported

### DIFF
--- a/_data/publications/2703030.yml
+++ b/_data/publications/2703030.yml
@@ -1,4 +1,3 @@
 inspire-id: 2703030
 focus-area: blueprint
-related-work: true
 comment: published in proceedings of CHEP 2023

--- a/_data/publications/2704887.yml
+++ b/_data/publications/2704887.yml
@@ -2,5 +2,4 @@ inspire-id: 2704887
 project:
   - pyhf
 focus-area: as
-related-work: true
 comment: published in proceedings of CHEP 2023


### PR DESCRIPTION
* "related-work" is meant for "prior and related work done by research groups involved with IRIS-HEP, even if not funded through IRIS-HEP."
* Amends PR #2039