### PR TITLE
docs: make new add presentation page

### DIFF
--- a/pages/docs.md
+++ b/pages/docs.md
@@ -26,5 +26,6 @@ title: "Documentation pages for the IRIS-HEP team"
 * [Add new news post](/docs/add_news)
 * [Add new focus-area page](/docs/add_focusarea_page)
 * [Add new project page](/docs/add_project_page)
+* [Add new presentation](/docs/add_presentation)
 * [Add new publication](/docs/add_publication)
 * [Last modified](/docs/modified)

--- a/pages/docs/add_presentation.md
+++ b/pages/docs/add_presentation.md
@@ -1,0 +1,47 @@
+---
+permalink: /docs/add_presentation.html
+layout: default
+title: Information for new IRIS-HEP team members
+pagetype: doc
+---
+
+## Add new presentations
+
+There is a section for presentations in your user file (in
+[`_data/people`](https://github.com/iris-hep/iris-hep.github.io/tree/master/_data/people)).
+We would like to keep track of the presentations made by IRIS-HEP team members,
+with the following criteria:
+
+  * Only presentations related to IRIS-HEP itself should be included.
+  * Any presentation in a "public" meeting should be included. This includes
+    presentations made in experiment meetings, even if they are protected such
+    that the presentation and meeting links are not world visible.
+  * Presentations in the IRIS-HEP topical meetings should be included.
+  * Minor presentations in internal "working" meetings of IRIS-HEP do not
+    need to be added.
+  * Presentations, lectures, etc. as part of training events should be included.
+  * Posters at workshops and conferences can also be included. You can add "(poster)" at the end of the title. Include a link to a pdf of the poster.
+  * Multiple presenters are not yet supported. A new field might be added with co-presenters in the future.
+
+The meaning of the fields is the following:
+
+  * `title` - the title of the talk: you made need to place it in double quotes if certain characters like a colon space ": " are included in the title.
+  * `date` - the date on which the presentation was made, in the numeric format "YYYY-MM-DD".
+  * `url` - this should be a direct URL to the presentation or page containing the presentation. For Indico, link to the contribution, not the PDF or other links. Required; leave blank if there's really no related URL.
+  * `meeting` - the name of the meeting.
+  * `meetingurl` - the URL for the meeting in which the presentation was made.
+  * `location` - optionally list the location of a meeting if it was a workshop or dedicated gathering. Meetings that are mostly in Vidyo can use "Virtual".
+  * `focus-area` - optionally list the relevant focus area for this presentation, using its short name, i.e. one of [ia,ssl,ssc,doma,as,osglhc,blueprint,core]. Can be a list, leave blank if none.
+  * `project` - optionally list the relevant project for this presentation, using its short name, i.e. those found in the [pages/projects/](https://github.com/iris-hep/iris-hep.github.io/tree/master/pages/projects) area. Can be a list, leave blank if none.
+
+This `presentation:` section is a list, so that should look like:
+
+```yaml
+presentations:
+- title: My Title
+  date: YYYY-MM-DD
+  url:
+- title: Another one
+  date: YYYY-MM-DD
+  url: ...
+```

--- a/pages/docs/add_publication.md
+++ b/pages/docs/add_publication.md
@@ -12,7 +12,7 @@ This will be useful for advertising your work and (more mundane) reporting.
 
 #### Inspire
 
-This is easiest if you have your paper's inspire ID, which we will assume for the purpose of this tutorial is 12345678. Make a new yaml file in  [_data/publications](https://github.com/iris-hep/iris-hep.github.io/tree/master/_data/publications) - you can click the new file button or [click here](https://github.com/iris-hep/iris-hep.github.io/new/master/_data/publications). Name your file `ID.yml`; in our example, it would be `12345678.yml` The contents of the file should look like this:
+This is easiest if you have your paper's inspire ID, which we will assume for the purpose of this tutorial is 12345678. Make a new yaml file in  [_data/publications](https://github.com/iris-hep/iris-hep.github.io/tree/master/_data/publications) - you can click the new file button or <a href="https://github.com/iris-hep/iris-hep.github.io/new/master/_data/publications" target="_blank">click here</a>. Name your file `ID.yml`; in our example, it would be `12345678.yml` The contents of the file should look like this:
 
 ```yaml
 inspire-id: 12345678

--- a/pages/docs/newteammember.md
+++ b/pages/docs/newteammember.md
@@ -46,6 +46,10 @@ presentations:
 * Have an existing team member add your email address to the [IRIS-HEP Slack][] team.
 * Subscribe to the relevant [Google mailing lists][], at the very least "IRIS-HEP Full Team" and "IRIS-HEP Announcements".
 
+#### Presentations
+
+If you don't have any presentations yet, you can leave presentations blank. For more on adding new presentations, see [the add a presentation page][presentation].
+
 [contribute an improvement]:    https://github.com/iris-hep/iris-hep.github.io/pulls
 [IRIS-HEP GitHub organization]: https://github.com/iris-hep
 [assets/images/team folder]:    https://github.com/iris-hep/iris-hep.github.io/tree/master/assets/images/team
@@ -53,30 +57,4 @@ presentations:
 [university file]:              https://github.com/iris-hep/iris-hep.github.io/tree/master/_data/universities
 [IRIS-HEP Slack]:               https://iris-hep.slack.com
 [Google mailing lists]:         https://groups.google.com/a/iris-hep.org
-
-#### Presentations
-
-There is a section for presentations in the file you created above. We would
-like to keep track of the presentations made by IRIS-HEP team members, with
-the following criteria:
-
-  * Only presentations related to IRIS-HEP itself should be included.
-  * Any presentation in a "public" meeting should be included. This includes
-    presentations made in experiment meetings, even if they are protected such
-    that the presentation and meeting links are not world visible.
-  * Presentations in the IRIS-HEP topical meetings should be included.
-  * Minor presentations in internal "working" meetings of IRIS-HEP do not
-    need to be added.
-  * Presentations, lectures, etc. as part of training events should be included.
-  * Posters at workshops and conferences can also be included. You can add "(poster)" at the end of the title. Include a link to a pdf of the poster.
-
-The meaning of the fields is the following:
-
-  * title - the title of the talk: you made need to place it in double quotes if certain characters like a colon space ": " are included in the title.
-  * date - the date on which the presentation was made, in the numeric format "YYYY-MM-DD".
-  * url - this should be a direct URL to the presentation or page containing the presentation. For Indico, link to the contribution, not the PDF or other links.
-  * meeting - the name of the meeting.
-  * meetingurl - the URL for the meeting in which the presentation was made.
-  * location - optionally list the location of a meeting if it was a workshop or dedicated gathering. Meetings that are mostly in Vidyo can use "Virtual".
-  * focus-area - optionally list the relevant focus area for this presentation, using its short name, i.e. one of [ia,ssl,ssc,doma,as,osglhc,blueprint,core]. Can be a list, leave blank if none.
-  * project - optionally list the relevant project for this presentation, using its short name, i.e. those found in the [pages/projects/](https://github.com/iris-hep/iris-hep.github.io/tree/master/pages/projects) area. Can be a list, leave blank if none.
+[presentation]:                 https://iris-hep.org/docs/addpresentation.html


### PR DESCRIPTION
I think this is more discoverable as a separate page. Also opens the GitHub edit page in a new tab, and mentions that url is required, but allowed to be blank. Noticed when helping @mdsokoloff.
