### PR TITLE
docs: add third AGC demo day event

### DIFF
--- a/_data/events/20231201-agc-demo-day.yml
+++ b/_data/events/20231201-agc-demo-day.yml
@@ -1,0 +1,9 @@
+name: IRIS-HEP / AGC Demo day
+startdate: 2023-12-01
+enddate: 2023-12-01
+location: CERN
+meetingurl: https://indico.cern.ch/e/agc-demo-day-3
+image:
+description: >
+  This third IRIS-HEP / AGC "Demo Day" is an informal event to showcase the latest developments with short contributions covering a variety of topics in the Analysis Grand Challenge sphere. Contributions are generally technical in nature, targeting developers and the interested community. Zoom coordinates are provided on the agenda, but feel free to also join us in room 4/3-001 at CERN!
+labels:


### PR DESCRIPTION
Adding the third AGC demo day to the website (https://indico.cern.ch/event/1340271/).

cc @oshadura 