### PR TITLE
Add CHEP-23 presentations and arxhiv preprints for Matevz, ia/mkfit.

### DIFF
--- a/_data/people/osschar.yml
+++ b/_data/people/osschar.yml
@@ -30,3 +30,17 @@ presentations:
     date: 2023-03-30
     focus-area: osglhc
     project: caching
+  - title: "Generalizing mkFit and its Application to HL-LHC"
+    meeting: CHEP-2023, Norfolk, VA, USA
+    meetingurl: https://indico.jlab.org/event/459/
+    url: https://indico.jlab.org/event/459/contributions/11432/
+    date: 2023-05-08
+    focus-area: ia
+    project: mkfit
+  - title: "RenderCore – a new WebGPU-based rendering engine for ROOT-EVE"
+    meeting: CHEP-2023, Norfolk, VA, USA
+    meetingurl: https://indico.jlab.org/event/459/
+    url: https://indico.jlab.org/event/459/contributions/11459/
+    date: 2023-05-11
+    focus-area: ia
+    project: mkfit

--- a/_data/publications/osschar-chep23-REveRCore.yml
+++ b/_data/publications/osschar-chep23-REveRCore.yml
@@ -1,0 +1,7 @@
+title: "RenderCore -- a new WebGPU-based rendering engine for ROOT-EVE"
+link: https://doi.org/10.48550/arXiv.2312.11729
+date: 2023-12-18
+citation: "Ciril Bohak, Dmytro Kovalskyi, Sergey Linev, Alja Mrak Tadel, Sebastien Strban, Matevz Tadel, Avi Yagil,	arXiv.2312.11729 (2023)."
+focus-area: ia
+project: mkfit
+submitted-to: CHEP-2023

--- a/_data/publications/osschar-chep23-REveRCore.yml
+++ b/_data/publications/osschar-chep23-REveRCore.yml
@@ -1,7 +1,7 @@
 title: "RenderCore -- a new WebGPU-based rendering engine for ROOT-EVE"
 link: https://doi.org/10.48550/arXiv.2312.11729
 date: 2023-12-18
-citation: "Ciril Bohak, Dmytro Kovalskyi, Sergey Linev, Alja Mrak Tadel, Sebastien Strban, Matevz Tadel, Avi Yagil,	arXiv.2312.11729 (2023)."
+citation: "Ciril Bohak, Dmytro Kovalskyi, Sergey Linev, Alja Mrak Tadel, Sebastien Strban, Matevz Tadel, Avi Yagil, arXiv.2312.11729 (2023)."
 focus-area: ia
 project: mkfit
 submitted-to: CHEP-2023

--- a/_data/publications/osschar-chep23-mkfit.yml
+++ b/_data/publications/osschar-chep23-mkfit.yml
@@ -1,7 +1,7 @@
 title: "Generalizing mkFit and its Application to HL-LHC"
 link: https://doi.org/10.48550/arXiv.2312.11728
 date: 2023-12-18
-citation: "Giuseppe Cerati, Peter Elmer, Patrick Gartung, Leonardo Giannini, Matti Kortelainen, Vyacheslav Krutelyov, Steven Lantz, Mario Masciovecchio, Tres Reid, Allison Reinsvold Hall, Daniel Riley, Matevz Tadel, Emmanouil Vourliotis, Peter Wittich, Avi Yagil (for the CMS Collaboration),	arXiv:2312.11728 (2023)."
+citation: "Giuseppe Cerati, Peter Elmer, Patrick Gartung, Leonardo Giannini, Matti Kortelainen, Vyacheslav Krutelyov, Steven Lantz, Mario Masciovecchio, Tres Reid, Allison Reinsvold Hall, Daniel Riley, Matevz Tadel, Emmanouil Vourliotis, Peter Wittich, Avi Yagil (for the CMS Collaboration), arXiv:2312.11728 (2023)."
 focus-area: ia
 project: mkfit
 submitted-to: CHEP-2023

--- a/_data/publications/osschar-chep23-mkfit.yml
+++ b/_data/publications/osschar-chep23-mkfit.yml
@@ -1,0 +1,7 @@
+title: "Generalizing mkFit and its Application to HL-LHC"
+link: https://doi.org/10.48550/arXiv.2312.11728
+date: 2023-12-18
+citation: "Giuseppe Cerati, Peter Elmer, Patrick Gartung, Leonardo Giannini, Matti Kortelainen, Vyacheslav Krutelyov, Steven Lantz, Mario Masciovecchio, Tres Reid, Allison Reinsvold Hall, Daniel Riley, Matevz Tadel, Emmanouil Vourliotis, Peter Wittich, Avi Yagil (for the CMS Collaboration),	arXiv:2312.11728 (2023)."
+focus-area: ia
+project: mkfit
+submitted-to: CHEP-2023


### PR DESCRIPTION
- Generalizing mkFit and its Application to HL-LHC
- RenderCore -- a new WebGPU-based rendering engine for ROOT-EVE