### PR TITLE
feat: Add Feickert March 2024 CERN EP newsletter article

### DIFF
--- a/_data/publications/feickert-cern-ep-newsletter-2024-03.yml
+++ b/_data/publications/feickert-cern-ep-newsletter-2024-03.yml
@@ -1,0 +1,8 @@
+title: "Extending ATLAS Physics Reach with Analysis Reuse Technology"
+link: https://ep-news.web.cern.ch/content/extending-atlas-physics-reach-analysis-reuse-technology
+date: 2024-03-10
+citation: "Matthew Feickert, CERN EP Newsletter"
+focus-area: as
+project:
+  - recast
+comment: CERN EP Newsletter, March 2024


### PR DESCRIPTION
Add [Extending ATLAS Physics Reach with Analysis Reuse Technology](https://ep-news.web.cern.ch/content/extending-atlas-physics-reach-analysis-reuse-technology) article in the March 2024 CERN EP Newsletter.