### PR TITLE
Update and rename 20230710-coding-camp.yml to 20230710-coding-camp-pu…

### DIFF
--- a/_data/events/20230710-coding-camp-puerto-rico.yml
+++ b/_data/events/20230710-coding-camp-puerto-rico.yml
@@ -2,7 +2,7 @@ name: Coding Camp
 startdate: 2023-07-10
 enddate: 2023-07-12
 location: Virtual
-meetingurl: https://indico.cern.ch/event/1300865/
+meetingurl: https://indico.cern.ch/event/1305236/
 image:
 description: |
   Training Puerto Rico High School teachers on basics of Python, Jupyter Notebooks


### PR DESCRIPTION
…erto-rico.yml

Wrong indico corrected and also yml name convention includes name of the place (Puerto Rico in this case)