### PR TITLE
chore: Update Feickert position to 'Research Scientist'

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -12,7 +12,7 @@ past_institution:
 name: Matthew Feickert
 photo: "/assets/images/team/matthewfeickert.jpeg"
 shortname: matthewfeickert
-title: Postdoctoral Researcher and Analysis Systems Area Lead
+title: Research Scientist and Analysis Systems Area Lead
 website: https://www.matthewfeickert.com
 presentations:
   - title: "pyhf: a pure Python implementation of HistFactory with tensors and autograd"


### PR DESCRIPTION
* Matthew Feickert is a research scientist at University of Wisconsin-Madison Data Scinece Institute as of 2024-06-01.