### PR TITLE
Fix ATLAS and CERN links

### DIFF
--- a/_codas-hep-students/2024/LukeVaughan.md
+++ b/_codas-hep-students/2024/LukeVaughan.md
@@ -10,9 +10,9 @@ orcid:
 title:
 website:
 logos:
-    - /assets/images/codas-hep/logos/ATLAS-logo.jpg
+    - /assets/images/codas-hep/logos/ATLAS-logo.png
     - /assets/images/codas-hep/logos/okstate-logo.png
-    - /assets/images/codas-hep/logos/Iris-hep-logo.png
+    - /assets/images/codas-hep/logos/CERN_logo.png
 ---
 
 ## My research:


### PR DESCRIPTION
Change ATLAS-logo file extension to fix the broken link and change IRIS HEP logo to CERN logo.