### PR TITLE
docs: Add pixi to the 'quick instructions' in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,24 @@ request will be tested to ensure that all is ok with your changes...
 
 ## Testing locally quick instructions (see [setup](https://iris-hep.org/docs/webdev) for full instructions):
 
+### Existing Ruby install
+
 ```bash
 gem install bundler
 bundle install
 bundle exec rake serve
 ```
+
+### `pixi`
+
+[Install `pixi`](https://pixi.sh/latest/#installation) and then run
+
+```shell
+pixi run install
+pixi run serve
+```
+
+### Docker
 
 Alternatively, you can test your changes out using the Jekyll docker image:
 ```bash


### PR DESCRIPTION
* Add pixi use instructions.
* Split the sections into existing Ruby install, pixi, and Docker.
* Amends PR #2361 