### PR TITLE
docs: update personnel lists on Uproot, Awkward, dask-awkward, and Vector

### DIFF
--- a/pages/projects/awkward-dask.md
+++ b/pages/projects/awkward-dask.md
@@ -13,17 +13,14 @@ focus-area: as
 github: https://github.com/ContinuumIO/dask-awkward
 start-date: 2021-08-19
 team:
- - jpivarski
- - douglasdavis (Anaconda)
- - martindurant (Anaconda)
- - ioifrim
- - ianna
- - and others
+- Douglas Davis (Anaconda)
+- Martin Durant (Anaconda)
+- Angus Hollands
+- Lindsey Gray
+- jpivarski
+- pfackeldey
 ---
 
 First component of the Awkward Array CSSI ([OAC-2103945](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2103945), a spin-off project of IRIS-HEP,
-is the development of a new Dask container type representing Awkward Arrays. This work is in development at
-[ContinuumIO/dask-awkward](https://github.com/ContinuumIO/dask-awkward/) in collaboration with [Anaconda](https://www.anaconda.com/).
-
-GitHub Discussions in the [Planning category](https://github.com/ContinuumIO/dask-awkward/discussions/categories/planning) contain summaries of our
-weekly meetings.
+is a new Dask container type representing Awkward Arrays. This work is in development at
+[dask-contrib/dask-awkward](https://github.com/dask-contrib/dask-awkward/) in collaboration with [Anaconda](https://www.anaconda.com/).

--- a/pages/projects/awkward.md
+++ b/pages/projects/awkward.md
@@ -14,19 +14,17 @@ github: https://github.com/scikit-hep/awkward
 start-date: 2018-06-10
 team:
 - jpivarski
+- ianna
+- ioifrim
+- henryiii
+- Angus Hollands
+- Anish Biswas
+- Pratyush Das
+- Santam Roy Choudhury
+- ncsmith
+- ManasviGoyal
 ---
 
-[awkward-array](https://github.com/scikit-hep/awkward-1.0)
-is a pure Python+NumPy library for manipulating complex data structures as you would NumPy arrays. Even if your data structures
+[Awkward Array](https://github.com/scikit-hep/awkward) is a library for nested, variable-sized data, including arbitrary-length lists, records, mixed types, and missing data, using NumPy-like idioms.
 
-* contain variable-length lists (jagged or ragged),
-* are deeply nested (record structure),
-* have different data types in the same list (heterogeneous),
-* are masked, bit-masked, or index-mapped (nullable),
-* contain cross-references or even cyclic references,
-* need to be Python class instances on demand,
-* are not defined at every point (sparse),
-* are not contiguous in memory,
-* should not be loaded into memory all at once (lazy),
-
-this library can access them with the efficiency of NumPy arrays. They may be converted from JSON or Python data, loaded from "awkd" files, HDF5, Parquet, or ROOT files, or they may be views into memory buffers like Arrow.
+Arrays are dynamically typed, but operations on them are compiled and fast. Their behavior coincides with NumPy when array dimensions are regular and generalizes when they're not.

--- a/pages/projects/uproot.md
+++ b/pages/projects/uproot.md
@@ -28,4 +28,4 @@ team:
 
 [Uproot](https://github.com/scikit-hep/uproot5) is a library for reading and writing ROOT files in pure Python and NumPy.
 
-Unlike the standard C++ ROOT implementation, Uproot is only an I/O library, primarily intended to stream data into machine learning libraries in Python. Unlike PyROOT and root_numpy, Uproot does not depend on C++ ROOT. Instead, it uses Numpy to cast blocks of data from the ROOT file as Numpy arrays.
+Unlike the standard C++ ROOT implementation, Uproot is only an I/O library, primarily intended to stream data into machine learning libraries in Python. Unlike PyROOT and root_numpy, Uproot does not depend on C++ ROOT. Instead, it uses NumPy to cast blocks of data from the ROOT file as NumPy arrays.

--- a/pages/projects/uproot.md
+++ b/pages/projects/uproot.md
@@ -14,8 +14,18 @@ github: https://github.com/scikit-hep/uproot4
 start-date: 2017-09-03
 team:
 - jpivarski
+- henryiii
+- Angus Hollands
 - Pratyush Das
+- Kush Kothari
+- Aryan Roy
+- Jerry Ling
+- ncsmith
+- Chris Burr
+- Giordon Stark
+- ioifrim
 ---
 
-[uproot](https://github.com/scikit-hep/uproot4)
-(originally μproot, for "micro-Python ROOT") is a reader and a writer of the ROOT file format using only Python and NumPy. Unlike the standard C++ ROOT implementation, uproot is only an I/O library, primarily intended to stream data into machine learning libraries in Python. Unlike PyROOT and root_numpy, uproot does not depend on C++ ROOT. Instead, it uses NumPy to cast blocks of data from the ROOT file as NumPy arrays.
+[Uproot](https://github.com/scikit-hep/uproot5) is a library for reading and writing ROOT files in pure Python and NumPy.
+
+Unlike the standard C++ ROOT implementation, Uproot is only an I/O library, primarily intended to stream data into machine learning libraries in Python. Unlike PyROOT and root_numpy, Uproot does not depend on C++ ROOT. Instead, it uses Numpy to cast blocks of data from the ROOT file as Numpy arrays.

--- a/pages/projects/vector.md
+++ b/pages/projects/vector.md
@@ -13,12 +13,13 @@ github: https://github.com/scikit-hep/vector
 start-date: 2018-07-08
 focus-area: as
 team:
+- Saransh-cpp
 - jpivarski
 - henryiii
 ---
 
 [Vector](https://github.com/scikit-hep/vector)
-is a Python 3.8+ library (Python 3.6 and 3.7 supported till `v0.9.0` and `v1.0.0`, respectively) for 2D, 3D, and [Lorentz vectors](https://en.wikipedia.org/wiki/Special_relativity#Physics_in_spacetime), especially _arrays of vectors_, to solve common physics problems in a NumPy-like way.
+is a Python library for 2D, 3D, and [Lorentz vectors](https://en.wikipedia.org/wiki/Special_relativity#Physics_in_spacetime), especially _arrays of vectors_, to solve common physics problems in a NumPy-like way.
 
 Main features of Vector:
 


### PR DESCRIPTION
...and remove anachronisms from the project descriptions.

This is in response to a ping from @matthewfeickert.