### PR TITLE
chore: Add GitHub profile as default website for AS team

### DIFF
--- a/_data/people/ianna.yml
+++ b/_data/people/ianna.yml
@@ -8,7 +8,7 @@ name: Ianna Osborne
 photo: "/assets/images/team/Ianna-Osborne.png"
 shortname: ianna
 title: Research Software Engineer
-website:
+website: https://github.com/ianna
 presentations:
   - title: "Bridging Python and Julia for Enhanced Data Analysis"
     date: 2024-08-29

--- a/_data/people/ketan96-m.yml
+++ b/_data/people/ketan96-m.yml
@@ -6,3 +6,4 @@ name: Ketan Mahajan
 photo: /assets/images/team/Ketan-Mahajan.jpg
 shortname: ketan96-m
 title: Software Programmer/Analyst
+website: https://github.com/ketan96-m


### PR DESCRIPTION
* For Analysis Systems team members without websites add their GitHub profiles as a default website so that all AS team members have a linked profile on the team page.