### PR TITLE
chore: Unify CHEP 2024 meeting name

### DIFF
--- a/_data/people/gordonwatts.yml
+++ b/_data/people/gordonwatts.yml
@@ -442,7 +442,7 @@ presentations:
     date: 2024-10-21
     url: https://indico.cern.ch/event/1338689/contributions/6011147/
     meetingurl: https://indico.cern.ch/event/1338689
-    meeting: "CHEP 2024 - Converence on Computing in High Energy Physics"
+    meeting: "CHEP 2024 - Conference on Computing in High Energy Physics"
     focus-area:
       - as
     location: Krakow, Poland

--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -498,7 +498,7 @@ presentations:
   - title: "Building a Columnar Analysis Demonstrator for ATLAS PHYSLITE Open Data using the Python Ecosystem"
     date: 2024-10-21
     url: https://indico.cern.ch/event/1338689/contributions/6015915/
-    meeting: "CHEP 2024 Conference"
+    meeting: "CHEP 2024 - Conference on Computing in High Energy and Nuclear Physics"
     meetingurl: https://indico.cern.ch/event/1338689/
     location: Kraków, Poland
     focus-area: as


### PR DESCRIPTION
* Use "CHEP 2024 - Conference on Computing in High Energy and Nuclear Physics" as the meeting title for CHEP contributions for Matthew Feickert.
* Fix typo.