### PR TITLE
Update gordonwatts.yml

### DIFF
--- a/_data/people/gordonwatts.yml
+++ b/_data/people/gordonwatts.yml
@@ -310,7 +310,7 @@ presentations:
     date: 2023-05-08
     url: https://indico.jlab.org/event/459/abstracts/1736/
     meetingurl: https://indico.jlab.org/event/459
-    meeting: CHEP 2024
+    meeting: CHEP 2023
     focus-area: as
   - title: "Analysis Grand Challenge Demonstrator"
     date: 2023-03-30


### PR DESCRIPTION
Fix the reference to CHEP 2023 from last year.