### PR TITLE
feat: Add videos of 2023 pyhf Users and Developers Workshop

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -454,6 +454,7 @@ presentations:
   - title: "Constructing and steering pyhf models with cabinetry"
     date: 2023-12-04
     url: https://indico.cern.ch/event/1294577/contributions/5689564/
+    video: https://youtu.be/hrs0EpceO_8
     meeting: pyhf Users and Developers Workshop 2023
     meetingurl: https://indico.cern.ch/event/1294577/
     location: "CERN"

--- a/_data/people/masonproffitt.yml
+++ b/_data/people/masonproffitt.yml
@@ -176,6 +176,7 @@ presentations:
   - title: "abcd_pyhf: Likelihood-based ABCD method for background estimation and hypothesis testing with pyhf"
     date: 2023-12-04
     url: https://indico.cern.ch/event/1294577/contributions/5700251/
+    video: https://youtu.be/EaNwmH_dTAc
     meeting: pyhf Users and Developers Workshop 2023
     meetingurl: https://indico.cern.ch/event/1294577/
     location: CERN


### PR DESCRIPTION
Add links to YouTube recordings of @alexander-held and @masonproffitt's talks at the 2023 pyhf Users and Developers Workshop at CERN.
   - c.f. https://youtu.be/hrs0EpceO_8
   - c.f. https://youtu.be/EaNwmH_dTAc