### PR TITLE
docs: update list of presentations and add challenge-area tags

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -132,6 +132,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - servicex
       - func-adl
@@ -148,6 +149,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -161,6 +163,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -186,6 +189,7 @@ presentations:
       - as
       - doma
       - ssl
+    challenge-area: agc
     project: agc
 
   - title: "From data delivery to statistical inference with CMS Open Data"
@@ -197,6 +201,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - servicex
       - func-adl
@@ -224,6 +229,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project: agc
 
   - title: "Analysis Grand Challenge updates"
@@ -235,6 +241,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -259,6 +266,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project: agc
 
   - title: "Analysis Grand Challenge updates"
@@ -270,6 +278,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -283,6 +292,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - servicex
       - func-adl
@@ -303,6 +313,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -316,6 +327,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -329,6 +341,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -353,6 +366,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -366,6 +380,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -389,6 +404,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -402,6 +418,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -415,6 +432,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project: agc
 
   - title: "Analysis Grand Challenge Demo"
@@ -425,6 +443,7 @@ presentations:
     location: "Princeton, USA"
     focus-area:
       - as
+    challenge-area: agc
     project:
       - agc
 
@@ -436,6 +455,7 @@ presentations:
     location: "Princeton, USA"
     focus-area:
       - as
+    challenge-area: agc
     project:
       - agc
       - cabinetry
@@ -449,6 +469,7 @@ presentations:
     focus-area:
       - as
       - doma
+    challenge-area: agc
     project:
       - coffea-casa
       - agc
@@ -495,6 +516,7 @@ presentations:
     location: "CERN"
     focus-area:
       - as
+    challenge-area: agc
     project:
       - agc
 
@@ -506,6 +528,7 @@ presentations:
     location: "Sacramento, USA"
     focus-area:
       - as
+    challenge-area: agc
     project:
       - agc
       - madminer
@@ -553,5 +576,40 @@ presentations:
       - as
       - doma
       - ssl
+    challenge-area: agc
+    project:
+      - agc
+
+  - title: "Practical model building for statistical analysis"
+    date: 2024-11-19
+    url: https://indico.cern.ch/event/1455307/
+    meeting: ATLAS Lecture Series
+    meetingurl: https://indico.cern.ch/event/1455307/
+    location: "CERN"
+    focus-area:
+      - as
+    project:
+      - cabinetry
+      - pyhf
+
+  - title: "Installing and Managing software on your laptop"
+    date: 2025-01-16
+    url: https://indico.cern.ch/event/1394564/contributions/6137259/
+    meeting: HSF-India Hyderabad
+    meetingurl: https://indico.cern.ch/event/1394564/
+    location: "Hyderabad, India"
+    focus-area:
+      - as
+    project:
+
+  - title: "IRIS-HEP analysis pipeline"
+    date: 2025-01-17
+    url: https://indico.cern.ch/event/1394564/contributions/6316173/
+    meeting: HSF-India Hyderabad
+    meetingurl: https://indico.cern.ch/event/1394564/
+    location: "Hyderabad, India"
+    focus-area:
+      - as
+    challenge-area: agc
     project:
       - agc


### PR DESCRIPTION
Updating my list of presentations and adding the new `challenge-area: agc` tag where relevant following #2437. cc @oshadura 

This is ready for review/merge.