### PR TITLE
docs: add HL-LHC blueprint talk from joint ATLAS/CMS session

### DIFF
--- a/_data/people/alexander-held.yml
+++ b/_data/people/alexander-held.yml
@@ -613,3 +613,17 @@ presentations:
     challenge-area: agc
     project:
       - agc
+
+  - title: "HL-LHC Analysis Blueprint Meeting"
+    date: 2025-02-03
+    url: https://indico.cern.ch/event/1501541/#4-benchmark-analyses-and-scena
+    meeting: Joint ATLAS S&C / CMS O&C meeting
+    meetingurl: https://indico.cern.ch/event/1501541/
+    location: "CERN"
+    focus-area:
+      - as
+      - doma
+      - ssl
+    challenge-area: agc
+    project:
+      - agc


### PR DESCRIPTION
Adding blueprint talk from the joint ATLAS S&C / CMS O&C session https://indico.cern.ch/event/1501541/. cc @oshadura 