### PR TITLE
Change one CHEP talk from AS to IA

### DIFF
--- a/_data/people/beomki-yeo.yml
+++ b/_data/people/beomki-yeo.yml
@@ -13,7 +13,7 @@ presentations:
     url: https://indico.cern.ch/event/1338689/contributions/6010050/
     meetingurl: https://indico.cern.ch/event/1338689
     meeting: "CHEP 2024 - Conference on Computing in High Energy Physics"
-    focus-area: as
+    focus-area: ia
     location: Krakow, Poland
   - title: GPU Demonstrator for ACTS Track Reconstruction
     date: 2021-05-15


### PR DESCRIPTION
Beomki Yeo's CHEP2024 talk on GPU tracking falls under IA rather that AS