### PR TITLE
feat: Add Feickert LHC Reinterpretation Forum Workshop 2025 talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -502,4 +502,13 @@ presentations:
     meetingurl: https://indico.cern.ch/event/1338689/
     location: Kraków, Poland
     focus-area: as
+    project: columnar-physlite
+
+  - title: "HEP Packaging Coordination: Reproducible reuse by default"
+    date: 2025-02-27
+    url: https://indico.cern.ch/event/1466101/contributions/6287842/
+    meeting: "LHC Reinterpretation Forum Workshop 2025"
+    meetingurl: https://indico.cern.ch/event/1466101/
+    location: Virtual
+    focus-area: as
     project:


### PR DESCRIPTION
* Add 'HEP Packaging Coordination: Reproducible reuse by default' talk given at the 2025 LHC Reinterpretation Forum Workshop.
   - c.f. https://indico.cern.ch/event/1466101/contributions/6287842/
* Add 'columnar-physlite' to CHEP 2024 talk.