### PR TITLE
fix: Use bundler over bundle

### DIFF
--- a/pages/docs/webdev.md
+++ b/pages/docs/webdev.md
@@ -37,7 +37,7 @@ rbenv local 3.1.2
 This will run the Ruby you just built whenever you enter this directory. You'll want to install bundler too:
 
 ```bash
-gem install bundle
+gem install bundler
 ```
 
 (You may want to add `--user-install` here if you are not using rbenv. And if

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 [tasks]
 # Need to use '--user-install' as using pixi instead of rbenv
 install = """
-gem install --user-install bundle && \
+gem install --user-install bundler && \
 bundle install
 """
 


### PR DESCRIPTION
* Have gem install bundler and use it to do the installs.
   - I think this was a typo on my part given `bundler` has been used since PR https://github.com/iris-hep/iris-hep.github.io/pull/256 and https://github.com/iris-hep/iris-hep.github.io/pull/1060.

This does not fix the issue in Issue https://github.com/iris-hep/iris-hep.github.io/issues/2499, but it was noticed while looking at it.