### PR TITLE
Mark Carlo Varni as inactive

### DIFF
--- a/_data/people/cvarni.yml
+++ b/_data/people/cvarni.yml
@@ -1,4 +1,4 @@
-active: true
+active: false
 e-mail: carlo.varni@berkeley.edu
 focus-area:
   - ia


### PR DESCRIPTION
As of March 1st, Carlo Varni is no longer funded by IRIS-HEP