### PR TITLE
chore: Migrate past institute members to non-active status

### DIFF
--- a/_data/people/alex-golub99.yml
+++ b/_data/people/alex-golub99.yml
@@ -1,4 +1,4 @@
-active: true
+active: false
 focus-area:
   - as
 institution: University of Washington

--- a/_data/people/anapeixotohep.yml
+++ b/_data/people/anapeixotohep.yml
@@ -1,4 +1,4 @@
-active: true
+active: false
 focus-area:
   - as
 institution: University of Washington

--- a/_data/people/masonproffitt.yml
+++ b/_data/people/masonproffitt.yml
@@ -1,4 +1,4 @@
-active: true
+active: false
 focus-area:
   - as
   - doma


### PR DESCRIPTION
* Mark Mason Proffitt, Ana Peixoto, and Alex Golub as non-active in IRIS-HEP.