### PR TITLE
Create 20251117-Teachers-Workshop-Python-Programming-SanJuan-PuertoRi…

### DIFF
--- a/_data/events/20251117-Teachers-Workshop-Python-Programming-SanJuan-PuertoRico.yml
+++ b/_data/events/20251117-Teachers-Workshop-Python-Programming-SanJuan-PuertoRico.yml
@@ -1,0 +1,10 @@
+name: PR Teachers Workshop on Python programming with applications to particle physics
+startdate: 2025-11-17
+enddate: 2025-11-18
+location: Educational Department of Puerto Rico, Sala de los Secretarios (San Juan (PR))
+meetingurl: https://indico.cern.ch/event/1600025/
+image:
+description: PR Teachers Workshop on Python programming with applications to particle physics
+labels:
+  - training
+  - outreach


### PR DESCRIPTION
…co.yml

PR Teachers Workshop on Python programming with applications to particle physics at Educational Department of Puerto Rico, Sala de los Secretarios (San Juan (PR))