### PR TITLE
Fix SSL CRL verification error in INSPIRE API connections

### DIFF
--- a/_plugins/getpub.rb
+++ b/_plugins/getpub.rb
@@ -26,6 +26,10 @@ module Publications
     def generate(site)
       @net = Net::HTTP.new('inspirehep.net', 443)
       @net.use_ssl = true
+      # Use a cert store without CRL checking (CRL checks can fail due to network/firewall issues)
+      store = OpenSSL::X509::Store.new
+      store.set_default_paths
+      @net.cert_store = store
 
       @site = site
 


### PR DESCRIPTION
Configure a custom OpenSSL certificate store for HTTPS connections to inspirehep.net that skips Certificate Revocation List (CRL) checking.

The default Ruby OpenSSL configuration was failing with 'unable to get certificate CRL' errors when connecting to the INSPIRE API, likely due to network/firewall restrictions blocking CRL distribution point access.

The certificate chain is still validated normally; only the revocation list check is bypassed.