### PR TITLE
feat: Add Feickert APS Global Summit 2026 talk

### DIFF
--- a/_data/people/matthewfeickert.yml
+++ b/_data/people/matthewfeickert.yml
@@ -512,3 +512,12 @@ presentations:
     location: Virtual
     focus-area: as
     project:
+
+  - title: "The HEP Software Ecosystem"
+    date: 2026-03-18
+    url: https://matthewfeickert-talks.github.io/talk-aps-global-physics-summit-2026/
+    meeting: "APS Global Physics Summit 2026"
+    meetingurl: https://summit.aps.org/events/APR-P88/2
+    location: Denver, U.S.A.
+    focus-area: as
+    project:


### PR DESCRIPTION
* Add 'The HEP Software Ecosystem' talk given at the mini-symposium on Advances in Computing in High Energy Physics at the 2026 APS Global Summit.
   - c.f. https://summit.aps.org/events/APR-P88/2