### PR TITLE
Create 20260712-Data-Camp-Fermilab.yml

### DIFF
--- a/_data/events/20260712-Data-Camp-Fermilab.yml
+++ b/_data/events/20260712-Data-Camp-Fermilab.yml
@@ -1,0 +1,10 @@
+name: Data Camp at Fermilab
+startdate: 2026-07-12
+enddate: 2026-07-17
+location: Fermilab
+meetingurl: https://indico.cern.ch/event/1690178/
+image:
+description: Data Camp is designed to be an introductory workshop for both new and veteran teachers of physics and physical science. 
+labels:
+  - training
+  - outreach

--- a/_data/events/20260712-Data-Camp-Fermilab.yml
+++ b/_data/events/20260712-Data-Camp-Fermilab.yml
@@ -4,7 +4,7 @@ enddate: 2026-07-17
 location: Fermilab
 meetingurl: https://indico.cern.ch/event/1690178/
 image:
-description: Data Camp is designed to be an introductory workshop for both new and veteran teachers of physics and physical science. 
+description: Data Camp is designed to be an introductory workshop for both new and veteran teachers of physics and physical science.
 labels:
   - training
   - outreach


### PR DESCRIPTION
Data Camp is designed to be an introductory workshop for both new and veteran teachers of physics and physical science. We welcome both those teachers who have little to no experience with QuarkNet and the world of high energy particle physics, and who are looking for a kickstart; as well as experienced QuarkNet teachers who have little experience with quantitative analysis of LHC data.