### PR TITLE
Add Agents and the future of HEP Analysis talk

### DIFF
--- a/_data/people/gordonwatts.yml
+++ b/_data/people/gordonwatts.yml
@@ -567,3 +567,11 @@ presentations:
     project:
       - llm
     location: Virtual
+  - title: "Running Headlong the Vortex: The Intersection of Experimental Particle Physics, LLMs, Agentic Workflows, and Collaborations"
+    date: 2026-08-13
+    url: https://iaifi.org/summer-workshop.html
+    meeting: "2026 IAIFI Summer Workshop"
+    meetingurl: https://iaifi.org/summer-workshop.html
+    project:
+      - llm
+    location: "MIT Schwarzman College of Computing, Cambridge, MA"

--- a/_data/people/gordonwatts.yml
+++ b/_data/people/gordonwatts.yml
@@ -559,3 +559,11 @@ presentations:
     project:
       - llm
     location: CERN
+  - title: "Agents and the future of HEP Analysis"
+    date: 2026-06-22
+    url: https://indico.cern.ch/event/1696598/contributions/7151771
+    meeting: "Bunches of Agents: Mini talk series (part 1)"
+    meetingurl: https://indico.cern.ch/event/1696598/
+    project:
+      - llm
+    location: Virtual


### PR DESCRIPTION
## Summary
- Add Gordon Watts's `Agents and the future of HEP Analysis` presentation from Indico.
- Add Gordon Watts's `Running Headlong the Vortex: The Intersection of Experimental Particle Physics, LLMs, Agentic Workflows, and Collaborations` presentation from the IAIFI Summer Workshop agenda.
- Classify both presentations under the `llm` project.

## Sources
- Indico contribution: https://indico.cern.ch/event/1696598/contributions/7151771
- IAIFI workshop agenda: https://iaifi.org/summer-workshop.html

## Validation
- YAML parsed and validated against `_scripts/people.schema.json`.
- `git diff --check` passed.
- The documented Ruby/pixi site check could not be run because those runtimes are not installed in the Windows environment.