### PR TITLE
Improve LLM project repository descriptions

### DIFF
--- a/pages/projects/llm.md
+++ b/pages/projects/llm.md
@@ -24,7 +24,7 @@ physicists work. This includes coding, attending conferences, reading and compre
 * [`hep-data-llm`](https://github.com/gordonwatts/hep-data-llm) a plot agent that experiments with taking the [`adl-benchmark-index`](https://github.com/iris-hep/adl-benchmarks-index)
   questions and hint files so that an LLM will generate and run the code. Complete with
   fairly complete evaluation metrics and ~20 open source and commercial models tested. Preceded by the [`atlas-plot-agent`](https://github.com/gordonwatts/atlas-plot-agent) project.
-* [`test-wsl2-llm`](https://github.com/gordonwatts/test-wsl2-llm) a Windows-to-WSL2 harness for running repeatable LLM tests, including templated batches, concurrent repetitions, continuations, and generated reports.
+* [`test-wsl2-llm`](https://github.com/gordonwatts/test-wsl2-llm) a Windows-to-WSL2 harness for running repeatable tests of coding CLIs (currently Codex), including templated batches, concurrent repetitions, continuations, and generated reports.
 * [cmspilot](https://github.com/rrutaa/cmspilot) a plot agent that uses RAG techniques to target very small LLMs. Fellow Project
 * [azure-light-rag](https://github.com/gordonwatts/azure-light-rag) RAG designed to work with very large corpora of text (e.g. all the European Union strategic update, or Snowmass documents). Uses RAG techniques plus entity extraction.
   Shows all the various problems that traditional RAG shows when working with very large amounts of data. Designed to run in the cloud, and be invoked as a tool from OpenAI's ChatGPT tool.

--- a/pages/projects/llm.md
+++ b/pages/projects/llm.md
@@ -18,14 +18,14 @@ team:
  - rrutaa
 ---
 
-This is an umbrella project to collect the experimental acitivites going on in the institute around using large language models to help particle
-physicists work. This includes coding, attending conferences, reading and comprehending papers, et.c
+This is an umbrella project to collect the experimental activities going on in the institute around using large language models to help particle
+physicists work. This includes coding, attending conferences, reading and comprehending papers, etc.
 
 * [`hep-data-llm`](https://github.com/gordonwatts/hep-data-llm) a plot agent that experiments with taking the [`adl-benchmark-index`](https://github.com/iris-hep/adl-benchmarks-index)
-  questions and hint files so that a LLM will generate and run the code. Complete with
+  questions and hint files so that an LLM will generate and run the code. Complete with
   fairly complete evaluation metrics and ~20 open source and commercial models tested. Preceded by the [`atlas-plot-agent`](https://github.com/gordonwatts/atlas-plot-agent) project.
-* [cmspiolot](https://github.com/rrutaa/cmspilot) a plot agent that uses RAG techniques to target very small LLM's. Fellow Project
-* [azure-light-rag](https://github.com/gordonwatts/azure-light-rag) RAG designed to work with very large corpuses of text (e.g. all the European Union stratigic update, or Snowmass documents). Uses RAG techniques plus entity extraction.
-  Shows all the various problems that traditional RAG shows when working with very large amounts of data. Designed to run in the cloud, and be invoked as a tool from OpenAI's chat-gpt tool.
-* [abstract-rankder](https://github.com/gordonwatts/abstract-ranker) - given a list of the users preferences will rank abstracts submitted to a conference and generate a spreadsheet
-  can be used to navigate a large confernece like ICHEP or CHEP.
+* [cmspilot](https://github.com/rrutaa/cmspilot) a plot agent that uses RAG techniques to target very small LLMs. Fellow Project
+* [azure-light-rag](https://github.com/gordonwatts/azure-light-rag) RAG designed to work with very large corpora of text (e.g. all the European Union strategic update, or Snowmass documents). Uses RAG techniques plus entity extraction.
+  Shows all the various problems that traditional RAG shows when working with very large amounts of data. Designed to run in the cloud, and be invoked as a tool from OpenAI's ChatGPT tool.
+* [abstract-ranker](https://github.com/gordonwatts/abstract-ranker) - given a list of the user's preferences, will rank abstracts submitted to a conference and generate a spreadsheet
+  can be used to navigate a large conference like ICHEP or CHEP.

--- a/pages/projects/llm.md
+++ b/pages/projects/llm.md
@@ -24,6 +24,7 @@ physicists work. This includes coding, attending conferences, reading and compre
 * [`hep-data-llm`](https://github.com/gordonwatts/hep-data-llm) a plot agent that experiments with taking the [`adl-benchmark-index`](https://github.com/iris-hep/adl-benchmarks-index)
   questions and hint files so that an LLM will generate and run the code. Complete with
   fairly complete evaluation metrics and ~20 open source and commercial models tested. Preceded by the [`atlas-plot-agent`](https://github.com/gordonwatts/atlas-plot-agent) project.
+* [`test-wsl2-llm`](https://github.com/gordonwatts/test-wsl2-llm) a Windows-to-WSL2 harness for running repeatable LLM tests, including templated batches, concurrent repetitions, continuations, and generated reports.
 * [cmspilot](https://github.com/rrutaa/cmspilot) a plot agent that uses RAG techniques to target very small LLMs. Fellow Project
 * [azure-light-rag](https://github.com/gordonwatts/azure-light-rag) RAG designed to work with very large corpora of text (e.g. all the European Union strategic update, or Snowmass documents). Uses RAG techniques plus entity extraction.
   Shows all the various problems that traditional RAG shows when working with very large amounts of data. Designed to run in the cloud, and be invoked as a tool from OpenAI's ChatGPT tool.

--- a/pages/projects/llm.md
+++ b/pages/projects/llm.md
@@ -24,7 +24,7 @@ physicists work. This includes coding, attending conferences, reading and compre
 * [`hep-data-llm`](https://github.com/gordonwatts/hep-data-llm) a plot agent that experiments with taking the [`adl-benchmark-index`](https://github.com/iris-hep/adl-benchmarks-index)
   questions and hint files so that an LLM will generate and run the code. Complete with
   fairly complete evaluation metrics and ~20 open source and commercial models tested. Preceded by the [`atlas-plot-agent`](https://github.com/gordonwatts/atlas-plot-agent) project.
-* [`test-wsl2-llm`](https://github.com/gordonwatts/test-wsl2-llm) a Windows-to-WSL2 harness for running repeatable tests of coding CLIs (currently Codex), including templated batches, concurrent repetitions, continuations, and generated reports.
+* [`test-wsl2-llm`](https://github.com/gordonwatts/test-wsl2-llm) a Windows-to-WSL2 harness for running LLMs in CLIs such as Codex (currently the only supported CLI), including templated batches, concurrent repetitions, continuations, and generated reports.
 * [cmspilot](https://github.com/rrutaa/cmspilot) a plot agent that uses RAG techniques to target very small LLMs. Fellow Project
 * [azure-light-rag](https://github.com/gordonwatts/azure-light-rag) RAG designed to work with very large corpora of text (e.g. all the European Union strategic update, or Snowmass documents). Uses RAG techniques plus entity extraction.
   Shows all the various problems that traditional RAG shows when working with very large amounts of data. Designed to run in the cloud, and be invoked as a tool from OpenAI's ChatGPT tool.


### PR DESCRIPTION
## Summary
- Fix typos and grammar on the Large Language Models As Assistants project page.
- Add test-wsl2-llm as a primary project repository, noting its CLI focus and current Codex-only support.

## Validation
- git diff --check