### PR TITLE
Add end date to HEP Tables project

### DIFF
--- a/pages/projects/hep-tables.md
+++ b/pages/projects/hep-tables.md
@@ -10,6 +10,7 @@ maturity: Archived
 maturity-note: No longer being developed
 github: https://github.com/gordonwatts/hep_tables
 start-date: 2020-03-15
+end-date: 2021-07-01
 focus-area: as
 team:
  - gordonwatts


### PR DESCRIPTION
## Summary
- add the missing end date for the archived HEP Tables project
- record the end date as July 1, 2021

## Validation
- git diff --check
- parsed the project front matter with PyYAML and confirmed end-date: 2021-07-01

## Local environment
- the full pixi run check task could not be run because pixi and Bundler are not installed in this environment