### PR TITLE
Add Gordon Watts MODE AI agents presentation

### DIFF
--- a/_data/people/gordonwatts.yml
+++ b/_data/people/gordonwatts.yml
@@ -575,3 +575,12 @@ presentations:
     project:
       - llm
     location: "MIT Schwarzman College of Computing, Cambridge, MA"
+  - title: "AI Agents and the future of HEP Analysis"
+    date: 2026-09-02
+    url: https://indico.cern.ch/event/1655754/contributions/7222252/
+    meeting: "Sixth MODE Workshop on Differentiable Programming for Experiment Design"
+    meetingurl: https://indico.cern.ch/event/1655754/
+    focus-area: as
+    project:
+      - llm
+    location: "OAC conference center, Kolymbari, Crete, Greece."


### PR DESCRIPTION
## Summary
- Add Gordon Watts's 2026-09-02 talk "AI Agents and the future of HEP Analysis" to his presentation list.
- Link the canonical Indico contribution and Sixth MODE Workshop event.

## Validation
- Focused people-data schema validation passed.
- `git diff --check` passed.
