### PR TITLE
Add 2026 summer school and PyHEP.dev presentations for henryiii

### DIFF
--- a/_data/people/henryiii.yml
+++ b/_data/people/henryiii.yml
@@ -435,3 +435,48 @@ presentations:
     location: Princeton, NJ
     focus-area: ssc
     project:
+
+  - title: Level up your python
+    date: 2026-08-10
+    url: https://indico.cern.ch/event/1672591/contributions/7130123/
+    meeting: Computational HEP Traineeship Summer School 2026
+    meetingurl: https://indico.cern.ch/event/1672591/
+    location: Brookhaven National Laboratory
+    focus-area: ssc
+    project:
+
+  - title: Tools to write better code
+    date: 2026-08-11
+    url: https://indico.cern.ch/event/1672591/contributions/7130153/
+    meeting: Computational HEP Traineeship Summer School 2026
+    meetingurl: https://indico.cern.ch/event/1672591/
+    location: Brookhaven National Laboratory
+    focus-area: ssc
+    project:
+
+  - title: Agentic AI
+    date: 2026-08-11
+    url: https://indico.cern.ch/event/1672591/contributions/7130154/
+    meeting: Computational HEP Traineeship Summer School 2026
+    meetingurl: https://indico.cern.ch/event/1672591/
+    location: Brookhaven National Laboratory
+    focus-area: ssc
+    project:
+
+  - title: Agentic Software Engineering
+    date: 2026-09-07
+    url: https://indico.nikhef.nl/event/7873/contributions/31514/
+    meeting: PyHEP.dev 2026 - "Python in HEP" Developer's Workshop
+    meetingurl: https://indico.nikhef.nl/event/7873/
+    location: Nikhef, Amsterdam, Netherlands
+    focus-area:
+    project:
+
+  - title: Histogramming Updates
+    date: 2026-09-09
+    url: https://indico.nikhef.nl/event/7873/contributions/31516/
+    meeting: PyHEP.dev 2026 - "Python in HEP" Developer's Workshop
+    meetingurl: https://indico.nikhef.nl/event/7873/
+    location: Nikhef, Amsterdam, Netherlands
+    focus-area: as
+    project: histogram


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds five 2026 presentations to `_data/people/henryiii.yml`, verified from the Indico export API:

- Computational HEP Traineeship Summer School 2026 (BNL): "Level up your python" (2026-08-10), "Tools to write better code" (2026-08-11), "Agentic AI" (2026-08-11)
- PyHEP.dev 2026 (Nikhef): "Agentic Software Engineering" (2026-09-07), "Histogramming Updates" (2026-09-09)

"Agentic AI" was co-presented with Andres Rios-Tascon; the schema has no field for co-presenters.

`bundle exec rake check` could not run locally (gems not installed), so the file was validated directly against `_scripts/people.schema.json`.